### PR TITLE
Refactor/enrich the tests of the analysis part of modules

### DIFF
--- a/tests/Evaluator/test_pyeval.py
+++ b/tests/Evaluator/test_pyeval.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch
 
 from quark.Evaluator.pyeval import PyEval, MAX_REG_COUNT
 from quark.Objects.tableobject import TableObject
@@ -29,10 +30,14 @@ def pyeval():
     # mock_hash_table = [...[], [v4_mock_variable_obj], [], [],
     # [v9_mock_variable_obj]....]
     v4_mock_variable_obj = RegisterObject(
-        "v4", "Lcom/google/progress/SMSHelper;", None,
+        "v4",
+        "Lcom/google/progress/SMSHelper;",
+        None,
     )
     v9_mock_variable_obj = RegisterObject(
-        "v9", "some_string", "java.io.file.close()",
+        "v9",
+        "some_string",
+        "java.io.file.close()",
     )
     pyeval.table_obj.insert(4, v4_mock_variable_obj)
     pyeval.table_obj.insert(9, v9_mock_variable_obj)
@@ -43,69 +48,287 @@ def pyeval():
 
 
 class TestPyEval:
-    def test_init(self, pyeval):
+    def test_init(self):
+        pyeval = PyEval()
+
         assert len(pyeval.table_obj.hash_table) == MAX_REG_COUNT
         assert isinstance(pyeval.table_obj, TableObject)
         assert pyeval.ret_stack == []
 
-        assert pyeval.table_obj.pop(4).register_name == "v4"
-        assert pyeval.table_obj.pop(
-            4,
-        ).value == "Lcom/google/progress/SMSHelper;"
-        assert pyeval.table_obj.pop(4).called_by_func == []
+    # Tests for _invoke
+    def test_invoke_with_non_list_object(self, pyeval):
+        instruction = None
 
-        assert pyeval.table_obj.pop(9).register_name == "v9"
-        assert pyeval.table_obj.pop(9).value == "some_string"
+        with pytest.raises(TypeError):
+            pyeval._invoke(instruction)
+
+    def test_invoke_with_empty_list(self, pyeval):
+        instruction = []
+
+        with pytest.raises(IndexError):
+            pyeval._invoke(instruction)
+
+    def test_invoke_with_wrong_types(self, pyeval):
+        instruction = [1, 2, 3]
+
+        with pytest.raises(TypeError):
+            pyeval._invoke(instruction)
+
+    def test_invoke_with_invalid_value(self, pyeval):
+        instruction = ["invoke-kind", "", ""]
+
+        with pytest.raises(ValueError):
+            pyeval._invoke(instruction)
+
+    def test_invoke_with_func_returning_value(self, pyeval):
+        instruction = ["invoke-kind", "v4", "v9", "some_function()Lclass;"]
+
+        pyeval._invoke(instruction)
+
+        assert pyeval.table_obj.pop(4).called_by_func == [
+            "some_function()Lclass;(Lcom/google/progress/SMSHelper;,some_string)"
+        ]
         assert pyeval.table_obj.pop(9).called_by_func == [
             "java.io.file.close()",
+            "some_function()Lclass;(Lcom/google/progress/SMSHelper;,some_string)",
+        ]
+        assert pyeval.ret_stack == [
+            "some_function()Lclass;(Lcom/google/progress/SMSHelper;,some_string)"
         ]
 
-    def test_invoke_direct(self, pyeval):
-        instruction = ["invoke-direct", "v4", "v9", "some_function()"]
+    @pytest.mark.skip(reasopytn="discussion needed.")
+    def test_invoke_with_func_not_returning_value(self, pyeval):
+        instruction = ["invoke-kind", "v4", "v9", "some_function()V"]
 
-        pyeval.INVOKE_DIRECT(instruction)
+        pyeval._invoke(instruction)
 
