### PR TITLE
Fix ValueError by adding 0 boundary in utils/weight.py, issue #60

### DIFF
--- a/quark/utils/weight.py
+++ b/quark/utils/weight.py
@@ -29,7 +29,7 @@ class Weight:
 
         total_weight = self.weight_sum
 
-        if 0 < total_weight <= level_one_threshold:
+        if 0 <= total_weight <= level_one_threshold:
             return green(LEVEL_INFO.LOW.value)
 
         elif level_one_threshold < total_weight <= level_two_threshold:


### PR DESCRIPTION
When the weight is 0, it will cause an error, because the 0 boundary is not processed