### PR TITLE
Refactor/enrich the rest of Quark's tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 
 python: 3.8
 
+before-install:
+  - sudo apt-get -y install graphviz
+
 # Installation
 install:
   - pipenv install -e . --skip-lock

--- a/tests/Object/test_analysis.py
+++ b/tests/Object/test_analysis.py
@@ -1,0 +1,64 @@
+from collections import defaultdict
+
+from quark.Objects.analysis import QuarkAnalysis
+
+
+class TestQuarkAnalysis:
+    def test_init(self):
+        analysis = QuarkAnalysis()
+        summary_table_field_list = [
+            "Filename",
+            "Rule",
+            "Confidence",
+            "Score",
+            "Weight",
+        ]
+        label_table_field_list = [
+            "Label",
+            "Description",
+            "Number of rules",
+            "MAX Confidence %",
+        ]
+
+        assert analysis.crime_description == ""
+        assert analysis.first_api is None
+        assert analysis.second_api is None
+        assert analysis.level_1_result == []
+        assert analysis.level_2_result == []
+        assert analysis.level_3_result == []
+        assert analysis.level_4_result == []
+        assert analysis.level_5_result == []
+
+        assert analysis.json_report == []
+        assert analysis.weight_sum == 0
+        assert analysis.score_sum == 0
+        assert all(
+            label
+            for label in summary_table_field_list
+            if label in analysis.summary_report_table
+        )
+        assert all(
+            label
+            for label in label_table_field_list
+            if label in analysis.label_report_table
+        )
+
+        assert analysis.call_graph_analysis_list == []
+        assert isinstance(analysis.parent_wrapper_mapping, defaultdict)
+        assert len(analysis.parent_wrapper_mapping.items()) == 0
+
+    def test_clean_result(self):
+        analysis = QuarkAnalysis()
+        analysis.level_1_result = ["123"]
+        analysis.level_2_result = ["123"]
+        analysis.level_3_result = ["123"]
+        analysis.level_4_result = ["123"]
+        analysis.level_5_result = ["123"]
+
+        analysis.clean_result()
+
+        assert analysis.level_1_result == []
+        assert analysis.level_2_result == []
+        assert analysis.level_3_result == []
+        assert analysis.level_4_result == []
+        assert analysis.level_5_result == []

--- a/tests/Object/test_quarkrule.py
+++ b/tests/Object/test_quarkrule.py
@@ -1,0 +1,73 @@
+import os
+
+import pytest
+from quark.Objects.quarkrule import QuarkRule
+
+
+@pytest.fixture(scope="function")
+def invalid_file(tmp_path):
+    invalid_file = tmp_path / "invalid_file.txt"
+    invalid_file.write_text("Not a json")
+
+    yield invalid_file
+
+
+@pytest.fixture(scope="function")
+def incomplete_rule(tmp_path):
+    incomplete_rule = tmp_path / "incomplete_rule.txt"
+    incomplete_rule.write_text("{}")
+
+    yield incomplete_rule
+
+
+@pytest.fixture(scope="function")
+def complete_rule():
+    return "quark/rules/sendLocation_SMS.json"
+
+
+class TestQuarkRule:
+    def test_init_with_invalid_path(self):
+        with pytest.raises(TypeError):
+            _ = QuarkRule(["Not", "a", "file"])
+
+    def test_init_with_non_exist_file(self):
+        with pytest.raises(FileNotFoundError):
+            _ = QuarkRule("NON_EXIST_FILE")
+
+    def test_init_with_invalid_file(self, invalid_file):
+        with pytest.raises(BaseException):
+            _ = QuarkRule(invalid_file)
+
+    def test_init_with_incomplete_rule(self, incomplete_rule):
+        with pytest.raises(KeyError):
+            _ = QuarkRule(incomplete_rule)
+
+    def test_init_with_complete_rule(self, complete_rule):
+        rule = QuarkRule(complete_rule)
+
+        assert all(rule.check_item) is False
+        assert rule.crime == "Send Location via SMS"
+        assert rule.permission == [
+            "android.permission.SEND_SMS",
+            "android.permission.ACCESS_COARSE_LOCATION",
+            "android.permission.ACCESS_FINE_LOCATION",
+        ]
+        assert rule.api == [
+            {
+                "class": "Landroid/telephony/TelephonyManager",
+                "method": "getCellLocation",
+                "descriptor": "()Landroid/telephony/CellLocation;",
+            },
+            {
+                "class": "Landroid/telephony/SmsManager",
+                "method": "sendTextMessage",
+                "descriptor": (
+                    "(Ljava/lang/String; Ljava/lang/String;"
+                    " Ljava/lang/String; Landroid/app/PendingIntent;"
+                    " Landroid/app/PendingIntent;)V"
+                ),
+            },
+        ]
+        assert rule.score == 4
+        assert rule.rule_filename == "sendLocation_SMS.json"
+        assert rule.label == ["location", "collection"]

