### PR TITLE
Ready to release stable v20.01

### DIFF
--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -12,6 +12,7 @@ class PyEval:
             "invoke-direct": self.INVOKE_DIRECT,
             "invoke-static": self.INVOKE_STATIC,
             "move-result-object": self.MOVE_RESULT_OBJECT,
+            "move-result-wide": self.MOVE_RESULT_WIDE,
             "move-result": self.MOVE_RESULT,
             "new-instance": self.NEW_INSTANCE,
             "const-string": self.CONST_STRING,
@@ -100,6 +101,24 @@ class PyEval:
             pre_ret = self.ret_stack.pop()
             variable_object = VarabileObject(reg, pre_ret)
             self.table_obj.insert(index, variable_object)
+        except Exception as e:
+            # No element in pop
+            pass
+
+    def MOVE_RESULT_WIDE(self, instruction):
+        """
+        move-result-wide vx
+
+        Move the long/double result value of the previous method invocation into vx,vx+1.
+        """
+        reg = instruction[1]
+        index = int(reg[1:])
+        try:
+            pre_ret = self.ret_stack.pop()
+            variable_object = VarabileObject(reg, pre_ret)
+            variable_object2 = VarabileObject(f"v{index + 1}", pre_ret)
+            self.table_obj.insert(index, variable_object)
+            self.table_obj.insert(index + 1, variable_object2)
         except Exception as e:
             # No element in pop
             pass

--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -10,7 +10,7 @@ from quark.Objects.TableObject import TableObject
 from quark.Objects.VarabileObject import VarabileObject
 
 MAX_REG_COUNT = 40
-TIMESTAMPS = datetime.now().strftime('%Y-%m-%d-%H-%M')
+TIMESTAMPS = datetime.now().strftime('%Y-%m-%d')
 LOG_FILENAME = f"{TIMESTAMPS}.quark.log"
 logging.basicConfig(level=logging.DEBUG, filename=LOG_FILENAME, filemode='w', datefmt='%Y-%m-%d %H:%M:%S')
 log = logging.getLogger(__name__)

--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -10,10 +10,19 @@ class PyEval:
         self.eval = {
             "invoke-virtual": self.INVOKE_VIRTUAL,
             "invoke-direct": self.INVOKE_DIRECT,
+            "invoke-static": self.INVOKE_STATIC,
             "move-result-object": self.MOVE_RESULT_OBJECT,
+            "move-result": self.MOVE_RESULT,
             "new-instance": self.NEW_INSTANCE,
             "const-string": self.CONST_STRING,
+            "const": self.CONST,
             "const/4": self.CONST_FOUR,
+            "const/16": self.CONST_SIXTEEN,
+            "const/high16": self.CONST_HIGHSIXTEEN,
+            "const-wide": self.CONST_WIDE,
+            "const-wide/16": self.CONST_WIDE_SIXTEEN,
+            "const-wide/32": self.CONST_WIDE_THIRTY_TWO,
+            "const-wide/high16": self.CONST_WIDE_HIGHSIXTEEN,
             "aget-object": self.AGET_OBJECT,
         }
 
@@ -69,6 +78,12 @@ class PyEval:
         # print("[Exec]:invoke-direct")
         self.__invoke(instruction)
 
+    def INVOKE_STATIC(self, instruction):
+        """
+        invoke-static {parameters}, methodtocall
+        """
+        self.__invoke(instruction)
+
     def MOVE_RESULT_OBJECT(self, instruction):
         """
         move-result-object vx
@@ -79,6 +94,25 @@ class PyEval:
         """
         # print("[Exec]:move-result-object")
 
+        reg = instruction[1]
+        index = int(reg[1:])
+        try:
+            pre_ret = self.ret_stack.pop()
+            variable_object = VarabileObject(reg, pre_ret)
+            self.table_obj.insert(index, variable_object)
+        except Exception as e:
+            # No element in pop
+            pass
+
+    def MOVE_RESULT(self, instruction):
+        """
+        move-result vx
+        Move the result value of the previous method invocation into vx.
+
+        Save the value returned by the previous
+        function call to the vx register,and then
+        insert the VariableObject into table.
+        """
         reg = instruction[1]
         index = int(reg[1:])
         try:
@@ -121,6 +155,19 @@ class PyEval:
         variable_object = VarabileObject(reg, value)
         self.table_obj.insert(index, variable_object)
 
