### PR TITLE
fix bug in aget-object in quark/Evaluator/pyeval.py

### DIFF
--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -7,6 +7,7 @@
 # http://pallergabor.uw.hu/androidblog/dalvik_opcodes.html
 
 import logging
+import re
 from datetime import datetime
 
 from quark.Objects.registerobject import RegisterObject
@@ -333,10 +334,10 @@ class PyEval:
         try:
 
             array_obj = self.table_obj.get_obj_list(
-                int(instruction[2][1:]),
+                int(re.sub("[^0-9]", "", instruction[2][1:])),
             ).pop()
             array_index = self.table_obj.get_obj_list(
-                int(instruction[3]),
+                int(re.sub("[^0-9]", "", instruction[3])),
             ).pop()
 
             variable_object = RegisterObject(

--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -333,10 +333,10 @@ class PyEval:
         try:
 
             array_obj = self.table_obj.get_obj_list(
-                int(instruction[2][1]),
+                int(instruction[2][1:]),
             ).pop()
             array_index = self.table_obj.get_obj_list(
-                int(instruction[3][1]),
+                int(instruction[3]),
             ).pop()
 
             variable_object = RegisterObject(


### PR DESCRIPTION
fix bug in `AGET_OBJECT` method in `quark/Evaluator/pyeval.py`
This method takes as parameter `instruction`, 
```
print(instruction)
> ['aget-object', 'v9', 'v12', '11']
```
* If register number (v12 in this case) has a certain value (i.e. an integer of 2 digits), with the original code it is taken the wrong register number, as in this case the expected value should be 12, but it is taken 1.
* Index of array (third parameter of instruction) is an integer, so it makes sense to take "all" the value of `instruction[3]` and not `instruction[3][1]`

The edited lines of code permit to get the correct number of register (12, not anymore 1) and the correct index (11 not anymore 1)

Hope this could help :-)