### PR TITLE
turn -r flag into optional

### DIFF
--- a/quark/cli.py
+++ b/quark/cli.py
@@ -39,9 +39,11 @@ check_update()
 @click.option(
     "-r",
     "--rule",
-    help="Rules folder need to be checked",
-    type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    required=True,
+    help="Rules directory",
+    type=click.Path(exists=True, file_okay=True, dir_okay=True),
+    default="quark-rules",
+    required=False,
+    show_default=True
 )
 @click.option(
     "-g",


### PR DESCRIPTION
Use the following command can directly use the rule sets we provide for analysis

```bash
quark -a test.apk -s
```

Fix the issue #105