+    def CONST(self, instruction):
+        """
+        const vx, lit32
+
+        Puts the integer constant into vx
+        """
+        reg = instruction[1]
+        value = instruction[2]
+        index = int(reg[1:])
+
+        variable_object = VarabileObject(reg, value)
+        self.table_obj.insert(index, variable_object)
+
     def CONST_FOUR(self, instruction):
         """
         const/4 vx,lit4
@@ -136,6 +183,96 @@ class PyEval:
 
         variable_object = VarabileObject(reg, value)
         self.table_obj.insert(index, variable_object)
+
+    def CONST_SIXTEEN(self, instruction):
+        """
+        const/16 vx,lit16
+
+        Puts the 4 bit constant into vx.
+        """
+        reg = instruction[1]
+        value = instruction[2]
+        index = int(reg[1:])
+
+        variable_object = VarabileObject(reg, value)
+        self.table_obj.insert(index, variable_object)
+
+    def CONST_HIGHSIXTEEN(self, instruction):
+        """
+        const/high16 v0, lit16
+        Puts the 16 bit constant into the topmost bits of the register. Used to initialize float values.
+        """
+
+        reg = instruction[1]
+        value = instruction[2]
+        index = int(reg[1:])
+
+        variable_object = VarabileObject(reg, value)
+        self.table_obj.insert(index, variable_object)
+
+    def CONST_WIDE(self, instruction):
+        """
+        const-wide vx, lit64
+
+        Puts the 64 bit constant into vx and vx+1 registers.
+        """
+        reg = instruction[1]
+        value = instruction[2]
+        index = int(reg[1:])
+        reg_plus_one = f"v{index + 1}"
+
+        variable_object = VarabileObject(reg, value)
+        variable_object2 = VarabileObject(reg_plus_one, value)
+        self.table_obj.insert(index, variable_object)
+        self.table_obj.insert(index + 1, variable_object2)
+
+    def CONST_WIDE_SIXTEEN(self, instruction):
+        """
+        const-wide/16 vx, lit16
+
+        Puts the integer constant into vx and vx+1 registers, expanding the integer constant into a long constant.
+        """
+        reg = instruction[1]
+        value = instruction[2]
+        index = int(reg[1:])
+        reg_plus_one = f"v{index + 1}"
+
+        variable_object = VarabileObject(reg, value)
+        variable_object2 = VarabileObject(reg_plus_one, value)
+        self.table_obj.insert(index, variable_object)
+        self.table_obj.insert(index + 1, variable_object2)
+
+    def CONST_WIDE_THIRTY_TWO(self, instruction):
+        """
+        const-wide/32 vx, lit32
+
+        Puts the 32 bit constant into vx and vx+1 registers, expanding the integer constant into a long constant.
+        """
+        reg = instruction[1]
+        value = instruction[2]
+        index = int(reg[1:])
+        reg_plus_one = f"v{index + 1}"
+
+        variable_object = VarabileObject(reg, value)
+        variable_object2 = VarabileObject(reg_plus_one, value)
+        self.table_obj.insert(index, variable_object)
+        self.table_obj.insert(index + 1, variable_object2)
+
+    def CONST_WIDE_HIGHSIXTEEN(self, instruction):
+        """
+        const-wide/high16 vx,lit16
+
+        Puts the 16 bit constant into the highest 16 bit of vx and vx+1 registers. Used to initialize double values.
+        """
+        reg = instruction[1]
+        value = instruction[2]
+        index = int(reg[1:])
+        reg_plus_one = f"v{index + 1}"
+
+        variable_object = VarabileObject(reg, value)
+        variable_object2 = VarabileObject(reg_plus_one, value)
+        self.table_obj.insert(index, variable_object)
+        self.table_obj.insert(index + 1, variable_object2)
 
     def AGET_OBJECT(self, instruction):
         """

--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -1,20 +1,45 @@
+# Thanks for the description of Dalvik bytecode instruction from the following websites, some of our explanations or
+# comments will quote from it.
+# https://source.android.google.cn/devices/tech/dalvik/instruction-formats
+# http://pallergabor.uw.hu/androidblog/dalvik_opcodes.html
+
+import logging
+from datetime import datetime
+
 from quark.Objects.TableObject import TableObject
 from quark.Objects.VarabileObject import VarabileObject
 
 MAX_REG_COUNT = 40
+TIMESTAMPS = datetime.now().strftime('%Y-%m-%d-%H-%M')
+LOG_FILENAME = f"{TIMESTAMPS}.quark.log"
+logging.basicConfig(level=logging.DEBUG, filename=LOG_FILENAME, filemode='w', datefmt='%Y-%m-%d %H:%M:%S')
+log = logging.getLogger(__name__)
+
+
+def logger(func):
+    def warp(*args, **kwargs):
+        log.info(f"{func.__name__} with args-> {args}")
+
+        func(*args, **kwargs)
+
+    return warp
 
 
 class PyEval:
     def __init__(self):
         # Main switch for executing the bytecode instruction.
         self.eval = {
+            # invoke-kind
             "invoke-virtual": self.INVOKE_VIRTUAL,
             "invoke-direct": self.INVOKE_DIRECT,
             "invoke-static": self.INVOKE_STATIC,
-            "move-result-object": self.MOVE_RESULT_OBJECT,
-            "move-result-wide": self.MOVE_RESULT_WIDE,
+            # move-result-kind
             "move-result": self.MOVE_RESULT,
+            "move-result-wide": self.MOVE_RESULT_WIDE,
+            "move-result-object": self.MOVE_RESULT_OBJECT,
+            # instance-kind
             "new-instance": self.NEW_INSTANCE,
+            # const-kind
             "const-string": self.CONST_STRING,
             "const": self.CONST,
             "const/4": self.CONST_FOUR,
@@ -24,19 +49,17 @@ class PyEval:
             "const-wide/16": self.CONST_WIDE_SIXTEEN,
             "const-wide/32": self.CONST_WIDE_THIRTY_TWO,
             "const-wide/high16": self.CONST_WIDE_HIGHSIXTEEN,
+            # array
             "aget-object": self.AGET_OBJECT,
         }
 
         self.table_obj = TableObject(MAX_REG_COUNT)
         self.ret_stack = []
 
-    def __invoke(self, instruction):
+    def _invoke(self, instruction):
         """
-        Function call in Android smali code.
-
-        It will check if the corresponding table field
-        has a value, if it does, inserts its own function
-        name into called_by_func column.
+        Function call in Android smali code. It will check if the corresponding table field has a value, if it does,
+        inserts its own function name into called_by_func column.
         """
 
         executed_fuc = instruction[-1]
@@ -63,37 +86,7 @@ class PyEval:
         # push the return value into ret_stack
         self.ret_stack.append(f"{executed_fuc}({','.join(value_of_reg_list)})")
 
