### PR TITLE
add quark-engine requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ quark -a sample/14d9f1a92dd984d6040cc41ed06e273e.apk \
 
 ## QuickStart
 ### Requirements
-- Python 3.7+
-- git
+-  Python 3.7+
+-  git
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ quark -a sample/14d9f1a92dd984d6040cc41ed06e273e.apk \
 <img src="https://i.imgur.com/kxPYeIO.png"/>
 
 ## QuickStart
+### Requirements
+- Python 3.7+
+- git
+
 ### Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -96,9 +96,10 @@ quark -a sample/14d9f1a92dd984d6040cc41ed06e273e.apk \
 <img src="https://i.imgur.com/kxPYeIO.png"/>
 
 ## QuickStart
+
 ### Requirements
--  Python 3.7+
--  git
+-   Python 3.7+
+-   git
 
 ### Installation
 


### PR DESCRIPTION
Quark failed to install on a system with Python 3.6 installed. It also failed to run without `git`.