--- a/tests/test_freshquark.py
+++ b/tests/test_freshquark.py
@@ -1,0 +1,37 @@
+from mock import patch
+from quark.freshquark import download
+
+
+def test_download_without_exist_rules(tmp_path):
+    non_exist_rule_directory = tmp_path / "quark-rules"
+
+    with patch("quark.config.DIR_PATH", non_exist_rule_directory) as _:
+
+        with patch("subprocess.run") as mock:
+            download()
+
+            mock.assert_called_once()
+            assert set(mock.call_args[0][0]) == {
+                "git",
+                "clone",
+                "https://github.com/quark-engine/quark-rules",
+                non_exist_rule_directory,
+            }
+
+
+def test_download_with_exist_rules(tmp_path):
+    exist_rule_directory = tmp_path / "quark-rules"
+    exist_rule_directory.mkdir()
+
+    with patch("quark.config.DIR_PATH", exist_rule_directory) as _:
+
+        with patch("subprocess.run") as mock:
+            download()
+
+            mock.assert_called_once()
+            assert mock.call_args[0][0] == [
+                "git",
+                "-C",
+                exist_rule_directory,
+                "pull",
+            ]

--- a/tests/test_freshquark.py
+++ b/tests/test_freshquark.py
@@ -1,4 +1,5 @@
-from mock import patch
+from unittest.mock import patch
+
 from quark.freshquark import download
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,160 @@
+import os
+import os.path
+import zipfile
+from unittest.mock import patch
+
+import pytest
+import requests
+from quark.report import Report
+
+
+@pytest.fixture(scope="function")
+def invalid_file(tempfile):
+    tempfile.write("Text in file.")
+
+    yield tempfile
+
+
+@pytest.fixture(scope="module")
+def sample_apk_file():
+    APK_SOURCE = (
+        "https://github.com/quark-engine/"
+        "apk-malware-samples/raw/master/Ahmyth.apk"
+    )
+    APK_NAME = "Ahmyth.apk"
+
+    # Download apk
+    request = requests.get(APK_SOURCE)
+    with open(APK_NAME, "wb") as apk_file:
+        apk_file.write(request.content)
+
+    yield APK_NAME
+
+    os.remove(APK_NAME)
+
+
+@pytest.fixture(scope="module")
+def sample_dex_file(sample_apk_file):
+    DEX_NAME = "classes.dex"
+
+    with zipfile.ZipFile(sample_apk_file, "r") as zip:
+        zip.extract(DEX_NAME)
+
+    yield DEX_NAME
+
+    os.remove(DEX_NAME)
+
+
+@pytest.fixture(scope="module")
+def sample_rule_file():
+    return "quark/rules/sendLocation_SMS.json"
+
+
+@pytest.fixture(scope="module")
+def sample_rule_directory():
+    return "quark/rules"
+
+
+@pytest.fixture(scope="function")
+def sample_report():
+    report = Report()
+
+    yield report
+
+    del report
+
+
+class TestReport:
+    def test_analysis_with_both_invalid_types(self, sample_report):
+        with pytest.raises(TypeError):
+            sample_report.analysis(None, None)
+
+    @pytest.mark.xfail(reason="Requirement for the future.")
+    def test_analysis_with_non_exist_apk(
+        self, sample_report, sample_rule_file
+    ):
+        with pytest.raises(FileNotFoundError):
+            sample_report.analysis("NON_EXIST_APK", sample_rule_file)
+
+    @pytest.mark.xfail(reason="Requirement for the future.")
+    def test_analysis_with_non_exist_rule(
+        self, sample_report, sample_apk_file
+    ):
+        with pytest.raises(FileNotFoundError):
+            sample_report.analysis(sample_apk_file, "NON_EXIST_RULE")
+
+    @pytest.mark.xfail(reason="Requirement for the future.")
+    def test_analysis_with_both_invalid_files(
+        self, sample_report, invalid_file
+    ):
+        with pytest.raises(BaseException):
+            sample_report.analysis(invalid_file, invalid_file)
+
+    def test_analysis_with_dex_and_single_rule(
+        self, sample_report, sample_dex_file, sample_rule_file
+    ):
+
+        with patch("quark.Objects.quark.Quark.run") as mock_run:
+            with patch(
+                "quark.Objects.quark.Quark.generate_json_report"
+            ) as mock_generate_report:
+                sample_report.analysis(sample_dex_file, sample_rule_file)
+
+                mock_run.assert_called_once()
+                mock_generate_report.assert_called_once()
+
+    def test_analysis_with_apk_and_single_rule(
+        self, sample_report, sample_apk_file, sample_rule_file
+    ):
+
+        with patch("quark.Objects.quark.Quark.run") as mock_run:
+            with patch(
+                "quark.Objects.quark.Quark.generate_json_report"
+            ) as mock_generate_report:
+                sample_report.analysis(sample_apk_file, sample_rule_file)
+
+                mock_run.assert_called_once()
+                mock_generate_report.assert_called_once()
+
+    def test_analysis_with_rule_directory(
+        self, sample_report, sample_apk_file, sample_rule_directory
+    ):
+        rule_list = [
+            name
+            for name in os.listdir(sample_rule_directory)
+            if os.path.splitext(name)[1] == ".json"
+        ]
+        num_of_rules = len(rule_list)
+
+        with patch("quark.Objects.quark.Quark.run") as mock_run:
+            with patch(
+                "quark.Objects.quark.Quark.generate_json_report"
+            ) as mock_generate_report:
+
+                sample_report.analysis(sample_apk_file, sample_rule_directory)
+
+                assert mock_run.call_count == num_of_rules
+                assert mock_generate_report.call_count == num_of_rules
+
+    def test_get_report_with_invalid_type(self, sample_report):
+        with pytest.raises(ValueError):
+            sample_report.get_report(None)
+
+    def test_get_report_with_invalid_value(self, sample_report):
+        with pytest.raises(ValueError):
+            sample_report.get_report("txt")
+
+    def test_get_report_with_json_type(
+        self, sample_report, sample_apk_file, sample_rule_file
+    ):
+        sample_report.analysis(sample_apk_file, sample_rule_file)
+
+        result = sample_report.get_report("json")
+
+        assert isinstance(result, dict)
+        assert result["md5"] == "893e05aabd8754236ea70d3da8363d52"
+        assert result["apk_filename"] == sample_apk_file
+        assert result["size_bytes"] == 268043
+        assert result["threat_level"] == "Low Risk"
+        assert result["total_score"] == 4
+        assert result["crimes"][0] is not None