-    def INVOKE_VIRTUAL(self, instruction):
-        """
-        invoke-virtual { parameters }, methodtocall
-        first parameter is "this".
-        """
-        # print("[Exec]:invoke-virtual")
-        self.__invoke(instruction)
-
-    def INVOKE_DIRECT(self, instruction):
-        """
-        invoke-direct { parameters }, methodtocall
-        first parameter is "this".
-        """
-        # print("[Exec]:invoke-direct")
-        self.__invoke(instruction)
-
-    def INVOKE_STATIC(self, instruction):
-        """
-        invoke-static {parameters}, methodtocall
-        """
-        self.__invoke(instruction)
-
-    def MOVE_RESULT_OBJECT(self, instruction):
-        """
-        move-result-object vx
-
-        Save the value returned by the previous
-        function call to the vx register,and then
-        insert the VariableObject into table.
-        """
-        # print("[Exec]:move-result-object")
+    def _move(self, instruction):
 
         reg = instruction[1]
         index = int(reg[1:])
@@ -101,10 +94,73 @@ class PyEval:
             pre_ret = self.ret_stack.pop()
             variable_object = VarabileObject(reg, pre_ret)
             self.table_obj.insert(index, variable_object)
-        except Exception as e:
-            # No element in pop
-            pass
+        except IndexError as e:
 
+            log.exception(f"{e} in _move")
+
+    def _assign_value(self, instruction):
+
+        reg = instruction[1]
+        value = instruction[2]
+        index = int(reg[1:])
+
+        variable_object = VarabileObject(reg, value)
+        self.table_obj.insert(index, variable_object)
+
+    def _assign_value_wide(self, instruction):
+        """
+        For 64 bit, it has two register, which is vx and vx+1
+        """
+        reg = instruction[1]
+        value = instruction[2]
+        index = int(reg[1:])
+        reg_plus_one = f"v{index + 1}"
+
+        variable_object = VarabileObject(reg, value)
+        variable_object2 = VarabileObject(reg_plus_one, value)
+        self.table_obj.insert(index, variable_object)
+        self.table_obj.insert(index + 1, variable_object2)
+
+    @logger
+    def INVOKE_VIRTUAL(self, instruction):
+        """
+        invoke-virtual { parameters }, methodtocall
+
+        Invokes a virtual method with parameters.
+        """
+        self._invoke(instruction)
+
+    @logger
+    def INVOKE_DIRECT(self, instruction):
+        """
+        invoke-direct { parameters }, methodtocall
+
+        Invokes a method with parameters without the virtual method resolution. (first parameter is "this")
+        """
+        self._invoke(instruction)
+
+    @logger
+    def INVOKE_STATIC(self, instruction):
+        """
+        invoke-static {parameters}, methodtocall
+
+        Invokes a static method with parameters.
+        """
+        self._invoke(instruction)
+
+    @logger
+    def MOVE_RESULT(self, instruction):
+        """
+        move-result vx
+
+        Move the result value of the previous method invocation into vx.
+
+        Save the value returned by the previous function call to the vx register,and then insert the VariableObject
+        into table.
+        """
+        self._move(instruction)
+
+    @logger
     def MOVE_RESULT_WIDE(self, instruction):
         """
         move-result-wide vx
@@ -119,187 +175,132 @@ class PyEval:
             variable_object2 = VarabileObject(f"v{index + 1}", pre_ret)
             self.table_obj.insert(index, variable_object)
             self.table_obj.insert(index + 1, variable_object2)
-        except Exception as e:
-            # No element in pop
-            pass
+        except IndexError as e:
+            log.exception(f"{e} in MOVE_RESULT_WIDE")
 
-    def MOVE_RESULT(self, instruction):
+    @logger
+    def MOVE_RESULT_OBJECT(self, instruction):
         """
-        move-result vx
-        Move the result value of the previous method invocation into vx.
+        move-result-object vx
 
-        Save the value returned by the previous
-        function call to the vx register,and then
-        insert the VariableObject into table.
+        Move the result object reference of the previous method invocation into vx.
+
+        Save the value returned by the previous function call to the vx register,and then insert the VariableObject
+        into table.
         """
-        reg = instruction[1]
-        index = int(reg[1:])
-        try:
-            pre_ret = self.ret_stack.pop()
-            variable_object = VarabileObject(reg, pre_ret)
-            self.table_obj.insert(index, variable_object)
-        except Exception as e:
-            # No element in pop
-            pass
 
+        self._move(instruction)
+
+    @logger
     def NEW_INSTANCE(self, instruction):
         """
         new-instance vx,type
 
-        store variables to vx, and then
-        insert the VariableObject into table.
+        Instantiates an object type and puts the reference of the newly created instance into vx.
+
+        Store variables to vx, and then insert the VariableObject into table.
         """
-        # print("[Exec]: new-instance vx,type")
 
-        reg = instruction[1]
-        value = instruction[2]
-        index = int(reg[1:])
+        self._assign_value(instruction)
 
-        variable_object = VarabileObject(reg, value)
-        self.table_obj.insert(index, variable_object)
-
+    @logger
     def CONST_STRING(self, instruction):
         """
         const-string vx,string_id
 
-        store string variable to vx, and then
-        insert the VariableObject into table.
+        Puts reference to a string constant identified by string_id into vx.
+
+        Store string variable to vx, and then insert the VariableObject into table.
         """
-        # print("[Exec]: const-string vx,string_id")
 
-        reg = instruction[1]
-        value = instruction[2]
-        index = int(reg[1:])
+        self._assign_value(instruction)
 
-        variable_object = VarabileObject(reg, value)
-        self.table_obj.insert(index, variable_object)
-
+    @logger
     def CONST(self, instruction):
         """
         const vx, lit32
 
