### PR TITLE
A workaround for tracing objects.

### DIFF
--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -81,7 +81,10 @@ class PyEval:
             obj_stack = self.table_obj.get_obj_list(index)
             if obj_stack:
                 var_obj = self.table_obj.pop(index)
-                value_of_reg_list.append(var_obj.value)
+                if var_obj.is_instance() and var_obj.called_by_func:
+                    value_of_reg_list.append(var_obj.called_by_func[-1])
+                else:
+                    value_of_reg_list.append(var_obj.value)
 
         # insert the function and the parameter into called_by_func
         for reg in reg_list:

--- a/quark/Objects/registerobject.py
+++ b/quark/Objects/registerobject.py
@@ -96,6 +96,8 @@ class RegisterObject:
         """
         return int(self.register_name[1:])
 
+    def is_instance(self):
+        return self.value.startswith('L') and self.value.endswith(';')
 
 if __name__ == "__main__":
     pass


### PR DESCRIPTION
Quark does not trace objects for now, which causes a strange false negative when analyzing (#159).
Here is a simple workaround that uses the value field of `RegisterObject` object to trace both primitive and reference types.
+ if a register stores a string that starts with 'L' and ends with ';', it is a reference type (object)
+ otherwise, it is a primitive type (number, float, string, etc.)

When an invocation occurs, the argument registers with reference types will taint the object by sharing the latest element of `called_by_func` property with it.

However, I think this **may not** be the best solution rather than a quick fix for an accurater analysis.
The best one needs more further discussion instead.