-        # It should be [some_function()(v4, v9)], and the query the value of v4
-        # and v9 and replace it with the value into
-        # [some_function()(Lcom/google/progress/SMSHelper;,some_string)]
-
-        v4_expected_call_by_func = [
-            "some_function()(Lcom/google/progress/SMSHelper;,some_string)",
+        assert pyeval.table_obj.pop(4).called_by_func == [
+            "some_function()V(Lcom/google/progress/SMSHelper;,some_string)"
         ]
-        v9_expected_call_by_func = [
+        assert pyeval.table_obj.pop(9).called_by_func == [
             "java.io.file.close()",
-            "some_function()(Lcom/google/progress/SMSHelper;,some_string)",
+            "some_function()V(Lcom/google/progress/SMSHelper;,some_string)",
         ]
-        assert pyeval.table_obj.pop(
-            4,
-        ).called_by_func == v4_expected_call_by_func
-        assert pyeval.table_obj.pop(
-            9,
-        ).called_by_func == v9_expected_call_by_func
+        assert pyeval.ret_stack == []
 
-    def test_invoke_virtual(self, pyeval):
-        instruction = ["invoke-virtual", "v4", "v9", "some_function()"]
+    def test_invoke_without_registers(self, pyeval):
+        instruction = ["invoke-static", "some-func()Lclass;"]
 
-        pyeval.INVOKE_VIRTUAL(instruction)
-        # It should be [some_function()(v4, v9)], and the query the value of v4
-        # and v9 and replace it with the value into
-        # [some_function()(Lcom/google/progress/SMSHelper;,some_string)]
+        pyeval._invoke(instruction)
 
-        v4_expected_call_by_func = [
-            "some_function()(Lcom/google/progress/SMSHelper;,some_string)",
+        assert pyeval.table_obj.pop(9).called_by_func == ["java.io.file.close()"]
+        assert pyeval.ret_stack == ["some-func()Lclass;()"]
+
+    # Tests for invoke_virtual
+    def test_invoke_virtual_with_valid_mnemonic(self, pyeval):
+        instruction = ["invoke-virtual", "v4", "v9", "some_function()V"]
+
+        with patch("quark.Evaluator.pyeval.PyEval._invoke") as mock:
+            pyeval.INVOKE_VIRTUAL(instruction)
+            mock.assert_called_once_with(instruction)
+
+    # Tests for invoke_direct
+    def test_invoke_direct_with_valid_mnemonic(self, pyeval):
+        instruction = ["invoke-direct", "v4", "v9", "some_function()V"]
+
+        with patch("quark.Evaluator.pyeval.PyEval._invoke") as mock:
+            pyeval.INVOKE_DIRECT(instruction)
+            mock.assert_called_once_with(instruction)
+
+    # Tests for invoke_static
+    def test_invoke_static_with_valid_mnemonic(self, pyeval):
+        instruction = ["invoke-static", "v4", "v9", "some_function()V"]
+
+        with patch("quark.Evaluator.pyeval.PyEval._invoke") as mock:
+            pyeval.INVOKE_STATIC(instruction)
+            mock.assert_called_once_with(instruction)
+
+    # Tests for invoke-interface
+    def test_invoke_interface_with_valid_mnemonic(self, pyeval):
+        instruction = ["invoke-interface", "v4", "v9", "some_function()V"]
+
+        with patch("quark.Evaluator.pyeval.PyEval._invoke") as mock:
+            pyeval.INVOKE_INTERFACE(instruction)
+            mock.assert_called_once_with(instruction)
+
+    # Tests for _move
+    def test_move_with_non_list_object(self, pyeval):
+        instruction = None
+
+        with pytest.raises(TypeError):
+            pyeval._move(instruction)
+
+    def test_move_with_empty_list(self, pyeval):
+        instruction = []
+
+        with pytest.raises(IndexError):
+            pyeval._move(instruction)
+
+    def test_move_with_invalid_instrcution(self, pyeval):
+        instruction = ["move-kind", "", ""]
+
+        with pytest.raises(ValueError):
+            pyeval._move(instruction)
+
+    def test_move_with_valid_instrcution(self, pyeval):
+        instruction = ["move-result-object", "v1"]
+        expected_return_value = "some_function()V(used_register_1, used_register_2)"
+        pyeval.ret_stack.append(expected_return_value)
+
+        pyeval._move(instruction)
+
+        assert pyeval.table_obj.pop(1).value == expected_return_value
+        assert pyeval.table_obj.pop(1).called_by_func == []
+
+    # Tests for move_result
+    def test_move_result_with_valid_mnemonic(self, pyeval):
+        instruction = ["move-result", "v1"]
+
+        with patch("quark.Evaluator.pyeval.PyEval._move") as mock:
+            pyeval.MOVE_RESULT(instruction)
+            mock.assert_called_once_with(instruction)
+
+    # Tests for move_result_wide
+    def test_move_result_wide_with_valid_mnemonic(self, pyeval):
+        instruction = ["move-result-wide", "v1"]
+        return_value = "Return Value"
+        pyeval.ret_stack.append("Return Value")
+
+        pyeval.MOVE_RESULT_WIDE(instruction)
+
+        assert pyeval.table_obj.pop(1).value == return_value
+        assert pyeval.table_obj.pop(2).value == return_value
+
+    # Tests for move_result_object
+    def test_move_result_object_with_valid_mnemonic(self, pyeval):
+        instruction = ["move-result-object", "v1"]
+
+        with patch("quark.Evaluator.pyeval.PyEval._move") as mock:
+            pyeval.MOVE_RESULT_OBJECT(instruction)
+            mock.assert_called_once_with(instruction)
+
+    # Tests for new instance
+    def test_new_instance(self, pyeval):
+        instruction = ["new-instance", "v3", "Lcom/google/progress/SMSHelper;"]
+
+        override_original_instruction = [
+            "new-instance",
+            "v4",
+            "override_value",
         ]
-        v9_expected_call_by_func = [
+
+        pyeval.NEW_INSTANCE(instruction)
+
+        assert pyeval.table_obj.pop(3).register_name == "v3"
+        assert (
+            pyeval.table_obj.pop(
+                3,
+            ).value
+            == "Lcom/google/progress/SMSHelper;"
+        )
+        assert pyeval.table_obj.pop(3).called_by_func == []
+
+        assert pyeval.table_obj.pop(4).register_name == "v4"
+        assert (
+            pyeval.table_obj.pop(
+                4,
+            ).value
+            == "Lcom/google/progress/SMSHelper;"
+        )
+        assert pyeval.table_obj.pop(4).called_by_func == []
+
+        pyeval.NEW_INSTANCE(override_original_instruction)
+
+        assert pyeval.table_obj.pop(4).register_name == "v4"
+        assert pyeval.table_obj.pop(4).value == "override_value"
+        assert pyeval.table_obj.pop(4).called_by_func == []
+
+    # Tests for const_string
+    def test_const_string(self, pyeval):
+        instruction = [
+            "const-string",
+            "v8",
+            "https://github.com/quark-engine/quark-engine",
+        ]
+
+        pyeval.CONST_STRING(instruction)
+
+        assert pyeval.table_obj.pop(8).register_name == "v8"
+        assert (
+            pyeval.table_obj.pop(8).value
+            == "https://github.com/quark-engine/quark-engine"
+        )
+        assert pyeval.table_obj.pop(8).called_by_func == []
+
+    # Tests for const
+    def test_const(self, pyeval):
+        instruction = ["const", "v1", "string value"]
+
+        with patch("quark.Evaluator.pyeval.PyEval._assign_value") as mock:
+            pyeval.CONST(instruction)
+            mock.assert_called_once_with(instruction)
+
+    # Tests for const-four
+    def test_const_four(self, pyeval):
+        instruction = [
+            "const/4",
+            "v8",
+            "https://github.com/quark-engine/quark-engine",
+        ]
+
+        with patch("quark.Evaluator.pyeval.PyEval._assign_value") as mock:
+            pyeval.CONST_FOUR(instruction)
+            mock.assert_called_once_with(instruction)
+
+    # Tests for const-sixteen
+    def test_const_sixteen(self, pyeval):
+        instruction = ["const/16", "v1", "123"]
+
+        with patch("quark.Evaluator.pyeval.PyEval._assign_value") as mock:
+            pyeval.CONST_SIXTEEN(instruction)
+            mock.assert_called_once_with(instruction)
+
+    # Tests for const-high-sixteen
+    def test_const_high_sixteen(self, pyeval):
+        instruction = ["const/high16", "v1", "123"]
+
+        with patch("quark.Evaluator.pyeval.PyEval._assign_value") as mock:
+            pyeval.CONST_HIGHSIXTEEN(instruction)
+            mock.assert_called_once_with(instruction)
+
+    # Tests for aget-object
+    def test_aget_object(self, pyeval):
+        """
+        aget-object vx,vy,vz
+
+        It means vx = vy[vz].
+        """
+        v2_mock_variable_obj = RegisterObject(
+            "v2",
+            "some_list_like[1,2,3,4]",
             "java.io.file.close()",
-            "some_function()(Lcom/google/progress/SMSHelper;,some_string)",
-        ]
-        assert pyeval.table_obj.pop(
-            4,
-        ).called_by_func == v4_expected_call_by_func
-        assert pyeval.table_obj.pop(
-            9,
-        ).called_by_func == v9_expected_call_by_func
+        )
+        v3_mock_variable_obj = RegisterObject("v3", "2", None)
+        pyeval.table_obj.insert(2, v2_mock_variable_obj)
+        pyeval.table_obj.insert(3, v3_mock_variable_obj)
 
-    def test_move_result_object(self, pyeval):
+        instruction = ["aget-object", "v1", "v2", "v3"]
+
+        pyeval.AGET_OBJECT(instruction)
+
+        pyeval.table_obj.pop(1).register_name == "v1"
+        pyeval.table_obj.pop(1).value = "some_list_like[1,2,3,4][2]"
+        assert pyeval.table_obj.pop(1).called_by_func == []
+
+    def test_show_table(self, pyeval):
+        assert len(pyeval.show_table()[4]) == 1
+        assert len(pyeval.show_table()[9]) == 1
+        assert len(pyeval.show_table()[3]) == 0
+
+        assert isinstance(pyeval.show_table()[4][0], RegisterObject)
+        assert isinstance(pyeval.show_table()[9][0], RegisterObject)
+
+    def test_invoke_and_move(self, pyeval):
         v6_mock_variable_obj = RegisterObject("v6", "some_string", None)
 
         pyeval.table_obj.insert(6, v6_mock_variable_obj)
@@ -131,91 +354,3 @@ class TestPyEval:
             == "Lcom/google/progress/ContactsCollecter;->getContactList()Ljava/lang/String;(some_string)"
         )
         assert pyeval.table_obj.pop(1).called_by_func == []
-
-    def test_new_instance(self, pyeval):
-        instruction = ["new-instance", "v3", "Lcom/google/progress/SMSHelper;"]
-
-        override_original_instruction = [
-            "new-instance", "v4", "override_value",
-        ]
-
-        pyeval.NEW_INSTANCE(instruction)
-
-        assert pyeval.table_obj.pop(3).register_name == "v3"
-        assert pyeval.table_obj.pop(
-            3,
-        ).value == "Lcom/google/progress/SMSHelper;"
-        assert pyeval.table_obj.pop(3).called_by_func == []
-
-        assert pyeval.table_obj.pop(4).register_name == "v4"
-        assert pyeval.table_obj.pop(
-            4,
-        ).value == "Lcom/google/progress/SMSHelper;"
-        assert pyeval.table_obj.pop(4).called_by_func == []
-
-        pyeval.NEW_INSTANCE(override_original_instruction)
-
-        assert pyeval.table_obj.pop(4).register_name == "v4"
-        assert pyeval.table_obj.pop(4).value == "override_value"
-        assert pyeval.table_obj.pop(4).called_by_func == []
-
-    def test_const_string(self, pyeval):
-        instruction = [
-            "const-string",
-            "v8",
-            "https://github.com/quark-engine/quark-engine",
-        ]
-
-        pyeval.CONST_STRING(instruction)
-
-        assert pyeval.table_obj.pop(8).register_name == "v8"
-        assert (
-            pyeval.table_obj.pop(8).value
-            == "https://github.com/quark-engine/quark-engine"
-        )
-        assert pyeval.table_obj.pop(8).called_by_func == []
-
-    def test_const_four(self, pyeval):
-        instruction = [
-            "const/4",
-            "v8",
-            "https://github.com/quark-engine/quark-engine",
-        ]
-
-        pyeval.CONST_FOUR(instruction)
-
-        assert pyeval.table_obj.pop(8).register_name == "v8"
-        assert (
-            pyeval.table_obj.pop(8).value
-            == "https://github.com/quark-engine/quark-engine"
-        )
-        assert pyeval.table_obj.pop(8).called_by_func == []
-
-    def test_aget_object(self, pyeval):
-        """
-        aget-object vx,vy,vz
-
-        It means vx = vy[vz].
-        """
-        v2_mock_variable_obj = RegisterObject(
-            "v2", "some_list_like[1,2,3,4]", "java.io.file.close()",
-        )
-        v3_mock_variable_obj = RegisterObject("v3", "2", None)
-        pyeval.table_obj.insert(2, v2_mock_variable_obj)
-        pyeval.table_obj.insert(3, v3_mock_variable_obj)
-
-        instruction = ["aget-object", "v1", "v2", "v3"]
-
-        pyeval.AGET_OBJECT(instruction)
-
-        pyeval.table_obj.pop(1).register_name == "v1"
-        pyeval.table_obj.pop(1).value = "some_list_like[1,2,3,4][2]"
-        assert pyeval.table_obj.pop(1).called_by_func == []
-
-    def test_show_table(self, pyeval):
-        assert len(pyeval.show_table()[4]) == 1
-        assert len(pyeval.show_table()[9]) == 1
-        assert len(pyeval.show_table()[3]) == 0
-
-        assert isinstance(pyeval.show_table()[4][0], RegisterObject)
-        assert isinstance(pyeval.show_table()[9][0], RegisterObject)

--- a/tests/Evaluator/test_pyeval.py
+++ b/tests/Evaluator/test_pyeval.py
@@ -96,7 +96,7 @@ class TestPyEval:
             "some_function()Lclass;(Lcom/google/progress/SMSHelper;,some_string)"
         ]
 
-    @pytest.mark.skip(reasopytn="discussion needed.")
+    @pytest.mark.skip(reason="discussion needed.")
     def test_invoke_with_func_not_returning_value(self, pyeval):
         instruction = ["invoke-kind", "v4", "v9", "some_function()V"]
 
@@ -340,7 +340,7 @@ class TestPyEval:
         first_instruction = [
             "invoke-virtual",
             "v6",
-            "Lcom/google/progress/ContactsCollecter;->getContactList()Ljava/lang/String;",
+            "Lcom/google/progress/ContactsCollector;->getContactList()Ljava/lang/String;",
         ]
 
         second_instruction = ["move-result-object", "v1"]
@@ -351,6 +351,6 @@ class TestPyEval:
         assert pyeval.table_obj.pop(1).register_name == "v1"
         assert (
             pyeval.table_obj.pop(1).value
-            == "Lcom/google/progress/ContactsCollecter;->getContactList()Ljava/lang/String;(some_string)"
+            == "Lcom/google/progress/ContactsCollector;->getContactList()Ljava/lang/String;(some_string)"
         )
         assert pyeval.table_obj.pop(1).called_by_func == []

--- a/tests/Object/test_apkinfo.py
+++ b/tests/Object/test_apkinfo.py
@@ -1,7 +1,5 @@
 import os
-import os.path
 import zipfile
-from posixpath import basename
 
 import pytest
 import requests
@@ -60,8 +58,8 @@ class TestApkinfo:
         with pytest.raises(TypeError):
             _ = Apkinfo(filepath)
 
-    def test_init_with_unexist_file(self):
-        filepath = "UNEXIST_FILE"
+    def test_init_with_non_exist_file(self):
+        filepath = "PATH_TO_NON_EXIST_FILE"
 
         with pytest.raises(FileNotFoundError):
             _ = Apkinfo(filepath)

--- a/tests/Object/test_apkinfo.py
+++ b/tests/Object/test_apkinfo.py
@@ -1,7 +1,11 @@
+import os
+import os.path
+import zipfile
+from posixpath import basename
+
 import pytest
 import requests
 from androguard.core.analysis.analysis import MethodAnalysis
-
 from quark.Objects.apkinfo import Apkinfo
 
 APK_SOURCE = (
@@ -11,17 +15,67 @@ APK_SOURCE = (
 APK_FILENAME = "13667fe3b0ad496a0cd157f34b7e0c991d72a4db.apk"
 
 
-@pytest.fixture()
-def apkinfo(scope="function"):
+@pytest.fixture(scope="function")
+def apk_path():
     r = requests.get(APK_SOURCE, allow_redirects=True)
-    open(APK_FILENAME, "wb").write(r.content)
+    file = open(APK_FILENAME, "wb")
+    file.write(r.content)
 
-    apk_file = APK_FILENAME
-    apkinfo = Apkinfo(apk_file)
+    return APK_FILENAME
+
+
+@pytest.fixture(scope="function")
+def apkinfo(apk_path):
+    apkinfo = Apkinfo(apk_path)
+
     yield apkinfo
 
 
+@pytest.fixture(scope="function")
+def dex_file():
+    APK_SOURCE = (
+        "https://github.com/quark-engine/apk-malware-samples/raw/master/Ahmyth.apk"
+    )
+    APK_NAME = "Ahmyth.apk"
+    DEX_NAME = "classes.dex"
+
+    r = requests.get(APK_SOURCE, allow_redirects=True)
+    file = open(APK_NAME, "wb")
+    file.write(r.content)
+    file.close()
+
+    with zipfile.ZipFile(APK_NAME, "r") as zip:
+        zip.extract(DEX_NAME)
+
+    yield DEX_NAME
+
+    os.remove(DEX_NAME)
+    os.remove(APK_NAME)
+
+
 class TestApkinfo:
+    def test_init_with_invalid_type(self):
+        filepath = None
+
+        with pytest.raises(TypeError):
+            _ = Apkinfo(filepath)
+
+    def test_init_with_unexist_file(self):
+        filepath = "UNEXIST_FILE"
+
+        with pytest.raises(FileNotFoundError):
+            _ = Apkinfo(filepath)
+
+    def test_init_with_apk(self, apk_path):
+        apkinfo = Apkinfo(apk_path)
+
+        assert apkinfo.ret_type == "APK"
+
+    def test_init_with_dex(self, dex_file):
+        apkinfo = Apkinfo(dex_file)
+
+        assert apkinfo.ret_type == "DEX"
+
     def test_filename(self, apkinfo):
         assert apkinfo.filename == "13667fe3b0ad496a0cd157f34b7e0c991d72a4db.apk"
 

--- a/tests/Object/test_registerobject.py
+++ b/tests/Object/test_registerobject.py
@@ -1,48 +1,53 @@
 import pytest
-
 from quark.Objects.registerobject import RegisterObject
 
 
 @pytest.fixture()
-def variable_obj():
-    variable_obj = RegisterObject("v3", "append()", None)
+def standard_register_obj():
+    register_obj = RegisterObject("v1", "value", "func")
+    yield register_obj
 
-    yield variable_obj
-
-    del variable_obj
+    del register_obj
 
 
-class TestVariableObject:
+class TestRegisterObject:
+    def test_init_without_called_by_func(self):
+        register_obj = RegisterObject("v1", "value")
 
-    def test_init(self, variable_obj):
-        with pytest.raises(TypeError):
-            variable_obj_with_no_argu = RegisterObject()
+        assert register_obj._register_name == "v1"
+        assert register_obj._value == "value"
+        assert register_obj._called_by_func == []
 
-        assert isinstance(variable_obj, RegisterObject)
-        assert variable_obj.register_name == "v3"
-        assert variable_obj.value == "append()"
-        assert variable_obj.called_by_func == []
+    def test_init_with_called_by_func(self):
+        register_obj = RegisterObject("v1", "value", "func")
 
-    def test_called_by_func(self, variable_obj):
-        variable_obj_with_called_by_func = RegisterObject(
-            "v3", "append()", "toString()",
-        )
+        assert register_obj._register_name == "v1"
+        assert register_obj._value == "value"
+        assert register_obj._called_by_func == ["func"]
 
-        assert variable_obj_with_called_by_func.called_by_func == [
-            "toString()",
-        ]
+    def test_called_by_func(self, standard_register_obj):
+        value = "func1"
 
-        variable_obj.called_by_func = "file_list"
-        variable_obj.called_by_func = "file_delete"
+        standard_register_obj.called_by_func = value
 
-        assert variable_obj.called_by_func == ["file_list", "file_delete"]
+        assert len(standard_register_obj.called_by_func) == 2
+        assert list(standard_register_obj.called_by_func)[-1] == value
 
-    def test_get_all(self, variable_obj):
-        variable_obj.called_by_func = "file_list"
-        variable_obj.called_by_func = "file_delete"
-        assert repr(
-            variable_obj,
-        ) == "<VarabileObject-register:v3, value:append(), called_by_func:file_list,file_delete>"
+    def test_register_name(self):
+        value = "v1"
 
-    def test_hash_index(self, variable_obj):
-        assert variable_obj.hash_index == 3
+        standard_register_obj.register_name = value
+
+        assert standard_register_obj.register_name == value
+
+    def test_value(self):
+        value = "value"
+
+        standard_register_obj.value = value
+
+        assert standard_register_obj.value == value
+
+    def test_hash_index(self, standard_register_obj):
+        standard_register_obj._register_name = "v5"
+
+        assert standard_register_obj.hash_index == 5

--- a/tests/Object/test_registerobject.py
+++ b/tests/Object/test_registerobject.py
@@ -31,7 +31,7 @@ class TestRegisterObject:
         standard_register_obj.called_by_func = value
 
         assert len(standard_register_obj.called_by_func) == 2
-        assert list(standard_register_obj.called_by_func)[-1] == value
+        assert standard_register_obj.called_by_func[-1] == value
 
     def test_register_name(self):
         value = "v1"

--- a/tests/Object/test_tableobject.py
+++ b/tests/Object/test_tableobject.py
@@ -13,33 +13,59 @@ def table_obj():
 
 
 class TestTableObject:
-
-    def test_init(self, table_obj):
+    def test_init_with_no_arg(self):
         with pytest.raises(TypeError):
-            table_obj_with_no_argu = TableObject()
+            _ = TableObject()
+
+    def test_init_with_non_numeric(self):
+        with pytest.raises(TypeError):
+            _ = TableObject(None)
+
+    def test_init_with_valid_arg(self):
+        table_obj = TableObject(5)
 
         assert isinstance(table_obj, TableObject)
-        assert table_obj.hash_table == [[], [], [], [], []]
         assert len(table_obj.hash_table) == 5
+        assert table_obj.hash_table == [[], [], [], [], []]
 
-    def test_insert(self, table_obj):
-        table_obj.insert(2, "test_insert_value")
+    def test_insert_with_non_numeric(self, table_obj):
+        with pytest.raises(TypeError):
+            table_obj.insert(None)
+
+    def test_insert_with_number_once(self, table_obj):
+        index, data = 1, "Value"
+
+        table_obj.insert(index, data)
+
+        assert table_obj.hash_table[index] == [data]
+
+    def test_insert_with_number_twice(self, table_obj):
         table_obj.insert(0, "first")
         table_obj.insert(0, "second")
 
-        assert table_obj.hash_table[2] == ["test_insert_value"]
         assert table_obj.hash_table[0] == ["first", "second"]
 
-    def test_get_obj_list(self, table_obj):
+    def test_insert_with_num_beyond_max(self, table_obj):
+        index, data = 6, "Max value"
+
+        table_obj.insert(6, data)
+
+    def test_get_obj_list_before_insertion(self, table_obj):
+        assert table_obj.get_obj_list(3) == []
+
+    def test_get_obj_list_after_insertion(self, table_obj):
         table_obj.insert(3, "test_value")
 
         assert table_obj.get_obj_list(3) == ["test_value"]
-        assert table_obj.hash_table[3] == ["test_value"]
 
     def test_get_table(self, table_obj):
         assert table_obj.hash_table == table_obj.get_table()
 
-    def test_pop(self, table_obj):
+    def test_pop_none(self, table_obj):
+        with pytest.raises(IndexError):
+            _ = table_obj.pop(1)
+
+    def test_pop_value(self, table_obj):
         table_obj.insert(4, "one")
         table_obj.insert(4, "two")
         table_obj.insert(4, "three")

--- a/tests/Object/test_tableobject.py
+++ b/tests/Object/test_tableobject.py
@@ -48,7 +48,10 @@ class TestTableObject:
     def test_insert_with_num_beyond_max(self, table_obj):
         index, data = 6, "Max value"
 
-        table_obj.insert(6, data)
+        try:
+            table_obj.insert(index, data)
+        except Exception:
+            pytest.fail('Should not raise exceptions.')
 
     def test_get_obj_list_before_insertion(self, table_obj):
         assert table_obj.get_obj_list(3) == []


### PR DESCRIPTION
#### Description
Please refer to [here](https://github.com/quark-engine/gsoc2021-ShengFengLu/issues/1). I want to write tests to increase the test coverage for Quark. This is the first PR.

In this PR, I focus on these files.

1. quark.py
2. apkinfo.py
2. pyeval.py
3. registerobject.py
4. tableobject.py

#### Why are these files first?

1. A [risk assessment](https://github.com/quark-engine/quark-engine/discussions/173#discussioncomment-831656) shows that those files have the highest priorities to write tests.
2. Those files compose the Dalvik bytecode loader and the well-known five-stage analysis in Quark.
3. The upcoming replacement of Androguard mainly makes changes to those files.

#### Code Changes
+ **For the existing tests**: Divide them by their test scenarios.
+ **For the new tests**: Add them according to two strategies and the coding guideline discussed in the above issue.

| Files                    | # Tests added for normal inputs | # Tests added for error inputs| # Tests modified |
| ------------------------ | :-----------------------------: | :--------------------------------: | :--------------: |
| `test_pyeval.py`         |                9                |                 5                 |        5         |
| `test_quark.py`          |                3                |                 8                  |        5         |
| `test_tableobject.py`    |                3                |                 3                  |        4         |
| `test_apkinfo.py` |                1                |                2                  |        1         |
| `test_registerobject.py` |                3                |                 3                  |        -         |
| `test_registerobject.py` |                3                |                 3                  |        -         |

#### Related Discussion
1. Issue [https://github.com/quark-engine/gsoc2021-ShengFengLu/issues/1](https://github.com/quark-engine/gsoc2021-ShengFengLu/issues/1)
2. Discussion [https://github.com/quark-engine/quark-engine/discussions/173](https://github.com/quark-engine/quark-engine/discussions/173)
