### PR TITLE
Creation of option to print Report based on Label Rules

### DIFF
--- a/quark/Objects/analysis.py
+++ b/quark/Objects/analysis.py
@@ -14,11 +14,19 @@ def init_pretty_table():
     tb.align = "l"
     return tb
 
+def init_label_report_table():
+    # Pretty Table Output
+    tb = PrettyTable()
+    tb.field_names = ["Label", "Description", "Number of rules", "MAX Score %"]
+    tb.align = "l"
+    tb.sortby = "Number of rules"
+    tb.reversesort = True
+    return tb
 
 class QuarkAnalysis:
     __slots__ = ["crime_description", "first_api", "second_api", "level_1_result", "level_2_result", "level_3_result",
                  "level_4_result", "level_5_result", "json_report", "weight_sum", "score_sum", "summary_report_table",
-                 "call_graph_analysis_list", "parent_wrapper_mapping"]
+                 "label_report_table", "call_graph_analysis_list", "parent_wrapper_mapping"]
 
     def __init__(self):
         self.crime_description = ""
@@ -37,6 +45,8 @@ class QuarkAnalysis:
         # Sum of the each rule
         self.score_sum = 0
         self.summary_report_table = init_pretty_table()
+        # label report
+        self.label_report_table = init_label_report_table()
         # Call graph analysis
         self.call_graph_analysis_list = []
 

--- a/quark/Objects/quark.py
+++ b/quark/Objects/quark.py
@@ -18,6 +18,8 @@ from quark.utils.graph import call_graph
 from quark.utils.out import print_info, print_success
 from quark.utils.output import output_parent_function_table, output_parent_function_json
 from quark.utils.weight import Weight
+import pandas as pd
+import os
 
 MAX_SEARCH_LAYER = 3
 CHECK_LIST = "".join(["\t[" + "\u2713" + "]"])
@@ -419,6 +421,32 @@ class Quark:
         self.quark_analysis.weight_sum += weight
         # add the score
         self.quark_analysis.score_sum += score
+
+    def show_label_report(self, rule_path, all_labels):
+        """
+        Show the report based on label, last column represents max score for that label
+        :param rule_path: the path where may be present the file label_desc.csv.
+        :param all_labels: dictionary containing label:<array of score associated to that label>
+        :return: None
+        """
+        label_desc = {}
+        if os.path.isfile(os.path.join(rule_path, "label_desc.csv")):
+            # associate to each label a description
+            col_list = ["label", "description"]
+            # csv file on form <label,description>
+            # put this file in the folder of rules (it must not be a json file since it could create conflict with management of rules)
+            df = pd.read_csv(os.path.join(rule_path, "label_desc.csv"), usecols=col_list)
+            label_desc = dict(zip(df["label"], df["description"]))
+        
+        for label_name in all_labels:
+            scores = all_labels[label_name]
+            self.quark_analysis.label_report_table.add_row([
+                green(label_name),
+                yellow(label_desc.get(label_name, "-")),
+                (len(scores)),
+                red(max(scores)),
+            ])
+            
 
     def show_detail_report(self, rule_obj):
         """

--- a/quark/Objects/quarkrule.py
+++ b/quark/Objects/quarkrule.py
@@ -9,7 +9,7 @@ import os
 class QuarkRule:
     """RuleObject is used to store the rule from json file"""
 
-    __slots__ = ["check_item", "_json_obj", "_crime", "_permission", "_api", "_score", "rule_filename"]
+    __slots__ = ["check_item", "_json_obj", "_crime", "_permission", "_api", "_score", "rule_filename", "_label"]
 
     def __init__(self, json_filename):
         """
@@ -27,6 +27,7 @@ class QuarkRule:
             self._api = self._json_obj["api"]
             self._score = self._json_obj["score"]
             self.rule_filename = os.path.basename(json_filename)
+            self._label = self._json_obj["label"]
 
     def __repr__(self):
         return f"<RuleObject-{self.rule_filename}>"

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -123,26 +123,23 @@ def entry_point(
             data.run(rule_checker)
             score = rule_checker.check_item.count(True) * 20
             labels = rule_checker._label # array type, e.g. ['network', 'collection']
-            for label in labels:
-                if label in all_labels:
-                    all_labels[label].append(score)
+            for single_label in labels:
+                if single_label in all_labels:
+                    all_labels[single_label].append(score)
                 else:
-                    all_labels[label] = [score]
+                    all_labels[single_label] = [score]
             
         # get how many label with max score >= 80%
         counter_high_score = 0
-        for label in all_labels:
-            if max(all_labels[label]) >= 80:
+        for single_label in all_labels:
+            if max(all_labels[single_label]) >= 80:
                 counter_high_score += 1
 
         print_info("Total Label found: " + yellow(str(len(all_labels))))
         print_info("Rules with label which max score >= 80%: " + yellow(str(counter_high_score)))
         
-        if label == "max":
-            data.show_label_report(rule, all_labels)
-            print(data.quark_analysis.label_report_table)
-        else:
-            print("TODO")
+        data.show_label_report(rule, all_labels, label)
+        print(data.quark_analysis.label_report_table)
 
     # Show summary report
     if summary:

--- a/quark/rules/sendLocation_SMS.json
+++ b/quark/rules/sendLocation_SMS.json
@@ -17,5 +17,9 @@
             "descriptor": "(Ljava/lang/String; Ljava/lang/String; Ljava/lang/String; Landroid/app/PendingIntent; Landroid/app/PendingIntent;)V"
         }
     ],
-    "score": 4
+    "score": 4,
+    "label": [
+        "location",
+        "collection"
+    ]
 }

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,6 @@ setuptools.setup(
         "colorama",
         "click==7.1.2",
         "graphviz",
+        "pandas", 
     ],
 )

--- a/tests/Object/test_ruleobject.py
+++ b/tests/Object/test_ruleobject.py
@@ -25,7 +25,11 @@ def rule_obj(scope="function"):
                 "method": "sendTextMessage"
             }
         ],
-        "score": 4
+        "score": 4,
+        "label": [
+        "location",
+        "collection"
+    ]
     }
     """
 
@@ -67,7 +71,6 @@ class TestRuleObject:
         assert rule_obj.score == 4
 
     def test_get_score(self, rule_obj):
-
         confidence = [1, 2, 3, 4, 5]
         expected_value = [0.25, 0.5, 1.0, 2.0, 4.0]
         for idx, value in enumerate(expected_value):


### PR DESCRIPTION
With the following `pull request` we (me, @cryptax, @Dil3mm3 and @3aglew0) propose you to add another option to print a report based on *labels* specified inside a rule.


<img src="https://user-images.githubusercontent.com/61980210/118356607-5a426080-b576-11eb-8c7e-a3e53f7f4758.png" width="400" height="300">

We have noticed they are not used and it could be interesting to print a short report taking into consideration these values. Here an example of output where it is printed for each label (found inside the rules) a description (see explanation below), the number of rules where this label is contained and other detailes described better below.

![example_of_output](https://user-images.githubusercontent.com/61980210/118354530-bd7ac580-b56b-11eb-8b46-4a7988ae7b1f.png)

This option permits to print a report based on label with two different levels of details
1. `quark -a malware_to_be_analysed.apk -r rule_dir -l max`
     print the maximum score for each label (as image above), this would permit us to understand in which topic (represented by label) a malware is more aggressive. For example, looking at the previous output we can see the malware performs with success malicious action related to location, calllog and sms. 
2. `quark -a malware_to_be_analysed.apk -r rule_dir -l detailed`
    print a detail report with all the previous information plus: 
    * Number of rules (with that label) which have a score >= 80%
    * Average score and standard deviation (computed over the all the scores obtained by that specific label). Interesting considerations could be the following:  label with high average and low standard deviation would allow us to say the malware performs a series of malicious actions (with success); then, a high standard deviation means there are some rules which take high score so the malware performs with success only some actions with that label; finally, a low standard deviation and a low average on a certain label means the malware is not performing malicious action on that topic. Example of output:
    
![output_detailed_report](https://user-images.githubusercontent.com/61980210/118355905-f79b9580-b572-11eb-9021-6bad6d93d50b.png)

The column description allows to add a short and representative sentence about a label, for example for the `callog` the relative description is `Retrieve or manipulate sensitive data from call log`. In order to implement a flexible solution we have thought to add a *csv file* in the same directory of rules with the following structure `label,description`. We have chosen `csv` extension because it is easy to manipulate and it wasn't possible to use a json format since in that folder all json files are interpreted as rules. If this file is not present or a `label,description` pair is absent, the corresponding cell in the label report is filled with `-`. Example of output

![output_with_desc](https://user-images.githubusercontent.com/61980210/118356087-ddae8280-b573-11eb-842e-f562bf21c652.png)

I leave here a sample of the csv file to be put in the folder of the rules ([label_desc.csv](https://github.com/quark-engine/quark-engine/files/6485320/label_desc.csv))

Do not hesitate to contact me for any type of clarification