### PR TITLE
NEW FEATURE FOR MALWARE COMPARISON BASED ON LABEL

### DIFF
--- a/quark/cli.py
+++ b/quark/cli.py
@@ -123,7 +123,7 @@ def entry_point(
     
     if comparison:
 
-        # selection of labels on which it will be done the comparison on radare chart
+        # selection of labels on which it will be done the comparison on radar chart
         # first look for all label found in the rule list
         all_labels = []
         for single_rule in tqdm(rules_list):
@@ -191,20 +191,20 @@ def entry_point(
                     else:
                         all_labels[single_label] = [confidence]
 
-            # extrapolate data used to plot radare chart
-            radare_data = {}
+            # extrapolate data used to plot radar chart
+            radar_data = {}
             for _label in selected_label:
                 confidences = np.array(all_labels[_label])
-                # on radare data use the maximum confidence for a certain label
-                radare_data[_label] = np.max(confidences)
+                # on radar data use the maximum confidence for a certain label
+                radar_data[_label] = np.max(confidences)
 
-            radare_confidence = []
-            for _label in radare_data:
-                radare_confidence.append(radare_data[_label])
+            radar_confidence = []
+            for _label in radar_data:
+                radar_confidence.append(radar_data[_label])
 
             fig.add_trace(
                 go.Scatterpolar(
-                    r=radare_confidence,
+                    r=radar_confidence,
                     theta=selected_label,
                     fill="toself",
                     name=apk_.split("/")[-1],

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -129,7 +129,9 @@ def entry_point(
         for single_rule in tqdm(rules_list):
             rulepath = os.path.join(rule, single_rule)
             rule_checker = QuarkRule(rulepath)
-            labels = rule_checker._label  # array type, e.g. ['network', 'collection']
+            labels = (
+                rule_checker._label
+            )  # array type, e.g. ['network', 'collection']
             for single_label in labels:
                 if single_label not in all_labels:
                     all_labels.append(single_label)
@@ -139,20 +141,26 @@ def entry_point(
             all_labels,
             multi_select=True,
             show_multi_select_hint=False,
-            )
+        )
         max_labels = 10
         min_labels = 5
         while True:
             menu_entry_indices = terminal_menu.show()
-            if len(menu_entry_indices) in range (min_labels, max_labels + 1):
+            if len(menu_entry_indices) in range(min_labels, max_labels + 1):
                 break
-            print("Select numbers of labels in range [" + str(min_labels) + "," + str(max_labels) + "]\n")
+            print(
+                "Select numbers of labels in range ["
+                + str(min_labels)
+                + ","
+                + str(max_labels)
+                + "]\n"
+            )
         selected_label = np.array(terminal_menu.chosen_menu_entries)
 
         # initialize Figure object used to build the graph
         fig = go.Figure()
 
-        # perform label based analysis on the apk_ 
+        # perform label based analysis on the apk_
         for apk_ in apk:
             data = Quark(apk_)
             all_labels = {}
@@ -174,42 +182,41 @@ def entry_point(
                 # Run the checker
                 data.run(rule_checker)
                 confidence = rule_checker.check_item.count(True) * 20
-                labels = rule_checker._label  # array type, e.g. ['network', 'collection']
+                labels = (
+                    rule_checker._label
+                )  # array type, e.g. ['network', 'collection']
                 for single_label in labels:
                     if single_label in all_labels:
                         all_labels[single_label].append(confidence)
                     else:
                         all_labels[single_label] = [confidence]
 
-            # extrapolate data used to plot radare chart 
-            radare_data = {}          
+            # extrapolate data used to plot radare chart
+            radare_data = {}
             for _label in selected_label:
                 confidences = np.array(all_labels[_label])
                 # on radare data use the maximum confidence for a certain label
                 radare_data[_label] = np.max(confidences)
-            
+
             radare_confidence = []
             for _label in radare_data:
                 radare_confidence.append(radare_data[_label])
-            
-            fig.add_trace(go.Scatterpolar(
-                r=radare_confidence,
-                theta=selected_label,
-                fill='toself',
-                name=apk_.split('/')[-1],
-                line=dict(
-                    width=4,
+
+            fig.add_trace(
+                go.Scatterpolar(
+                    r=radare_confidence,
+                    theta=selected_label,
+                    fill="toself",
+                    name=apk_.split("/")[-1],
+                    line=dict(
+                        width=4,
+                    ),
                 )
-            ))
-            print ("hey")
+            )
         # plot the graph with specific layout
         fig.update_layout(
-        polar=dict(
-            radialaxis=dict(
-            visible=True,
-            range=[0, 100]
-            )),
-        showlegend=True
+            polar=dict(radialaxis=dict(visible=True, range=[0, 100])),
+            showlegend=True,
         )
         fig.show()
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
         "androguard==3.4.0a1",
         "tqdm",
         "colorama",
-        "click",
+        "click==8.0.1",
         "graphviz",
         "pandas",
         "simple_term_menu",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ setuptools.setup(
         "colorama",
         "click",
         "graphviz",
-        "pandas", 
+        "pandas",
+        "simple_term_menu",
+        "plotly",
     ],
 )


### PR DESCRIPTION
With the following pull request we (me, @cryptax, @Dil3mm3 and @3aglew0) propose you to add another option which allows user to compare different malware. The comparison criteria is based on label result confidence discussed in pull request #165. 

![Screenshot from 2021-05-29 11-29-28](https://user-images.githubusercontent.com/61980210/120065409-6a2b6b80-c071-11eb-8fa8-e27920a49ff7.png)

This idea was born when you proposed radar chart to analyze report based on labels: we thought it could be useful to use such graph to analyze different malwares. The following represents an example where two radar chart (malware RED and malware BLU) are used to compare features of two different malwares.
![Screenshot from 2021-05-29 11-17-07](https://user-images.githubusercontent.com/61980210/120065030-9219cf80-c06f-11eb-9511-e8ef5d4d88a8.png)
In the image, at the border, there are some labels that the user selected (see below for further information) and each figure represents different malwares. Figures are draw based on maximum confidence result the malware obtained for any rules with those labels: for example in this case both malware reach 100% confidence in sms label because there exist at least one rule with sms label where they obtain that confidence.
Given the above result we could conclude for example that both malware perform malicious actions related to sms and location content, the RED one exploits accessibility service while the BLUE one wifi connection.

How to use this feature
This feature introduces the possibility to analyze more than one malware. A possible usage when launched from the terminal could be the following

quark -a malware_RED.apk -a malware_BLUE.apk -r path/to/rule/folder -C

*(note that it is possible to analyze an indefinite number of malwares)*

As first, the user is asked to select a list of labels (dynamically loaded from the rules folder). She must select a number of labels in a certain interval (in our case we defined a minimum of 5 and a maximum of 10, of course it can be modified): in order to create a user friendly menu we have used simple_term_menu module in python. 

![Screenshot from 2021-05-29 11-43-57](https://user-images.githubusercontent.com/61980210/120065734-36514580-c073-11eb-844e-0f356639e1c5.png)

For each malware passed as parameter it is performed the same type of analysis described in merge request #165 (delimited only by the rules which contains the selected labels).
Using plotly module we print the result on a radar chart. This tool is very flexible and it permits to visualize on the same graph different plots or disable some of them to make the image more clear.

Do not hesitate to contact me for any type of clarification, hope this feature could help for malware analysis :smiley: