### PR TITLE
Detect APIs in the extended classes

### DIFF
--- a/quark/Objects/apkinfo.py
+++ b/quark/Objects/apkinfo.py
@@ -120,6 +120,10 @@ class Apkinfo:
         return custom_methods
 
     @property
+    def all_classes(self):
+        return set(self.analysis.get_classes())
+
+    @property
     def all_methods(self):
         """
         Return all methods including Android native API and custom methods from given APK.

--- a/quark/Objects/quark.py
+++ b/quark/Objects/quark.py
@@ -35,6 +35,35 @@ class Quark:
 
         self.quark_analysis = QuarkAnalysis()
 
+    def find_api_usage(self, class_name, method_name, descriptor_name):
+        method_list = []
+        # origin class
+        method = self.apkinfo.find_method(
+            class_name, method_name, descriptor_name)
+        method_list.append(method)
+
+        # child class
+        if method or ')' in descriptor_name:
+            origin_parameters = str(
+                method.get_descriptor()) if method else descriptor_name
+            origin_parameters = origin_parameters[:origin_parameters.index(
+                ')')]
+
+            for cla in self.apkinfo.all_classes:
+                if not (class_name == str(cla.extends) or class_name in cla.implements):
+                    continue
+
+                # Check override
+                for cla_method in cla.get_methods():
+                    if not cla_method.name == method_name:
+                        continue
+
+                    signature = str(cla_method.get_descriptor())
+                    if signature[:signature.index(')')] == origin_parameters:
+                        method_list.append(cla_method)
+
+        return [method for method in method_list if method]
+
     def find_previous_method(self, base_method, parent_function, wrapper, visited_methods=None):
         """
         Find the method under the parent function, based on base_method before to parent_function.

--- a/quark/Objects/quark.py
+++ b/quark/Objects/quark.py
@@ -71,7 +71,8 @@ class Quark:
                             continue
 
                         signature = str(cla_method.get_descriptor())
-                        if signature[:signature.index(')')] == origin_parameters:
+                        if signature[:signature.index(')')]\
+                                == origin_parameters:
                             method_list.append(cla_method)
 
         return [method for method in method_list if method]

--- a/quark/Objects/quark.py
+++ b/quark/Objects/quark.py
@@ -49,18 +49,30 @@ class Quark:
             origin_parameters = origin_parameters[:origin_parameters.index(
                 ')')]
 
-            for cla in self.apkinfo.all_classes:
-                if not (class_name == str(cla.extends) or class_name in cla.implements):
-                    continue
+            set_updated = True
+            class_name_set = {class_name}
 
-                # Check override
-                for cla_method in cla.get_methods():
-                    if not cla_method.name == method_name:
+            while set_updated:
+                set_updated = False
+                for cla in self.apkinfo.all_classes:
+                    if str(cla.name) in class_name_set:
+                        continue
+                    elif str(cla.extends) not in class_name_set and not\
+                            [interface for interface in cla.implements
+                                if str(interface) in class_name_set]:
                         continue
 
-                    signature = str(cla_method.get_descriptor())
-                    if signature[:signature.index(')')] == origin_parameters:
-                        method_list.append(cla_method)
+                    class_name_set.add(str(cla.name))
+                    set_updated = True
+
+                    # Check override
+                    for cla_method in cla.get_methods():
+                        if not cla_method.name == method_name:
+                            continue
+
+                        signature = str(cla_method.get_descriptor())
+                        if signature[:signature.index(')')] == origin_parameters:
+                            method_list.append(cla_method)
 
         return [method for method in method_list if method]
 

--- a/tests/Object/test_quark.py
+++ b/tests/Object/test_quark.py
@@ -34,6 +34,24 @@ def result(scope="function"):
 
 class TestQuark():
 
+    def test_find_api_usage(self, result: Quark):
+        # Test Case 1
+        expect_list = {
+            result.apkinfo.find_method(
+                'Lcom/google/progress/GetInfomation;', 'getInfo', '()Ljava/lang/String;'),
+            result.apkinfo.find_method(
+                'Lcom/google/progress/FileList;', 'getInfo', '()Ljava/lang/String;'),
+            result.apkinfo.find_method(
+                'Lcom/google/progress/GetCallLog;', 'getInfo', '()Ljava/lang/String;'),
+            result.apkinfo.find_method(
+                'Lcom/google/progress/SMSHelper;', 'getInfo', '()Ljava/lang/String;')
+        }
+
+        api_usage_list = set(result.find_api_usage(
+            'Lcom/google/progress/GetInfomation;', 'getInfo', '()Ljava/lang/String;'))
+
+        assert api_usage_list == expect_list
+
     def test_find_previous_method(self, result):
         # Test Case 1
 

--- a/tests/Object/test_quark.py
+++ b/tests/Object/test_quark.py
@@ -38,17 +38,25 @@ class TestQuark():
         # Test Case 1
         expect_list = {
             result.apkinfo.find_method(
-                'Lcom/google/progress/GetInfomation;', 'getInfo', '()Ljava/lang/String;'),
+                'Lcom/google/progress/GetInfomation;',
+                'getInfo',
+                '()Ljava/lang/String;'),
             result.apkinfo.find_method(
-                'Lcom/google/progress/FileList;', 'getInfo', '()Ljava/lang/String;'),
+                'Lcom/google/progress/FileList;',
+                'getInfo', '()Ljava/lang/String;'),
             result.apkinfo.find_method(
-                'Lcom/google/progress/GetCallLog;', 'getInfo', '()Ljava/lang/String;'),
+                'Lcom/google/progress/GetCallLog;',
+                'getInfo', '()Ljava/lang/String;'),
             result.apkinfo.find_method(
-                'Lcom/google/progress/SMSHelper;', 'getInfo', '()Ljava/lang/String;')
+                'Lcom/google/progress/SMSHelper;',
+                'getInfo',
+                '()Ljava/lang/String;')
         }
 
         api_usage_list = set(result.find_api_usage(
-            'Lcom/google/progress/GetInfomation;', 'getInfo', '()Ljava/lang/String;'))
+            'Lcom/google/progress/GetInfomation;',
+            'getInfo',
+            '()Ljava/lang/String;'))
 
         assert api_usage_list == expect_list
 


### PR DESCRIPTION
Fix issues #158.

Detect APIs not only in the classes defined in the rule but in all classes that extend it.