### PR TITLE
Show Parent Functions' Cross-References In Rule Classification

### DIFF
--- a/quark/Objects/quark.py
+++ b/quark/Objects/quark.py
@@ -575,8 +575,12 @@ class Quark:
 
     def show_rule_classification(self):
         print_info("Rules Classification")
-        output_parent_function_table(self.quark_analysis.call_graph_analysis_list)
-        output_parent_function_json(self.quark_analysis.call_graph_analysis_list)
+        output_parent_function_table(
+            self.quark_analysis.call_graph_analysis_list, MAX_SEARCH_LAYER
+        )
+        output_parent_function_json(
+            self.quark_analysis.call_graph_analysis_list, MAX_SEARCH_LAYER
+        )
 
 
 if __name__ == "__main__":

--- a/quark/Objects/quark.py
+++ b/quark/Objects/quark.py
@@ -22,7 +22,12 @@ from quark.utils.colors import (
     colorful_report,
 )
 from quark.utils.graph import call_graph
-from quark.utils.output import output_parent_function_table, output_parent_function_json
+from quark.utils.output import (
+    get_rule_classification_data,
+    output_parent_function_graph,
+    output_parent_function_table,
+    output_parent_function_json,
+)
 from quark.utils.pprint import print_info, print_success
 from quark.utils.weight import Weight
 
@@ -575,12 +580,14 @@ class Quark:
 
     def show_rule_classification(self):
         print_info("Rules Classification")
