### PR TITLE
Update setup.py to latest click version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         "androguard==3.4.0a1",
         "tqdm",
         "colorama",
-        "click",
+        "click==8.0.1",
         "graphviz",
         "pandas", 
     ],


### PR DESCRIPTION
Hi all,

Testing Quark we noticed that, without forcing Click to the latest version (8.0.1) in the Setup.py file, the attribute `flag_value`, inserted to let the options `-s` and `-d` take zero or more arguments, is not working. For this reason, I just changed the Setup.py and Click version. Everything should work correctly now :smile: 