-        Puts the integer constant into vx
+        Puts the integer constant into vx.
         """
-        reg = instruction[1]
-        value = instruction[2]
-        index = int(reg[1:])
+        self._assign_value(instruction)
 
-        variable_object = VarabileObject(reg, value)
-        self.table_obj.insert(index, variable_object)
-
+    @logger
     def CONST_FOUR(self, instruction):
         """
         const/4 vx,lit4
 
-        store 4 bit constant into vx, and then
-        insert the VariableObject into table.
+        Puts the 4 bit constant into vx.
+
+        Store 4 bit constant into vx, and then insert the VariableObject into table.
         """
-        # print("[Exec]: const/4 vx,lit4")
 
-        reg = instruction[1]
-        value = instruction[2]
-        index = int(reg[1:])
+        self._assign_value(instruction)
 
-        variable_object = VarabileObject(reg, value)
-        self.table_obj.insert(index, variable_object)
-
+    @logger
     def CONST_SIXTEEN(self, instruction):
         """
         const/16 vx,lit16
 
         Puts the 4 bit constant into vx.
         """
-        reg = instruction[1]
-        value = instruction[2]
-        index = int(reg[1:])
+        self._assign_value(instruction)
 
-        variable_object = VarabileObject(reg, value)
-        self.table_obj.insert(index, variable_object)
-
+    @logger
     def CONST_HIGHSIXTEEN(self, instruction):
         """
         const/high16 v0, lit16
+
         Puts the 16 bit constant into the topmost bits of the register. Used to initialize float values.
         """
 
-        reg = instruction[1]
-        value = instruction[2]
-        index = int(reg[1:])
+        self._assign_value(instruction)
 
-        variable_object = VarabileObject(reg, value)
-        self.table_obj.insert(index, variable_object)
-
+    @logger
     def CONST_WIDE(self, instruction):
         """
         const-wide vx, lit64
 
         Puts the 64 bit constant into vx and vx+1 registers.
         """
-        reg = instruction[1]
-        value = instruction[2]
-        index = int(reg[1:])
-        reg_plus_one = f"v{index + 1}"
+        self._assign_value_wide(instruction)
 
-        variable_object = VarabileObject(reg, value)
-        variable_object2 = VarabileObject(reg_plus_one, value)
-        self.table_obj.insert(index, variable_object)
-        self.table_obj.insert(index + 1, variable_object2)
-
+    @logger
     def CONST_WIDE_SIXTEEN(self, instruction):
         """
         const-wide/16 vx, lit16
 
         Puts the integer constant into vx and vx+1 registers, expanding the integer constant into a long constant.
         """
-        reg = instruction[1]
-        value = instruction[2]
-        index = int(reg[1:])
-        reg_plus_one = f"v{index + 1}"
+        self._assign_value_wide(instruction)
 
-        variable_object = VarabileObject(reg, value)
-        variable_object2 = VarabileObject(reg_plus_one, value)
-        self.table_obj.insert(index, variable_object)
-        self.table_obj.insert(index + 1, variable_object2)
-
+    @logger
     def CONST_WIDE_THIRTY_TWO(self, instruction):
         """
         const-wide/32 vx, lit32
 
         Puts the 32 bit constant into vx and vx+1 registers, expanding the integer constant into a long constant.
         """
-        reg = instruction[1]
-        value = instruction[2]
-        index = int(reg[1:])
-        reg_plus_one = f"v{index + 1}"
+        self._assign_value_wide(instruction)
 
-        variable_object = VarabileObject(reg, value)
-        variable_object2 = VarabileObject(reg_plus_one, value)
-        self.table_obj.insert(index, variable_object)
-        self.table_obj.insert(index + 1, variable_object2)
-
+    @logger
     def CONST_WIDE_HIGHSIXTEEN(self, instruction):
         """
         const-wide/high16 vx,lit16
 
         Puts the 16 bit constant into the highest 16 bit of vx and vx+1 registers. Used to initialize double values.
         """
-        reg = instruction[1]
-        value = instruction[2]
-        index = int(reg[1:])
-        reg_plus_one = f"v{index + 1}"
+        self._assign_value_wide(instruction)
 
-        variable_object = VarabileObject(reg, value)
-        variable_object2 = VarabileObject(reg_plus_one, value)
-        self.table_obj.insert(index, variable_object)
-        self.table_obj.insert(index + 1, variable_object2)
-
+    @logger
     def AGET_OBJECT(self, instruction):
         """
         aget-object vx,vy,vz
 
+        Gets an object reference value of an object reference array into vx. The array is referenced by vy and is
+        indexed by vz.
+
         It means vx = vy[vz].
         """
-        # print("[Exec]: aget-object vx,vy,vz")
 
         reg = instruction[1]
         index = int(reg[1:])
@@ -313,9 +314,8 @@ class PyEval:
                 reg, f"{array_obj.value}[{array_index.value}]"
             )
             self.table_obj.insert(index, variable_object)
-        except Exception as e:
-            # No element in pop
-            pass
+        except IndexError as e:
+            log.exception(f"{e} in AGET_OBJECT")
 
     def show_table(self):
         return self.table_obj.get_table()

--- a/quark/Objects/Apkinfo.py
+++ b/quark/Objects/Apkinfo.py
@@ -10,10 +10,6 @@ class Apkinfo:
 
     def __init__(self, apk_filepath):
         self.a, self.d, self.dx = AnalyzeAPK(apk_filepath)
-
-        # Create Class, Method, String and Field
-        # crossreferences for all classes in the Analysis.
-        # self.dx.create_xref()
         self.apk_filename = os.path.basename(apk_filepath)
 
     def __repr__(self):
@@ -22,18 +18,20 @@ class Apkinfo:
     @property
     def permissions(self):
         """
