### PR TITLE
Choose one rule or label to be analyzed in summary or detailed output + more Rules info in output

### DIFF
--- a/quark/Objects/analysis.py
+++ b/quark/Objects/analysis.py
@@ -10,7 +10,7 @@ from prettytable import PrettyTable
 def init_pretty_table():
     # Pretty Table Output
     tb = PrettyTable()
-    tb.field_names = ["Rule", "Confidence", "Score", "Weight"]
+    tb.field_names = ["Filename", "Rule", "Confidence", "Score", "Weight"]
     tb.align = "l"
     return tb
 

--- a/quark/Objects/quark.py
+++ b/quark/Objects/quark.py
@@ -385,9 +385,10 @@ class Quark:
         # add the score
         self.quark_analysis.score_sum += score
 
-    def add_table_row(self, rule_obj, confidence, score, weight):
+    def add_table_row(self, name, rule_obj, confidence, score, weight):
 
         self.quark_analysis.summary_report_table.add_row([
+            name,
             green(rule_obj.crime),
             yellow(confidence),
             score,
@@ -406,14 +407,15 @@ class Quark:
         conf = rule_obj.check_item.count(True)
         weight = rule_obj.get_score(conf)
         score = rule_obj.score
+        name = rule_obj.rule_filename
 
         if threshold:
 
             if rule_obj.check_item.count(True) * 20 >= int(threshold):
-                self.add_table_row(rule_obj, confidence, score, weight)
+                self.add_table_row(name, rule_obj, confidence, score, weight)
 
         else:
-            self.add_table_row(rule_obj, confidence, score, weight)
+            self.add_table_row(name, rule_obj, confidence, score, weight)
 
         # add the weight
         self.quark_analysis.weight_sum += weight

--- a/quark/Objects/quarkrule.py
+++ b/quark/Objects/quarkrule.py
@@ -9,7 +9,7 @@ import os
 class QuarkRule:
     """RuleObject is used to store the rule from json file"""
 
-    __slots__ = ["check_item", "_json_obj", "_crime", "_permission", "_api", "_score", "rule_filename"]
+    __slots__ = ["check_item", "_json_obj", "_crime", "_permission", "_api", "_score", "rule_filename", "_label"]
 
     def __init__(self, json_filename):
         """
@@ -27,6 +27,7 @@ class QuarkRule:
             self._api = self._json_obj["api"]
             self._score = self._json_obj["score"]
             self.rule_filename = os.path.basename(json_filename)
+            self._label = self._json_obj["label"]
 
     def __repr__(self):
         return f"<RuleObject-{self.rule_filename}>"

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -19,8 +19,18 @@ logo()
 
 
 @click.command(no_args_is_help=True)
-@click.option("-s", "--summary", is_flag=True, help="Show summary report")
-@click.option("-d", "--detail", is_flag=True, help="Show detail report")
+@click.option(
+    "-s", 
+    "--summary", 
+    is_flag=False, 
+    flag_value="all_rules",
+    help="Show summary report")
+@click.option(
+    "-d", 
+    "--detail", 
+    is_flag=False, 
+    flag_value="all_rules", 
+    help="Show detail report")
 @click.option(
     "-o",
     "--output",
@@ -102,9 +112,22 @@ def entry_point(
     # Show summary report
     if summary:
 
+        if summary=="all_rules" :
+            label_flag = False
+        elif summary.endswith("json") :
+            rules_list = [summary]
+            label_flag = False
+        else :
+            label_flag = True
+
         for single_rule in tqdm(rules_list):
             rulepath = os.path.join(rule, single_rule)
             rule_checker = QuarkRule(rulepath)
+
+            labels = rule_checker._label
+            if label_flag :
+                if summary not in labels :
+                    continue
 
             # Run the checker
             data.run(rule_checker)
@@ -124,10 +147,24 @@ def entry_point(
     # Show detail report
     if detail:
 
+        if detail=="all_rules" :
+            label_flag = False
+        elif detail.endswith("json") :
+            rules_list = [detail]
+            label_flag = False
+        else :
+            label_flag = True
+
         for single_rule in tqdm(rules_list):
             rulepath = os.path.join(rule, single_rule)
             print(rulepath)
             rule_checker = QuarkRule(rulepath)
+
+            print("Rule crime: " + rule_checker._crime)
+            labels = rule_checker._label
+            if label_flag :
+                if detail not in labels :
+                    continue
 
             # Run the checker
             data.run(rule_checker)

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -157,10 +157,8 @@ def entry_point(
 
         for single_rule in tqdm(rules_list):
             rulepath = os.path.join(rule, single_rule)
-            print("Rulepath: " + rulepath)
             rule_checker = QuarkRule(rulepath)
 
-            print("Rule crime: " + rule_checker._crime)
             labels = rule_checker._label
             if label_flag :
                 if detail not in labels :
@@ -169,6 +167,8 @@ def entry_point(
             # Run the checker
             data.run(rule_checker)
 
+            print("Rulepath: " + rulepath)
+            print("Rule crime: " + rule_checker._crime)
             data.show_detail_report(rule_checker)
             print_success("OK")
 

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -157,7 +157,7 @@ def entry_point(
 
         for single_rule in tqdm(rules_list):
             rulepath = os.path.join(rule, single_rule)
-            print(rulepath)
+            print("Rulepath: " + rulepath)
             rule_checker = QuarkRule(rulepath)
 
             print("Rule crime: " + rule_checker._crime)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         "androguard==3.4.0a1",
         "tqdm",
         "colorama",
-        "click==7.1.2",
+        "click==8.0.1",
         "graphviz",
     ],
 )


### PR DESCRIPTION
With the following pull request we (me, @cryptax, @ciastron and @3aglew0) propose you to add the possibility of choosing a rule or a label to filter the output of quark. Using Quark during the last weeks we thought that having the possibility to choose only a certain rule/label when printing the summary or detailed output can be useful. With the changes we made, we filter the rules that Quark is using to analyze the current APK/DEX file; in this way we are not just applying a filter to the output, but we are also preventing Quark from wasting time analyzing rules on which we are not interested in. 

In order to do so, we changed the `summary` and `detail` options: in few words, we added the possibility to add a parameter after invoking those options. With _Click 8.0.1_ in fact, it is possible to specify options in a way that they can accept zero or more parameters, using the "_flag_value_" attribute.

Thanks to this new feature of Click, now it is possible to invoke the two options in three different ways:

1. `Quark -a sample.apk -s` --> will analyze and print the output of all the rules inside the default directory
2. `Quark -a sample.apk -s label` --> will analyze and print only the output related to the specified label
3. `Quark -a sample.apk -s rule.json` --> will analyze and print only the output related to the specified rule

The same thing happens when using the `-d` option. 

Obviously this is something that can be extended to more rules or labels at the same time if you find it useful.

Moreover, we added the `Filename`column to the `summary` table. We thought that having the possibility to understand immediately which rule is obtaining a certain level of confidence can be useful, for example, to edit them faster or simply to easily identify them inside the rules directory (that can result quite boring reading only the crime associated to that rule). In addition, this is something that is already shown in the detailed output, that's why we thought that it can be useful to have it also in the summary table.
In the same way, in the detailed output only the Rulepath was printed while the rule crime was not shown, for this reason we added it too.

I will show you some output examples here:
![summary_label_censored](https://user-images.githubusercontent.com/62121715/119231467-5a67d080-bb21-11eb-8697-a9da6195433e.jpg)
![summary_rule_censored](https://user-images.githubusercontent.com/62121715/119231473-60f64800-bb21-11eb-8cfe-bc4bfae0653f.jpg)
![detail_rule_censored](https://user-images.githubusercontent.com/62121715/119231475-66539280-bb21-11eb-85e9-e57bbf825340.jpg)

