### PR TITLE
Added check to skip permissions check if DEX file

### DIFF
--- a/quark/Objects/quark.py
+++ b/quark/Objects/quark.py
@@ -219,7 +219,9 @@ class Quark:
         self.quark_analysis.crime_description = rule_obj.crime
 
         # Level 1: Permission Check
-        if set(rule_obj.permission).issubset(set(self.apkinfo.permissions)):
+        if self.apkinfo.ret_type == "DEX":
+            rule_obj.check_item[0] = True
+        elif set(rule_obj.permission).issubset(set(self.apkinfo.permissions)):
             rule_obj.check_item[0] = True
         else:
             # Exit if the level 1 stage check fails.


### PR DESCRIPTION
Fix issue with DEX files. 

If the file that has to be analyzed is a DEX file, it does not contain a manifest, so it is useless to check for permissions. In fact, this check will only leads to an unwanted behavior: the permission check will fail (even if the permissions are actually requested) and the analysis on that rule will stop (even if the rule is matched for the 100%)

I just edited two lines of code in the `Quark.py` file to skip permissions check if we are analyzing a DEX file. 