-        :returns: A list of permissions
-        :rtype: list
+        Return all permissions from given APK.
+
+        :return: a list of all permissions
         """
         return self.a.get_permissions()
 
     def find_method(self, class_name=".*", method_name=".*"):
         """
         Find method from given class_name and method_name,
-        default is find all.
+        default is find all method.
 
-        :returns: an generator of MethodClassAnalysis
-        :rtype: generator
+        :param class_name:
+        :param method_name:
+        :return: a generator of MethodClassAnalysis
         """
 
         result = self.dx.find_methods(class_name, method_name)
@@ -49,12 +47,13 @@ class Apkinfo:
         """
         Return the upper level method from given class name and
         method name.
+
         :param class_name:
         :param method_name:
-        :return: list
+        :return: a list of all upper functions
         """
 
-        result = []
+        upperfunc_result = []
         method_set = self.find_method(class_name, method_name)
 
         if method_set is not None:
@@ -62,9 +61,9 @@ class Apkinfo:
                 for _, call, _ in md.get_xref_from():
                     # Get class name and method name:
                     # call.class_name, call.name
-                    result.append((call.class_name, call.name))
+                    upperfunc_result.append((call.class_name, call.name))
 
-            return tools.remove_dup_list(result)
+            return tools.remove_dup_list(upperfunc_result)
         else:
             return None
 
@@ -72,9 +71,10 @@ class Apkinfo:
         """
         Return the corresponding bytecode according to the
         given class name and method name.
+
         :param class_name:
         :param method_name:
-        :return: generator
+        :return: a generator of all bytecode instructions
         """
 
         result = self.dx.find_methods(class_name, method_name)
@@ -88,17 +88,15 @@ class Apkinfo:
                     # count the number of the registers.
                     length_operands = len(ins.get_operands())
                     if length_operands == 0:
-                        # No register, no parm
+                        # No register, no parameter
                         bytecode_obj = BytecodeObject(ins.get_name(), None, None)
                     elif length_operands == 1:
                         # Only one register
 
-                        reg_list.append(
-                            "v" + str(ins.get_operands()[length_operands - 1][1])
-                        )
+                        reg_list.append(f"v{ins.get_operands()[length_operands - 1][1]}")
                         bytecode_obj = BytecodeObject(ins.get_name(), reg_list, None, )
                     elif length_operands >= 2:
-                        # the last one is parm, the other are registers.
+                        # the last one is parameter, the other are registers.
 
                         parameter = ins.get_operands()[length_operands - 1]
                         for i in range(0, length_operands - 1):

--- a/quark/Objects/Apkinfo.py
+++ b/quark/Objects/Apkinfo.py
@@ -1,6 +1,10 @@
+import os
+
 from androguard.misc import AnalyzeAPK
+
 from quark.Objects.BytecodeObject import BytecodeObject
 from quark.utils import tools
+
 
 class Apkinfo:
 
@@ -10,6 +14,10 @@ class Apkinfo:
         # Create Class, Method, String and Field
         # crossreferences for all classes in the Analysis.
         # self.dx.create_xref()
+        self.apk_filename = os.path.basename(apk_filepath)
+
+    def __repr__(self):
+        return "<Apkinfo-APK:{}>".format(self.apk_filename)
 
     @property
     def permissions(self):

--- a/quark/Objects/BytecodeObject.py
+++ b/quark/Objects/BytecodeObject.py
@@ -4,6 +4,10 @@ class BytecodeObject:
         self._registers = registers
         self._parameter = parameter
 
+    def __repr__(self):
+        return "<BytecodeObject-mnemonic:{}, registers:{}, parameter:{}>".format(self._mnemonic, self._registers,
+                                                                                 self._parameter)
+
     @property
     def mnemonic(self):
         return self._mnemonic

--- a/quark/Objects/BytecodeObject.py
+++ b/quark/Objects/BytecodeObject.py
@@ -1,5 +1,12 @@
 class BytecodeObject:
     def __init__(self, mnemonic, registers, parameter):
+        """
+        ['invoke-virtual', 'v3', 'Lcom/google/progress/APNOperator;->deleteAPN()Z']
+
+        :param mnemonic:
+        :param registers:
+        :param parameter:
+        """
         self._mnemonic = mnemonic
         self._registers = registers
         self._parameter = parameter
@@ -10,12 +17,28 @@ class BytecodeObject:
 
     @property
     def mnemonic(self):
+        """
+        Dalvik bytecode instructions set, for example 'invoke-virtual'.
+
+        :return: a string of mnemonic
+        """
         return self._mnemonic
 
     @property
     def registers(self):
+        """
+        Registers used in Dalvik instructions, for example '[v3]'.
+
+        :return: a list containing all the registers used
+        """
         return self._registers
 
     @property
     def parameter(self):
+        """
+        Commonly used for functions called by invoke-kind instructions, for example
+        'Lcom/google/progress/APNOperator;->deleteAPN()Z'.
+
+        :return: a string of the function name
+        """
         return self._parameter

--- a/quark/Objects/RuleObject.py
+++ b/quark/Objects/RuleObject.py
@@ -4,6 +4,12 @@ import os
 
 class RuleObject:
     def __init__(self, json_filename):
+        """
+        According to customized JSON rules, calculate the weighted score and assessing the stages of the crime.
+
+        :param json_filename:
+        """
+        # the state of five stages
         self.check_item = [False, False, False, False, False]
 
         with open(json_filename, "r") as f:
@@ -19,26 +25,49 @@ class RuleObject:
 
     @property
     def crime(self):
+        """
+        Description of given crime.
+
+        :return: a string of the crime
+        """
         return self._crime
 
     @property
     def x1_permission(self):
+        """
+        Permission requested by the apk to practice the crime.
+
+        :return: a list of given permissions
+        """
         return self._x1_permission
 
     @property
     def x2n3n4_comb(self):
+        """
+        Key native APIs that do the action and target in order.
+
+        :return: a list recording the APIs class_name and method_name in order
+        """
         return self._x2n3n4_comb
 
     @property
     def yscore(self):
+        """
+        The value used to calculate the weighted score
+
+        :return: integer
+        """
         return self._yscore
 
     def get_score(self, confidence):
         """
