### PR TITLE
Add A Standard Interface for Accessing APK Infomation

### DIFF
--- a/quark/Objects/baseapkinfo.py
+++ b/quark/Objects/baseapkinfo.py
@@ -1,0 +1,183 @@
+import hashlib
+import os.path
+from abc import abstractmethod
+from os import PathLike
+from typing import Dict, List, Optional, Set, Union
+
+from quark.Objects.bytecodeobject import BytecodeObject
+from quark.Objects.methodobject import MethodObject
+
+
+class BaseApkinfo:
+
+    __slots__ = ["ret_type", "apk_filename", "apk_filepath", "core_library"]
+
+    def __init__(
+        self, apk_filepath: Union[str, PathLike], core_library: str = "None"
+    ):
+        with open(apk_filepath, "rb") as file:
+            raw = file.read()
+            self.ret_type = self._check_file_signature(raw)
+
+        self.apk_filename = os.path.basename(apk_filepath)
+        self.apk_filepath = apk_filepath
+        self.core_library = core_library
+
+    def __repr__(self) -> str:
+        return f"<Apkinfo-APK:{self.apk_filename}, Imp:{self.core_library}>"
+
+    @property
+    def filename(self) -> str:
+        """
+        Return the filename of apk.
+
+        :return: a string of apk filename
+        """
+        return os.path.basename(self.apk_filepath)
+
+    @property
+    def filesize(self) -> int:
+        """
+        Return the file size of apk file by bytes.
+
+        :return: a number of size bytes
+        """
+        return os.path.getsize(self.apk_filepath)
+
+    @property
+    def md5(self) -> str:
+        """
+        Return the md5 checksum of the apk file.
+
+        :return: a string of md5 checksum of the apk file
+        """
+        md5 = hashlib.md5()
+        with open(self.apk_filepath, "rb") as f:
+            for chunk in iter(lambda: f.read(4096), b""):
+                md5.update(chunk)
+        return md5.hexdigest()
+
+    @property
+    @abstractmethod
+    def permissions(self) -> List[str]:
+        """
+        Return all permissions from given APK.
+
+        :return: a list of all permissions
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def android_apis(self) -> Set[MethodObject]:
+        """
+        Return all Android native APIs from given APK.
+
+        :return: a set of all Android native APIs MethodObject
+        """
+        pass
+
+    @property
+    @abstractmethod
+    def custom_methods(self) -> Set[MethodObject]:
+        """
+        Return all custom methods from given APK.
+
+        :return: a set of all custom methods MethodObject
+        """
+        pass
+
+    @property
+    def all_methods(self) -> Set[MethodObject]:
+        """
+        Return all methods including Android native API and custom methods from given APK.
+
+        :return: a set of all method MethodObject
+        """
+        pass
+
+    @abstractmethod
+    def find_method(
+        self,
+        class_name: Optional[str] = ".*",
+        method_name: Optional[str] = ".*",
+        descriptor: Optional[str] = ".*",
+    ) -> MethodObject:
+        """
+        Find method from given class_name, method_name and the descriptor.
+        default is find all method.
+
+        :param class_name: the class name of the Android API
+        :param method_name: the method name of the Android API
+        :param descriptor: the descriptor of the Android API
+        :return: a generator of MethodObject
+        """
+        pass
+
+    @abstractmethod
+    def upperfunc(self, method_object: MethodObject) -> Set[MethodObject]:
+        """
+        Return the xref from method from given MethodObject instance.
+
+        :param method_object: the MethodObject instance
+        :return: a set of all xref from functions
+        """
+        pass
+
+    @abstractmethod
+    def lowerfunc(self, method_object: MethodObject) -> Set[MethodObject]:
+        """
+        Return the xref from method from given MethodObject instance.
+
+        :param method_object: the MethodObject instance
+        :return: a set of all xref from functions
+        """
+        pass
+
+    @abstractmethod
+    def get_method_bytecode(
+        self, method_object: MethodObject
+    ) -> Set[MethodObject]:
+        """
+        Return the corresponding bytecode according to the
+        given class name and method name.
+
+        :param method_object: the MethodObject instance
+        :return: a generator of all bytecode instructions
+        """
+        pass
+
+    @abstractmethod
+    def get_strings(self) -> str:
+        pass
+
+    @abstractmethod
+    def get_wrapper_smali(
+        self,
+        parent_method: MethodObject,
+        first_method: MethodObject,
+        second_method: MethodObject,
+    ) -> Dict[str, Union[BytecodeObject, str]]:
+        """
+        Return the dict of two method smali code from given MethodObject instance, only for self-defined
+        method.
+        :param method_analysis:
+        :return:
+
+        {
+        "first": "invoke-virtual v5, Lcom/google/progress/Locate;->getLocation()Ljava/lang/String;",
+        "second": "invoke-virtual v3, v0, v4, Lcom/google/progress/SMSHelper;->sendSms(Ljava/lang/String; Ljava/lang/String;)I"
+        }
+        """
+        pass
+
+    @staticmethod
+    def _check_file_signature(raw: bytes) -> Optional[str]:
+        if raw[0:3] == b"dex":
+            return "DEX"
+        elif raw[0:2] == b"PK":
+            return "APK"
+        elif raw[0:4] in [b"\x03\x00\x08\x00", b"\x00\x00\x08\x00"]:
+            return "AXML"
+        else:
+            return None

--- a/quark/Objects/methodobject.py
+++ b/quark/Objects/methodobject.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass, field
+
+
+@dataclass(unsafe_hash=True)
+class MethodObject(object):
+    """
+    Information about a method in a dex file.
+    """
+
+    class_name: str
+    name: str
+    descriptor: str
+    access_flags: str = field(compare=False, default="")
+    cache: object = field(compare=False, default=None, repr=False)
+
+    @property
+    def full_name(self) -> str:
+        return self.__str__()
+
+    def is_android_api(self) -> bool:
+        # Packages found at https://developer.android.com/reference/packages
+        api_list = [
+            "Landroid/",
+            "Lcom/google/android/",
+            "Ldalvik/",
+            "Ljava/",
+            "Ljavax/",
+            "Ljunit/",
+            "Lorg/apache/",
+            "Lorg/json/",
+            "Lorg/w3c/",
+            "Lorg/xml/",
+            "Lorg/xmlpull/",
+        ]
+
+        return any(self.class_name.startswith(prefix) for prefix in api_list)
+
+    def __str__(self) -> str:
+        return f"{self.class_name} {self.name} {self.descriptor}"

--- a/tests/Object/test_methodobject.py
+++ b/tests/Object/test_methodobject.py
@@ -1,0 +1,64 @@
+from quark.Objects.methodobject import MethodObject
+
+
+class TestMethodObject:
+    def test_full_name(self):
+        method = MethodObject(
+            class_name="ClassName;", name="Method", descriptor="(Descriptor)"
+        )
+
+        full_name = method.full_name
+
+        assert full_name == "ClassName; Method (Descriptor)"
+
+    def test_compare_with_different_access_flags(self):
+        method_1 = MethodObject(
+            class_name="Ljava/lang/Object;",
+            name="clone",
+            descriptor="()Ljava/lang/Object;",
+            access_flags="public",
+        )
+
+        method_2 = MethodObject(
+            class_name=method_1.class_name,
+            name=method_1.name,
+            descriptor=method_1.descriptor,
+            access_flags="protected",
+        )
+
+        assert method_1 == method_2
+
+    def test_compare_with_different_caches(self):
+        method_1 = MethodObject(
+            class_name="Ljava/lang/Object;",
+            name="clone",
+            descriptor="()Ljava/lang/Object;",
+            cache=("Cache Type A"),
+        )
+
+        method_2 = MethodObject(
+            class_name=method_1.class_name,
+            name=method_1.name,
+            descriptor=method_1.descriptor,
+            cache={"Cache Type B"},
+        )
+
+        assert method_1 == method_2
+
+    def test_is_android_api_with_api(self):
+        method = MethodObject(
+            class_name="Ljava/lang/Object;",
+            name="clone",
+            descriptor="()Ljava/lang/Object;",
+        )
+
+        assert method.is_android_api() is True
+
+    def test_is_android_api_with_custom_method(self):
+        method = MethodObject(
+            "Lcom/example/google/service/ContactsHelper;",
+            "getPhoneContacts",
+            "()V",
+        )
+
+        assert method.is_android_api() is False


### PR DESCRIPTION
**Description**
This PR adds a standard interface for Quark to access an APK.

It is the first step to make the analysis code independent of the core library, Androguard.

This PR provides:
1. BaseApkinfo class, a standard interface that defines how Quark interacts with its core library.
2. MethodObject class, used by the standard interface. It is a replacement for MethodAnalysis class.

**Why is there an additional class, MethodObject ?**
Quark uses MethodAnalysis objects as parameters in most of its files. It's not practical to eliminate the dependency file by file.

A working solution I used here is to replace MethodAnalysis with a Quark-owned class.
The only change to the existing code is adjusting the return values in apkinfo.py. And this change will arrive in the next few PRs.

**Code Changes**
+ Add quark/Object/methodobject.py
+ Add quark/Object/baseapkinfo.py

**Test Plans**
+ Add five tests for methodobject.py