-        output_parent_function_table(
+
+        data_bundle = get_rule_classification_data(
             self.quark_analysis.call_graph_analysis_list, MAX_SEARCH_LAYER
         )
-        output_parent_function_json(
-            self.quark_analysis.call_graph_analysis_list, MAX_SEARCH_LAYER
-        )
+
+        output_parent_function_table(data_bundle)
+        output_parent_function_json(data_bundle)
+        output_parent_function_graph(data_bundle)
 
 
 if __name__ == "__main__":

--- a/quark/utils/output.py
+++ b/quark/utils/output.py
@@ -4,18 +4,54 @@
 
 import json
 from collections import defaultdict
+from graphviz.dot import Digraph
 
 from prettytable import PrettyTable
 from quark.utils.colors import green, red
 
+_GRAPH_SETTINGS = {
+    "filename": "rules_classification",
+    "comment": "A reference tree for parent functions",
+    "format": "png",
+    "graph_attr": {
+        "center": "true",
+        "label": "Reference Tree of Rule Classification",
+        "labelloc": "top",
+        "rankdir": "LR",
+        "fontsize": "24",
+        "fontname": "Courier New Bold",
+        "fillcolor": "white",
+        "shape": "box",
+        "style": "rounded",
+    },
+    "node_attr": {
+        "fontsize": "16",
+        "fontname": "Courier New",
+        "fontcolor": "red",
+        "shape": "none",
+    },
+    "edge_attr": {"label": "calls"},
+}
 
-def _collect_analysis_data(call_graph_analysis_list, search_depth=3):
+
+def get_rule_classification_data(call_graph_analysis_list, search_depth):
+    return _collect_crime_description(
+        call_graph_analysis_list
+    ), _search_cross_references(call_graph_analysis_list, search_depth)
+
+
+def _collect_crime_description(call_graph_analysis_list):
     report_dict = defaultdict(set)
 
     for item in call_graph_analysis_list:
-        key = _get_function_display_name(item["parent"])
-        description = item["crime"]
-        report_dict[key].add(description)
+        report_dict[item["parent"]].add(item["crime"])
+
+    return report_dict
+
+
+# @functools.lru_cache
+def _search_cross_references(call_graph_analysis_list, search_depth):
+    reference_dict = defaultdict(set)
 
     parent_set = {item["parent"] for item in call_graph_analysis_list}
 
@@ -34,23 +70,37 @@ def _collect_analysis_data(call_graph_analysis_list, search_depth=3):
         referenced_set = called_function_set.intersection(parent_set)
         referenced_set.discard(parent)
 
-        for function in referenced_set:
-            key = _get_function_display_name(parent)
-            description = f"Call {_get_function_display_name(function)}"
-            report_dict[key].add(description)
+        reference_dict[parent] = referenced_set
 
-    for parent in report_dict:
-        report_dict[parent] = list(report_dict[parent])
+    return reference_dict
 
-    return report_dict
+
+def _convert_to_printable_dict(report_dict, reference_dict):
+    printable_dict = defaultdict(list)
+
+    for parent, reference_set in reference_dict.items():
+        key = _get_function_display_name(parent)
+
+        printable_dict[key].extend(
+            [
+                f"Call {_get_function_display_name(reference)}"
+                for reference in reference_set
+            ]
+        )
+
+    for parent, values in report_dict.items():
+        key = _get_function_display_name(parent)
+        printable_dict[key].extend(list(values))
+
+    return printable_dict
 
 
 def _get_function_display_name(function):
     return f"{function.class_name}{function.name}"
 
 
-def output_parent_function_table(call_graph_analysis_list, search_depth):
-    dd = _collect_analysis_data(call_graph_analysis_list, search_depth)
+def output_parent_function_table(rule_classification_data_bundle):
+    dd = _convert_to_printable_dict(*rule_classification_data_bundle)
 
     # Pretty Table Output
 
@@ -70,8 +120,8 @@ def output_parent_function_table(call_graph_analysis_list, search_depth):
         print(tb)
 
 
-def output_parent_function_json(call_graph_analysis_list, search_depth):
-    dd = _collect_analysis_data(call_graph_analysis_list, search_depth)
+def output_parent_function_json(rule_classification_data_bundle):
+    dd = _convert_to_printable_dict(*rule_classification_data_bundle)
 
     # Json Output
 
@@ -87,3 +137,38 @@ def output_parent_function_json(call_graph_analysis_list, search_depth):
 
     with open("rules_classification.json", "w") as outfile:
         json.dump(data, outfile)
+
+
+def output_parent_function_graph(rule_classification_data_bundle):
+    report_dict, reference_dict = rule_classification_data_bundle
+
+    identifier_dict = {
+        parent: f"p{index}" for index, parent in enumerate(report_dict.keys())
+    }
+
+    dot = Digraph(**_GRAPH_SETTINGS)
+
+    for parent, identifier in identifier_dict.items():
+        descriptions = "\l".join(report_dict[parent]) + "\l"
+
+        with dot.subgraph(
+            name=f"cluster_{identifier}",
+            graph_attr={
+                "label": _get_function_display_name(parent),
+                "fontsize": "16",
+            },
+        ) as sub:
+            sub.node(identifier, label=descriptions)
+
+    edge_list = []
+    for parent, identifier in identifier_dict.items():
+        edge_list.extend(
+            [
+                (identifier, identifier_dict[function])
+                for function in reference_dict[parent]
+            ]
+        )
+
+    dot.edges(edge_list)
+
+    dot.render()

--- a/tests/utils/test_output.py
+++ b/tests/utils/test_output.py
@@ -4,6 +4,7 @@ import os
 import pytest
 import requests
 from quark.Objects.apkinfo import Apkinfo
+from quark.Objects.quark import MAX_SEARCH_LAYER
 from quark.utils.output import (
     output_parent_function_json,
     output_parent_function_table,
@@ -28,34 +29,83 @@ def sample_apk():
 
 
 @pytest.fixture(scope="module")
-def method_object(sample_apk):
-    analysis_object = Apkinfo(sample_apk)
+def analysis_object(sample_apk):
+    return Apkinfo(sample_apk)
 
-    return analysis_object.find_method(
+
+@pytest.fixture(scope="module")
+def analysis_element_1(analysis_object):
+    parent = analysis_object.find_method(
         "Lcom/google/progress/Locate;",
         "getLocation",
         "()Ljava/lang/String;",
     )
+    first_api = analysis_object.find_method(
+        "Lorg/apache/http/HttpResponse;",
+        "getEntity",
+        "()Lorg/apache/http/HttpEntity;",
+    )
+    second_api = analysis_object.find_method(
+        "Lorg/json/JSONObject;",
+        "put",
+        "(Ljava/lang/String; I)Lorg/json/JSONObject;",
+    )
+
+    return {
+        "crime": "The Crime",
+        "parent": parent,
+        "first_call": first_api,
+        "first_api": first_api,
+        "second_call": second_api,
+        "second_api": second_api,
+    }
+
+
+@pytest.fixture(scope="module")
+def analysis_element_2(analysis_object):
+    parent = analysis_object.find_method(
+        "Lcom/google/progress/AndroidClientService;",
+        "sendMessage",
+        "()V",
+    )
+    first_api = analysis_object.find_method(
+        "Lcom/google/progress/FileList;",
+        "getInfo",
+        "()Ljava/lang/String;",
+    )
+    second_api = analysis_object.find_method(
+        "Lcom/google/progress/SMSHelper;",
+        "sendSms",
+        "(Ljava/lang/String; Ljava/lang/String;)I",
+    )
+
+    return {
+        "crime": "Another Crime",
+        "parent": parent,
+        "first_call": first_api,
+        "first_api": first_api,
+        "second_call": second_api,
+        "second_api": second_api,
+    }
 
 
 @pytest.fixture(scope="function")
-def one_crime_list(method_object):
-    return [
-        {"crime": "The Crime", "parent": method_object},
-    ]
+def one_crime_list(analysis_element_1):
+    return [analysis_element_1]
 
 
 @pytest.fixture(scope="function")
-def duplicate_crime_list(method_object):
-    return [
-        {"crime": "The Crime", "parent": method_object},
-        {"crime": "The Crime", "parent": method_object},
-        {"crime": "Another Crime", "parent": method_object},
-    ]
+def referenced_crime_list(analysis_element_1, analysis_element_2):
+    return [analysis_element_1, analysis_element_2]
+
+
+@pytest.fixture(scope="function")
+def duplicate_crime_list(analysis_element_1):
+    return [analysis_element_1, analysis_element_1]
 
 
 def test_output_parent_function_table_with_one_crime(capsys, one_crime_list):
-    output_parent_function_table(one_crime_list)
+    output_parent_function_table(one_crime_list, MAX_SEARCH_LAYER)
 
     # f"{item['parent'].class_name}{item['parent'].name}"
     output = capsys.readouterr().out
@@ -63,26 +113,92 @@ def test_output_parent_function_table_with_one_crime(capsys, one_crime_list):
     assert output.count("The Crime") == 1
 
 
-def test_output_parent_function_table_with_duplicated_description(
-    capsys, duplicate_crime_list
+def test_output_parent_function_table_with_referenced_crime(
+    capsys, referenced_crime_list
 ):
-
-    output_parent_function_table(duplicate_crime_list)
+    output_parent_function_table(referenced_crime_list, MAX_SEARCH_LAYER)
 
     output = capsys.readouterr().out
-    assert output.count("Lcom/google/progress/Locate;getLocation") == 1
+    assert output.count("Lcom/google/progress/Locate;getLocation") == 2
+    assert (
+        output.count("Lcom/google/progress/AndroidClientService;sendMessage")
+        == 1
+    )
+    assert output.count("Call Lcom/google/progress/Locate;getLocation") == 1
     assert output.count("The Crime") == 1
     assert output.count("Another Crime") == 1
 
 
+def test_output_parent_function_table_with_duplicated_description(
+    capsys, duplicate_crime_list
+):
+
+    output_parent_function_table(duplicate_crime_list, MAX_SEARCH_LAYER)
+
+    output = capsys.readouterr().out
+    print(output)
+    assert output.count("Lcom/google/progress/Locate;getLocation") == 1
+    assert output.count("The Crime") == 1
+
+
 def test_output_parent_function_json_with_one_crime(one_crime_list):
-    output_parent_function_json(one_crime_list)
+    output_parent_function_json(one_crime_list, MAX_SEARCH_LAYER)
+    expected_result = {
+        "rules_classification": [
+            {
+                "parent": "Lcom/google/progress/Locate;getLocation",
+                "crime": ["The Crime"],
+            }
+        ]
+    }
 
     with open("rules_classification.json", "r") as classification_report:
         report = json.load(classification_report)
 
-        assert len(report["rules_classification"]) == 1
+        assert report == expected_result
+
+
+def test_output_parent_function_json_with_referenced_crime(
+    referenced_crime_list,
+):
+    output_parent_function_json(referenced_crime_list, MAX_SEARCH_LAYER)
+
+    with open("rules_classification.json", "r") as classification_report:
+        report = json.load(classification_report)
+
+        assert len(report["rules_classification"]) == 2
+
+        first_item = report["rules_classification"][0]
+        second_item = report["rules_classification"][1]
+        if first_item["parent"] != "Lcom/google/progress/Locate;getLocation":
+            first_item, second_item = second_item, first_item
+
+        assert set(first_item["crime"]) == {"The Crime"}
+        assert set(second_item["crime"]) == {
+            "Call Lcom/google/progress/Locate;getLocation",
+            "Another Crime",
+        }
+
         assert (
-            report["rules_classification"][0]["parent"]
-            == "Lcom/google/progress/Locate;getLocation"
+            second_item["parent"]
+            == "Lcom/google/progress/AndroidClientService;sendMessage"
         )
+
+
+def test_output_parent_function_json_with_duplicated_crime(
+    duplicate_crime_list,
+):
+    output_parent_function_json(duplicate_crime_list, MAX_SEARCH_LAYER)
+    expected_result = {
+        "rules_classification": [
+            {
+                "parent": "Lcom/google/progress/Locate;getLocation",
+                "crime": ["The Crime"],
+            }
+        ]
+    }
+
+    with open("rules_classification.json", "r") as classification_report:
+        report = json.load(classification_report)
+
+        assert report == expected_result


### PR DESCRIPTION
**Description**

The PR adds a new feature that lists references of the parent functions in the rule classification report. (See the text with a yellow underline bellow.)

![](https://i.imgur.com/jKejWOl.png)

With this text, the user can see how parent functions interact with each other.

For more details, please refer to issue #191.

**Code Changes**

1. Add a new function to prepare the data of a rule classification report.
2. Add code to search for cross-references.

**Test Plan**

1. Add tests with test data containing cross-references.