-        the number of confidence will turn
-        into the threshold.
+        According to the state of the five stages, we calculate the weighted score based on exponential growth.
+        For example, we captured the third stage in five stages, then the weighted score would be (2^3-1) / 2^4.
 
         2^(confidence - 1)
+
+        :param confidence:
+        :return: floating point
         """
         if confidence == 0:
             return 0

--- a/quark/Objects/RuleObject.py
+++ b/quark/Objects/RuleObject.py
@@ -3,7 +3,6 @@ import json
 
 class RuleObject:
     def __init__(self, json_filename):
-
         self.check_item = [False, False, False, False, False]
 
         with open(json_filename, "r") as f:
@@ -37,6 +36,8 @@ class RuleObject:
 
         2^(confidence - 1)
         """
+        if confidence == 0:
+            return 0
         return (2 ** (confidence - 1) * self._yscore) / 2 ** 4
 
 

--- a/quark/Objects/RuleObject.py
+++ b/quark/Objects/RuleObject.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 
 class RuleObject:
@@ -7,11 +8,14 @@ class RuleObject:
 
         with open(json_filename, "r") as f:
             self._json_obj = json.loads(f.read())
-
             self._crime = self._json_obj["crime"]
             self._x1_permission = self._json_obj["x1_permission"]
             self._x2n3n4_comb = self._json_obj["x2n3n4_comb"]
             self._yscore = self._json_obj["yscore"]
+            self.rule_filename = os.path.basename(json_filename)
+
+    def __repr__(self):
+        return "<RuleObject-{}>".format(self.rule_filename)
 
     @property
     def crime(self):

--- a/quark/Objects/TableObject.py
+++ b/quark/Objects/TableObject.py
@@ -12,6 +12,9 @@ class TableObject:
         """
         self.hash_table = [[] for _ in range(count_reg)]
 
+    def __repr__(self):
+        return "<TableObject-{}>".format(self.hash_table)
+
     def insert(self, index, var_obj):
         """
         insert VariableObject into the nested

--- a/quark/Objects/TableObject.py
+++ b/quark/Objects/TableObject.py
@@ -1,14 +1,11 @@
 class TableObject:
-    """
-    This table used to store the variable object,
-    which using a hash table with a stack-based
-    list to generate the bytecode variable tracker table.
-    """
 
     def __init__(self, count_reg):
         """
+        This table used to store the variable object, which uses a hash table with a stack-based list to generate the
+        bytecode variable tracker table.
 
-        :param count_reg:
+        :param count_reg: the maximum number of register to initialize
         """
         self.hash_table = [[] for _ in range(count_reg)]
 
@@ -17,38 +14,38 @@ class TableObject:
 
     def insert(self, index, var_obj):
         """
-        insert VariableObject into the nested
-        list in the hashtable.
-        :param index:
-        :param var_obj:
-        :return:
+        Insert VariableObject into the nested list in the hashtable.
+
+        :param index: the index to insert to the table
+        :param var_obj: instance of VariableObject
+        :return: None
         """
         self.hash_table[index].append(var_obj)
 
     def get_obj_list(self, index):
         """
-        return the list which contains the
-        VariableObject.
-        :param index:
-        :return:
+        Return the list which contains the VariableObject.
+
+        :param index: the index to get the corresponding VariableObject
+        :return: a list containing VariableObject
         """
         return self.hash_table[index]
 
     def get_table(self):
         """
-        :rtype: list
-        :return: a nested list.
+        Get the entire hash table.
+
+        :return: a two-dimensional list
         """
         return self.hash_table
 
     def pop(self, index):
         """
-        override the original pop() to `not`
-        deleting element after() in order to get
-        the top element of the stack in the
-        hashtable, which is VariableObject.
-
-        :rtype: VariableObject
+        Override the built-in pop function, to get the top element, which is VariableObject on the stack while not
+        delete it.
+        
+        :param index: the index to get the corresponding VariableObject
+        :return: VariableObject
         """
         return self.hash_table[index][-1]
 

--- a/quark/Objects/VarabileObject.py
+++ b/quark/Objects/VarabileObject.py
@@ -79,14 +79,6 @@ class VarabileObject:
         """
         self._value = value
 
-    def get_current_status(self):
-        """
-        Get the current status of this VariableObject.
-
-        :return: a string containing register_name, value, [called_by_func]
-        """
-        return f"{self._register_name} ,{self._value} ,[{','.join(self._called_by_func)}]"
-
     @property
     def hash_index(self):
         """