--- a/tests/utils/test_colors.py
+++ b/tests/utils/test_colors.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+from quark.utils.colors import color
+
+
+def test_color():
+    text = "Text"
+    color_code = 1
+
+    colored_text = color(text, color_code)
+
+    if sys.platform == "win32" and os.getenv("TERM") != "xterm":
+        assert colored_text == text
+    else:
+        assert colored_text == "\x1b[1mText\x1b[0m"

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -1,0 +1,119 @@
+import os.path
+
+import pytest
+import requests
+from androguard.misc import AnalyzeAPK
+from quark.utils.graph import call_graph, wrapper_lookup
+
+
+@pytest.fixture(scope="module")
+def analysis_object(tmp_path_factory):
+    APK_SOURCE = (
+        "https://github.com/quark-engine/"
+        "apk-malware-samples/raw/master/Ahmyth.apk"
+    )
+    APK_NAME = "Ahmyth.apk"
+
+    # Download apk
+    request = requests.get(APK_SOURCE)
+    apk_file = tmp_path_factory.getbasetemp() / APK_NAME
+    apk_file.write_bytes(request.content)
+    _, _, analysis = AnalyzeAPK(apk_file)
+
+    yield analysis
+
+
+@pytest.fixture(scope="function")
+def parent_method(analysis_object):
+    return next(
+        analysis_object.find_methods(
+            "Lahmyth/mine/king/ahmyth/ConnectionManager;",
+            "sendReq",
+            "\\(\\)V",
+        )
+    )
+
+
+@pytest.fixture(scope="function")
+def connect_method_1(analysis_object):
+    return next(
+        analysis_object.find_methods(
+            "Lio/socket/client/Socket;",
+            "connect",
+            "\\(\\)Lio/socket/client/Socket;",
+        )
+    )
+
+
+@pytest.fixture(scope="function")
+def connect_method_2(analysis_object):
+    return next(
+        analysis_object.find_methods(
+            "Lahmyth/mine/king/ahmyth/ConnectionManager\\$1;",
+            "<init>",
+            "\\(\\)V",
+        )
+    )
+
+
+@pytest.fixture(scope="function")
+def leaf_method_1(analysis_object):
+    return next(
+        analysis_object.find_methods(
+            "Lio/socket/client/Socket;",
+            "open",
+            "\\(\\)Lio/socket/client/Socket;",
+        )
+    )
+
+
+@pytest.fixture(scope="function")
+def leaf_method_2(analysis_object):
+    return next(
+        analysis_object.find_methods(
+            "Ljava/lang/Object;",
+            "<init>",
+            "\\(\\)V",
+        )
+    )
+
+
+def test_wrapper_lookup_with_result(
+    parent_method, connect_method_1, leaf_method_1
+):
+    path = []
+
+    wrapper_lookup(path, parent_method, leaf_method_1)
+
+    assert path == [connect_method_1]
+
+
+def test_wrapper_lookup_with_no_result(leaf_method_1, parent_method):
+    path = []
+
+    wrapper_lookup(path, leaf_method_1, parent_method)
+
+    assert path == []
+
+
+@pytest.mark.usefixture("remove_call_graph_directory")
+def test_call_graph(
+    parent_method,
+    connect_method_1,
+    connect_method_2,
+    leaf_method_1,
+    leaf_method_2,
+):
+    call_graph_analysis = {
+        "parent": parent_method,
+        "first_call": connect_method_1,
+        "second_call": connect_method_2,
+        "first_api": leaf_method_1,
+        "second_api": leaf_method_2,
+        "crime": "For test only.",
+    }
+    expected_file_name = f"call_graph_image/{parent_method.name}_{connect_method_1.name}_{connect_method_2.name}"
+
+    call_graph(call_graph_analysis)
+
+    assert os.path.exists(expected_file_name)

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -2,7 +2,7 @@ import os.path
 
 import pytest
 import requests
