### PR TITLE
multi-line string fix

### DIFF
--- a/quark/utils/regex.py
+++ b/quark/utils/regex.py
@@ -10,12 +10,14 @@ IP_ADDRESS_REGEX = r"(?:\d{1,3}\.)+(?:\d{1,3})"
 
 URL_REGEX = r"(?i)\b((?:https?://|www\d{0,3}[.]|[a-z0-9.\-]+[.][a-z]{2,4}/)(?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>]+|(\([^\s()<>]+\)))*\)|[^\s`!()\[\]{};:'\".,<>?«»“”‘’]))"
 
-VALIDATE_URL = r"^(?:http|ftp)s?://"  # http:// or https://
-r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|"  # domain...
-r"localhost|"  # localhost...
-r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"  # ...or ip
-r"(?::\d+)?"  # optional port
-r"(?:/?|[/?]\S+)$"
+VALIDATE_URL = (
+    r"^(?:http|ftp)s?://"  # http:// or https://
+    r"(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|"  # domain...
+    r"localhost|"  # localhost...
+    r"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})"  # ...or ip
+    r"(?::\d+)?"  # optional port
+    r"(?:/?|[/?]\S+)$"
+)
 
 ANDROID_CONTENT = "content://"
 ANDROID_FILE = "file://"


### PR DESCRIPTION
The regex string for URL validation was probably aimed to be implemented as a **multi-line string**, but it was missing parenthesis/brackets and thus the strings following the initial one (for HTTP check) were ignored.