--- a/quark/Objects/VarabileObject.py
+++ b/quark/Objects/VarabileObject.py
@@ -1,15 +1,12 @@
 class VarabileObject:
-    """
-    Data structure for creating the bytecode variable
-    object.
-
-    +================+========+==================+
-    | register_name  | value | called_by_func   |
-    +================+========+==================+
-    """
 
     def __init__(self, register_name, value, called_by_func=None):
         """
+        A data structure for creating the bytecode variable object, which used to record the state of each register.
+
+        +================+========+==================+
+        | register_name  | value | called_by_func    |
+        +================+========+==================+
 
         :param register_name:
         :param value:
@@ -28,69 +25,76 @@ class VarabileObject:
     @property
     def called_by_func(self):
         """
+        Record which functions have been called by using this register as a parameter.
 
-        :return:
+        :return: a list containing function name
         """
         return self._called_by_func
 
     @called_by_func.setter
     def called_by_func(self, called_by_func):
         """
+        Setter of called_by_func.
 
         :param called_by_func:
-        :return:
+        :return: None
         """
         self._called_by_func.append(called_by_func)
 
     @property
     def register_name(self):
         """
+        Individual register name, for example 'v3'.
 
-        :return:
+        :return: a string of register name
         """
         return self._register_name
 
     @register_name.setter
     def register_name(self, reg_name):
         """
+        Setter of register_name.
 
         :param reg_name:
-        :return:
+        :return: None
         """
         self._register_name = reg_name
 
     @property
     def value(self):
         """
+        The current value stored in the register.
 
-        :return:
+        :return: a string of the value
         """
         return self._value
 
     @value.setter
     def value(self, value):
         """
+        Setter of value.
 
         :param value:
-        :return:
+        :return: None
         """
         self._value = value
 
-    def get_all(self):
+    def get_current_status(self):
         """
+        Get the current status of this VariableObject.
 
-        :return:
+        :return: a string containing register_name, value, [called_by_func]
         """
-
         return f"{self._register_name} ,{self._value} ,[{','.join(self._called_by_func)}]"
 
     @property
     def hash_index(self):
         """
+        Get the index number from given VarabileObject.
 
-        :return:
+        :return: an integer corresponding to the register index
         """
-        return int(self.register_name[-1])
+        return int(self.register_name[1:])
 
 
 if __name__ == "__main__":

--- a/quark/Objects/VarabileObject.py
+++ b/quark/Objects/VarabileObject.py
@@ -21,6 +21,10 @@ class VarabileObject:
         if called_by_func is not None:
             self._called_by_func.append(called_by_func)
 
+    def __repr__(self):
+        return "<VarabileObject-register:{}, value:{}, called_by_func:{}>".format(self._register_name, self._value,
+                                                                                  ','.join(self._called_by_func))
+
     @property
     def called_by_func(self):
         """

--- a/quark/Objects/XRule.py
+++ b/quark/Objects/XRule.py
@@ -234,10 +234,15 @@ class XRule:
                 same = self.find_intersection(upperfunc0, upperfunc1)
                 if same is not None:
 
+                    # Clear the results from the previous rule
+                    self.same_sequence_show_up.clear()
+                    self.same_operation.clear()
+
                     for common_method in same:
 
                         base_method_0 = (test_cls0, test_md0)
                         base_method_1 = (test_cls1, test_md1)
+                        # Clear the results from the previous common_method
                         self.pre_method0.clear()
                         self.pre_method1.clear()
                         self.find_previous_method(base_method_0, common_method, self.pre_method0)

--- a/quark/Objects/XRule.py
+++ b/quark/Objects/XRule.py
@@ -156,6 +156,8 @@ class XRule:
                 return True
             else:
                 return False
+        else:
+            return False
 
     def check_parameter(self, common_method, first_method_name, second_method_name):
         """

--- a/quark/logo.py
+++ b/quark/logo.py
@@ -14,7 +14,7 @@ def logo():
            \__>          \/           \/ v{}
     """
             )