-from androguard.misc import AnalyzeAPK
+from quark.Objects.apkinfo import Apkinfo
 from quark.utils.graph import call_graph, wrapper_lookup
 
 
@@ -18,63 +18,53 @@ def analysis_object(tmp_path_factory):
     request = requests.get(APK_SOURCE)
     apk_file = tmp_path_factory.getbasetemp() / APK_NAME
     apk_file.write_bytes(request.content)
-    _, _, analysis = AnalyzeAPK(apk_file)
+    analysis = Apkinfo(apk_file)
 
     yield analysis
 
 
 @pytest.fixture(scope="function")
 def parent_method(analysis_object):
-    return next(
-        analysis_object.find_methods(
-            "Lahmyth/mine/king/ahmyth/ConnectionManager;",
-            "sendReq",
-            "\\(\\)V",
-        )
+    return analysis_object.find_method(
+        "Lahmyth/mine/king/ahmyth/ConnectionManager;",
+        "sendReq",
+        "()V",
     )
 
 
 @pytest.fixture(scope="function")
 def connect_method_1(analysis_object):
-    return next(
-        analysis_object.find_methods(
-            "Lio/socket/client/Socket;",
-            "connect",
-            "\\(\\)Lio/socket/client/Socket;",
-        )
+    return analysis_object.find_method(
+        "Lio/socket/client/Socket;",
+        "connect",
+        "()Lio/socket/client/Socket;",
     )
 
 
 @pytest.fixture(scope="function")
 def connect_method_2(analysis_object):
-    return next(
-        analysis_object.find_methods(
-            "Lahmyth/mine/king/ahmyth/ConnectionManager\\$1;",
-            "<init>",
-            "\\(\\)V",
-        )
+    return analysis_object.find_method(
+        "Lahmyth/mine/king/ahmyth/ConnectionManager$1;",
+        "<init>",
+        "()V",
     )
 
 
 @pytest.fixture(scope="function")
 def leaf_method_1(analysis_object):
-    return next(
-        analysis_object.find_methods(
-            "Lio/socket/client/Socket;",
-            "open",
-            "\\(\\)Lio/socket/client/Socket;",
-        )
+    return analysis_object.find_method(
+        "Lio/socket/client/Socket;",
+        "open",
+        "()Lio/socket/client/Socket;",
     )
 
 
 @pytest.fixture(scope="function")
 def leaf_method_2(analysis_object):
-    return next(
-        analysis_object.find_methods(
-            "Ljava/lang/Object;",
-            "<init>",
-            "\\(\\)V",
-        )
+    return analysis_object.find_method(
+        "Ljava/lang/Object;",
+        "<init>",
+        "()V",
     )
 
 
@@ -96,7 +86,6 @@ def test_wrapper_lookup_with_no_result(leaf_method_1, parent_method):
     assert path == []
 
 
-@pytest.mark.usefixture("remove_call_graph_directory")
 def test_call_graph(
     parent_method,
     connect_method_1,

--- a/tests/utils/test_output.py
+++ b/tests/utils/test_output.py
@@ -1,47 +1,90 @@
+import json
+import os
+
 import pytest
 import requests
-
-from quark.utils.output import output_parent_function_table
-from quark.Objects.quark import Quark
-
-APK_SOURCE = (
-    "https://github.com/quark-engine/apk-malware-samples"
-    "/raw/master/14d9f1a92dd984d6040cc41ed06e273e.apk"
+from androguard.misc import AnalyzeAPK
+from quark.utils.output import (
+    output_parent_function_json,
+    output_parent_function_table,
 )
-APK_FILENAME = "14d9f1a92dd984d6040cc41ed06e273e.apk"
 
 
-@pytest.fixture()
-def quark_obj(scope="function"):
-    r = requests.get(APK_SOURCE, allow_redirects=True)
-    open(APK_FILENAME, "wb").write(r.content)
+@pytest.fixture(scope="module")
+def sample_apk():
+    APK_SOURCE = (
+        "https://github.com/quark-engine/"
+        "apk-malware-samples/raw/master/14d9f1a92dd984d6040cc41ed06e273e.apk"
+    )
+    APK_NAME = "14d9f1a92dd984d6040cc41ed06e273e.apk"
 
-    return Quark(APK_FILENAME)
+    request = requests.get(APK_SOURCE, allow_redirects=True)
+    with open(APK_NAME, "wb") as file:
+        file.write(request.content)
+
+    yield APK_NAME
+
+    os.remove(APK_NAME)
 
 
-def test_output_parent_function_table(capsys, quark_obj):
-    method_obj = quark_obj.apkinfo.find_method(
-        "Lcom/google/progress/WifiCheckTask;", "goConnectNetwork", "()V"
+@pytest.fixture(scope="module")
+def method_object(sample_apk):
+    _, _, analysis_object = AnalyzeAPK(sample_apk)
+
+    return next(
+        analysis_object.find_methods(
+            "Lcom/google/progress/Locate;",
+            "getLocation",
+            "\\(\\)Ljava/lang/String;",
+        )
     )
 
-    call_graph_analysis_list = (
-        {"crime": "The Crime", "parent": method_obj},
-        {"crime": "The Crime", "parent": method_obj},
-        {"crime": "Another Crime", "parent": method_obj},
-    )
 
-    # Test one crime
-    output_parent_function_table([call_graph_analysis_list[0]])
+@pytest.fixture(scope="function")
+def one_crime_list(method_object):
+    return [
+        {"crime": "The Crime", "parent": method_object},
+    ]
 
+
+@pytest.fixture(scope="function")
+def duplicate_crime_list(method_object):
+    return [
+        {"crime": "The Crime", "parent": method_object},
+        {"crime": "The Crime", "parent": method_object},
+        {"crime": "Another Crime", "parent": method_object},
+    ]
+
+
+def test_output_parent_function_table_with_one_crime(capsys, one_crime_list):
+    output_parent_function_table(one_crime_list)
+
+    # f"{item['parent'].class_name}{item['parent'].name}"
     output = capsys.readouterr().out
-    assert output.count("Lcom/google/progress/WifiCheckTask;goConnectNetwork") == 1
+    assert output.count("Lcom/google/progress/Locate;getLocation") == 1
     assert output.count("The Crime") == 1
 
-    # Test crimes with duplicated description
-    output_parent_function_table(call_graph_analysis_list)
+
+def test_output_parent_function_table_with_duplicated_description(
+    capsys, duplicate_crime_list
+):
+
+    output_parent_function_table(duplicate_crime_list)
 
     output = capsys.readouterr().out
-    print(output)
-    assert output.count("Lcom/google/progress/WifiCheckTask;goConnectNetwork") == 1
+    assert output.count("Lcom/google/progress/Locate;getLocation") == 1
     assert output.count("The Crime") == 1
     assert output.count("Another Crime") == 1
+
+
+def test_output_parent_function_json_with_one_crime(one_crime_list):
+    output_parent_function_json(one_crime_list)
+
+    with open("rules_classification.json", "r") as classification_report:
+        report = json.load(classification_report)
+
+        assert len(report["rules_classification"]) == 1
+        assert (
+            report["rules_classification"][0]["parent"]
+            == "Lcom/google/progress/Locate;getLocation"
+        )

--- a/tests/utils/test_output.py
+++ b/tests/utils/test_output.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 import requests
-from androguard.misc import AnalyzeAPK
+from quark.Objects.apkinfo import Apkinfo
 from quark.utils.output import (
     output_parent_function_json,
     output_parent_function_table,
@@ -29,14 +29,12 @@ def sample_apk():
 
 @pytest.fixture(scope="module")
 def method_object(sample_apk):
-    _, _, analysis_object = AnalyzeAPK(sample_apk)
+    analysis_object = Apkinfo(sample_apk)
 
-    return next(
-        analysis_object.find_methods(
-            "Lcom/google/progress/Locate;",
-            "getLocation",
-            "\\(\\)Ljava/lang/String;",
-        )
+    return analysis_object.find_method(
+        "Lcom/google/progress/Locate;",
+        "getLocation",
+        "()Ljava/lang/String;",
     )
 
 

--- a/tests/utils/test_pprint.py
+++ b/tests/utils/test_pprint.py
@@ -1,0 +1,105 @@
+import base64
+import sys
+
+import pytest
+from quark.utils.pprint import (
+    print_error,
+    print_info,
+    print_success,
+    print_warning,
+    table,
+)
+
+
+@pytest.fixture(scope="module")
+def bold_style():
+    return "\x1b[1m"
+
+
+@pytest.fixture(scope="module")
+def cyan_color():
+    return "\x1b[36m"
+
+
+@pytest.fixture(scope="module")
+def yellow_color():
+    return "\x1b[33m"
+
+
+@pytest.fixture(scope="module")
+def red_color():
+    return "\x1b[91m"
+
+
+@pytest.fixture(scope="module")
+def green_color():
+    return "\x1b[92m"
+
+
+def test_print_info(capsys, bold_style, cyan_color):
+    message = "message"
+
+    print_info(message)
+
+    output = capsys.readouterr().out
+    if not sys.platform.startswith("win32"):
+        assert bold_style in output
+        assert cyan_color in output
+
+    assert message in output
+
+
+def test_print_warning(capsys, bold_style, yellow_color):
+    message = "message"
+
+    print_warning(message)
+
+    output = capsys.readouterr().out
+    if not sys.platform.startswith("win32"):
+        assert bold_style in output
+        assert yellow_color in output
+
+    assert "WARNING" in output
+    assert message in output
+
+
+def test_print_error(capsys, bold_style, red_color):
+    message = "message"
+
+    print_error(message)
+
+    output = capsys.readouterr().out
+    if not sys.platform.startswith("win32"):
+        assert bold_style in output
+        assert red_color in output
+
+    assert "ERROR" in output
+    assert message in output
+
+
+def test_print_success(capsys, bold_style, green_color):
+    message = "message"
+
+    print_success(message)
+
+    output = capsys.readouterr().out
+    if not sys.platform.startswith("win32"):
+        assert bold_style in output
+        assert green_color in output
+
+    assert "DONE" in output
+    assert message in output
+
+
+def test_table():
+    expected_csv = base64.b64decode(
+        "Q29sdW1uIDEsQ29sdW1uIDIsQ29sdW1uIDMNClJv"
+        "dyAxLDExLDIyDQpSb3cgMiwzMyw0NA0K"
+    ).decode()
+
+    header = ["Column 1", "Column 2", "Column 3"]
+    rows = [["Row 1", "11", "22"], ["Row 2", "33", "44"]]
+
+    table_obj = table(header, rows)
+
+    assert table_obj.get_csv_string() == expected_csv

--- a/tests/utils/test_regex.py
+++ b/tests/utils/test_regex.py
@@ -1,0 +1,148 @@
+import pytest
+from quark.utils.regex import (
+    extract_content,
+    extract_file,
+    extract_ip,
+    extract_url,
+    validate_base64,
+    validate_ip_address,
+    validate_url,
+)
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        "http://doc.quark-engine.com",  # Domain
+        "ftp://127.0.0.1",  # Ip address
+        "https://localhost",  # localhost
+        "http://domain:8888",  # port
+        "http://domain/file",  # path
+        "http://domain?query=val",  # query
+        "http://domain:8888/path/file?query=val",  # compound
+    ],
+)
+def valid_url(request):
+    return request.param
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        "http",
+        "127.0.0.1",
+        "localhost",
+        "127.0.0.1:8888",
+        "path/file",
+        "var=val",
+    ],
+)
+def invalid_url(request):
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def valid_ip():
+    return "127.0.0.1"
+
+
+@pytest.fixture(scope="module", params=["127.0.0", "127.0.0.1.0"])
+def invalid_ip(request):
+    return request.param
+
+
+@pytest.mark.xfail(reason="Requirement for the future")
+def test_validate_url_with_valid_string(valid_url):
+    result = validate_url(valid_url)
+
+    assert result is True
+
+
+def test_validate_url_with_invalid_string(invalid_url):
+    result = validate_url(invalid_url)
+
+    assert result is False
+
+
+def test_validate_ip_address_with_valid_string(valid_ip):
+    result = validate_ip_address(valid_ip)
+
+    assert result is True
+
+
+def test_validate_ip_address_with_invalid_string(invalid_ip):
+    result = validate_ip_address(invalid_ip)
+
+    assert result is False
+
+
+def test_validate_base64_with_valid_string():
+    result = validate_base64("TWVzc2VuZ2U=")
+
+    assert result is True
+
+
+def test_validate_base64_with_invalid_string():
+    result = validate_base64("NOT_A_BASE64")
+
+    assert result is False
+
+
+def test_extract_ip_with_no_result():
+    result = extract_ip("CXS127.0.O.1DIO8.8.8.BDC")
+
+    assert result == []
+
+
+def test_extract_ip_with_result():
+    result = extract_ip("CXS127.0.0.1DIO8.8.8.8DC")
+
+    assert result == ["127.0.0.1", "8.8.8.8"]
+
+
+def test_extract_url_with_no_result():
+    url = "HTTPS://127.0.O.1.0/?DFCHTTPS:/VAL?/?REIOS1"
+
+    result = extract_url(url)
+
+    assert result == []
+
+
+def test_extract_url_with_result():
+    url = "CHAR https://www.google.com/search?q=QUARK CHAR"
+
+    result = extract_url(url)
+
+    assert result == ["https://www.google.com/search?q=QUARK"]
+
+
+def test_extract_content_with_no_result():
+    url = "NOT_A_CONTENT"
+
+    result = extract_content(url)
+
+    assert result is None
+
+
+def test_extract_content_with_result():
+    url = "CHARcontent://SMS/SENTCHAR"
+
+    result = extract_content(url)
+
+    assert result == url
+
+
+def test_extract_file_with_no_result():
+    url = "NOT_A_FILE"
+
+    result = extract_file(url)
+
+    assert result is None
+
+
+def test_extract_content_with_result():
+    url = "CHARfile://usr/bin/shCHAR"
+
+    result = extract_file(url)
+
+    assert result == url

--- a/tests/utils/test_tools.py
+++ b/tests/utils/test_tools.py
@@ -1,14 +1,62 @@
-from quark.utils import tools
+import pytest
+from quark.utils.tools import contains, remove_dup_list
 
 
-def test_remove_dup_list():
-    assert tools.remove_dup_list([]) == []
-    assert tools.remove_dup_list([1, 2, 3, 4, 3, 4, 2]) == [1, 2, 3, 4]
-    assert len(tools.remove_dup_list([1, 2, 3, 4, 3, 4, 2])) == 4
-    assert set(tools.remove_dup_list(["hello", "test", "test"])) == {
-        "hello", "test",
+def test_remove_dup_list_with_invalid_arg():
+    with pytest.raises(TypeError):
+        remove_dup_list(123)
+
+
+def test_remove_dup_list_with_empty_list():
+    assert remove_dup_list([]) == []
+
+
+def test_remove_dup_list_with_numbers():
+    assert remove_dup_list([1, 2, 3, 4, 3, 4, 2]) == [1, 2, 3, 4]
+
+
+def test_remove_dup_list_with_strings():
+    assert set(remove_dup_list(["hello", "test", "test"])) == {
+        "hello",
+        "test",
     }
-    assert len(tools.remove_dup_list(["hello", "test", "test"])) == 2
-    assert tools.remove_dup_list([2.0, 30, 4.0, 2.0]) == [2.0, 4.0, 30]
-    assert len(tools.remove_dup_list([2.0, 30, 4.0, 2.0])) == 3
-    assert tools.remove_dup_list([1, 2, 3]) == [1, 2, 3]
+
+
+def test_remove_dup_list_with_floats():
+    assert remove_dup_list([2.0, 30, 4.0, 2.0]) == [2.0, 4.0, 30]
+
+
+def test_contains_with_mutually_exclusive_list():
+    subset = ["getCellLocation", "sendTextMessage"]
+    target = ["put", "query"]
+
+    result = contains(subset, target)
+
+    assert result is False
+
+
+def test_contains_with_superset():
+    subset = ["put", "getCellLocation", "query", "sendTextMessage"]
+    target = ["put", "query"]
+
+    result = contains(subset, target)
+
+    assert result is False
+
+
+def test_contains_with_incorrect_sequence():
+    subset = ["getCellLocation", "sendTextMessage"]
+    target = ["sendTextMessage", "put", "getCellLocation", "query"]
+
+    result = contains(subset, target)
+
+    assert result is False
+
+
+def test_contains_with_correct_sequence():
+    subset = ["getCellLocation", "sendTextMessage"]
+    target = ["put", "getCellLocation", "query", "sendTextMessage"]
+
+    result = contains(subset, target)
+
+    assert result is True

--- a/tests/utils/test_weight.py
+++ b/tests/utils/test_weight.py
@@ -1,40 +1,38 @@
 import pytest
-
-from quark.utils.weight import Weight, LEVEL_INFO
+from quark.utils.weight import LEVEL_INFO, Weight
 
 
 @pytest.fixture(params=[(20, 10), (30, 21), (50, 25)])
-def data(request):
+def expected_data(request):
     # (score_sum, weight_sum)
     return request.param
 
 
 @pytest.fixture(params=[(0, 0), (100, 0), (20, 100), (-50, 20)])
-def expected_failed_data(request):
+def unexpected_data(request):
     # (score_sum, weight_sum)
     return request.param
 
 
 class TestWeight:
-    def test_init(self, data):
-        score_sum, weight_sum = data
+    def test_init(self, expected_data):
+        score_sum, weight_sum = expected_data
 
         weight_obj = Weight(score_sum, weight_sum)
 
         with pytest.raises(TypeError):
-            weight_obj_no_argu = Weight()
+            _ = Weight()
 
         assert weight_obj.score_sum == score_sum
         assert weight_obj.weight_sum == weight_sum
-        assert isinstance(weight_obj, Weight)
 
     def test_level_info(self):
         assert LEVEL_INFO.LOW.value == "Low Risk"
         assert LEVEL_INFO.Moderate.value == "Moderate Risk"
         assert LEVEL_INFO.High.value == "High Risk"
 
-    def test_calculate(self, data):
-        score_sum, weight_sum = data
+    def test_calculate_with_expected_data(self, expected_data):
+        score_sum, weight_sum = expected_data
         weight_obj = Weight(score_sum, weight_sum)
 
         assert weight_obj.calculate() in [
@@ -44,8 +42,8 @@ class TestWeight:
         ]
 
     @pytest.mark.xfail(raises=ValueError)
-    def test_calculate_with_value_error(self, expected_failed_data):
-        score_sum, weight_sum = expected_failed_data
+    def test_calculate_with_unexpected_data(self, unexpected_data):
+        score_sum, weight_sum = unexpected_data
 
         weight_obj = Weight(score_sum, weight_sum)
 


### PR DESCRIPTION
#### Description

Please refer [here](https://github.com/quark-engine/gsoc2021-ShengFengLu/issues/1). For the replacement of Androguard, I want to write tests to improve the test coverage of Quark. This is the **final** PR. (You can find the previous PR [here](https://github.com/quark-engine/quark-engine/pull/182) )

In this PR, I focus on these files.

+ `quark/Objects/analysis.py`
+ `quark/Objects/quarkrule.py`
+ `quark/report.py`
+ `quark/freshquark.py`
+ all seven files in `quark/utils` (colors.py, graph.py, pprint.py, output.py, etc.)
#### Code Changes
+ **For the existing tests**: Divide them by their test scenarios.
+ **For the new tests**: Add them according to two strategies and the coding guideline discussed in the above issue.

| Files               | # Tests added for normal inputs | # Tests added for error inputs | # Tests modified |
| ------------------- | :-----------------------------: | :----------------------------: | :--------------: |
| `test_analysis.py`  |                1                |               0                |        0         |
| `test_quarkrule.py` |                1                |               4                |        -         |
| `test_report.py`    |                4                |               6                |        -         |
| `test_freshquark.py`   |                2                |               0                |        -         |
| `test_colors.py`    |                1                |               0                |        -         |
| `test_graph.py`     |                3                |               0                |        -         |
| `test_output.py`    |                3                |               0                |        -         |
| `test_pprint.py`    |                5                |               0                |        -         |
| `test_regex.py`     |               11                |               3                |        -         |
| `test_tools.py`     |                5                |               1                |        1         |
| `test_weight.py`    |                0                |               0                |        3         |
| **Total**           |             **36**              |             **14**             |      **4**       |

#### Related Discussions

1. issue [https://github.com/quark-engine/gsoc2021-ShengFengLu/issues/1](https://github.com/quark-engine/gsoc2021-ShengFengLu/issues/1)
2. Discussion [https://github.com/quark-engine/quark-engine/discussions/173](https://github.com/quark-engine/quark-engine/discussions/173)