-        ).format("19.10")
+        ).format("20.01")
         + bold(
             lightblue(
                 """

--- a/tests/Object/test_variableobject.py
+++ b/tests/Object/test_variableobject.py
@@ -1,4 +1,5 @@
 import pytest
+
 from quark.Objects.VarabileObject import VarabileObject
 
 
@@ -35,7 +36,8 @@ class TestVariableObject(object):
     def test_get_all(self, variable_obj):
         variable_obj.called_by_func = "file_list"
         variable_obj.called_by_func = "file_delete"
-        assert variable_obj.get_current_status() == "v3 ,append() ,[file_list,file_delete]"
+        assert repr(
+            variable_obj) == "<VarabileObject-register:v3, value:append(), called_by_func:file_list,file_delete>"
 
     def test_hash_index(self, variable_obj):
         assert variable_obj.hash_index == 3

--- a/tests/Object/test_variableobject.py
+++ b/tests/Object/test_variableobject.py
@@ -35,7 +35,7 @@ class TestVariableObject(object):
     def test_get_all(self, variable_obj):
         variable_obj.called_by_func = "file_list"
         variable_obj.called_by_func = "file_delete"
-        assert variable_obj.get_all() == "v3 ,append() ,[file_list,file_delete]"
+        assert variable_obj.get_current_status() == "v3 ,append() ,[file_list,file_delete]"
 
     def test_hash_index(self, variable_obj):
         assert variable_obj.hash_index == 3

--- a/tests/Object/test_xrule.py
+++ b/tests/Object/test_xrule.py
@@ -57,3 +57,22 @@ class TestXRule():
         assert xrule.find_intersection(location_api_upper, sms_api_upper) == expected_result_location
 
         assert xrule.find_intersection(contact_api_upper, sms_api_upper) == expected_result_contact
+
+    def test_check_sequence(self, xrule):
+        # Send Location via SMS
+
+        location_api = ("Lcom/google/progress/Locate;", "getLocation")
+        sendSms_api = ("Lcom/google/progress/SMSHelper;", "sendSms")
+
+        common_method_yes = ("Lcom/google/progress/AndroidClientService;", "sendMessage")
+        common_method_no = ("Lcom/google/progress/AndroidClientService$2;", "run")
+
+        # # Send contact via SMS
+
+        contact_api = ("Lcom/google/progress/ContactsCollecter;", "getContactList")
+        sendSms_api = ("Lcom/google/progress/SMSHelper;", "sendSms")
+
+        assert xrule.check_sequence(common_method_yes, location_api, sendSms_api) == True
+        assert xrule.check_sequence(common_method_yes, contact_api, sendSms_api) == True
+        assert xrule.check_sequence(common_method_no, location_api, sendSms_api) == False
+        assert xrule.check_sequence(common_method_no, contact_api, sendSms_api) == False

--- a/tests/Object/test_xrule.py
+++ b/tests/Object/test_xrule.py
@@ -22,3 +22,38 @@ class TestXRule():
         xrule.find_previous_method(base_method, top_method, test_list)
 
         assert test_list == expected_list
+
+    def test_find_intersection(self, xrule):
+        location_api_upper = [("Lcom/google/progress/Locate;", "getLocation")]
+        sms_api_upper = [("Lcom/google/progress/SMSHelper;", "sendSms")]
+        contact_api_upper = [("Lcom/google/progress/APNOperator;", "addAPN"),
+                             ("Lcom/google/progress/ContactsCollecter;", "getPhoneNumbers"),
+                             ("Lcom/google/progress/APNOperator;", "getAPNList"),
+                             ("Lcom/google/progress/SMSHelper;", "readSMSList"),
+                             ("Lcom/google/progress/ContactsCollecter;", "getEmail"),
+                             ("Lcom/google/progress/APNOperator;", "checkAPNisAvailable"),
+                             ("Lcom/google/progress/APNOperator;, deleteAPN"),
+                             ("Lcom/google/progress/ContactsCollecter;", "getContactList"),
+                             ("Lcom/google/progress/GetCallLog;", "getCallLog")]
+
+        with pytest.raises(ValueError, match="List is Null"):
+            xrule.find_intersection([], [])
+            xrule.find_intersection([], [1])
+            xrule.find_intersection([1], [])
+
+        assert len(set(location_api_upper).intersection(sms_api_upper)) == 0
+
+        # When there is no intersection in first layer, it will try to enter the second layer to check the intersection.
+
+        # Send Location via SMS
+        expected_result_location = {("Lcom/google/progress/AndroidClientService;", "doByte"),
+                                    ("Lcom/google/progress/AndroidClientService;", "sendMessage"),
+                                    ("Lcom/google/progress/AndroidClientService$2;", "run")}
+
+        # Send contact via SMS
+        expected_result_contact = {("Lcom/google/progress/AndroidClientService;", "doByte"),
+                                   ("Lcom/google/progress/AndroidClientService;", "sendMessage")}
+
+        assert xrule.find_intersection(location_api_upper, sms_api_upper) == expected_result_location
+
+        assert xrule.find_intersection(contact_api_upper, sms_api_upper) == expected_result_contact

--- a/tests/Object/test_xrule.py
+++ b/tests/Object/test_xrule.py
@@ -76,3 +76,11 @@ class TestXRule():
         assert xrule.check_sequence(common_method_yes, contact_api, sendSms_api) == True
         assert xrule.check_sequence(common_method_no, location_api, sendSms_api) == False
         assert xrule.check_sequence(common_method_no, contact_api, sendSms_api) == False
+
+    def test_check_parameter(self, xrule):
+        first_method_name = "getLocation"
+        second_method_name = "sendSms"
+
+        common_method_yes = ("Lcom/google/progress/AndroidClientService;", "sendMessage")
+
+        assert xrule.check_parameter(common_method_yes, first_method_name, second_method_name) == True

--- a/tests/Object/test_xrule.py
+++ b/tests/Object/test_xrule.py
@@ -1,0 +1,24 @@
+import pytest
+
+from quark.Objects.XRule import XRule
+
+
+@pytest.fixture()
+def xrule(scope="function"):
+    apk_file = "quark/sample/14d9f1a92dd984d6040cc41ed06e273e.apk"
+    xrule = XRule(apk_file)
+    yield xrule
+
+
+class TestXRule():
+
+    def test_find_previous_method(self, xrule):
+        base_method = ("Lcom/google/progress/SMSHelper;", "sendSms")
+        top_method = ("Lcom/google/progress/AndroidClientService;", "sendMessage")
+        expected_list = [("Lcom/google/progress/SMSHelper;", "sendSms")]
+
+        test_list = []
+
+        xrule.find_previous_method(base_method, top_method, test_list)
+
+        assert test_list == expected_list


### PR DESCRIPTION
1. add more bytecode instruction into pyeval.py.

2. add dunder method `__repr__` to each object to better represent the state of object.

3. add unit test for XRule.py.

4. follow sphinx docstring style to generate doc automatically in the future.

5. using list.clear() to clean the result from the previous rule to avoid duplicate results in detail report.

6. add logging module to pyeval.py to keep track of the bytecode usage.

7. update version number from v19.10 to v20.01