### PR TITLE
Clean Up the Direct Use of MethodAnalysis

### DIFF
--- a/quark/Objects/apkinfo.py
+++ b/quark/Objects/apkinfo.py
@@ -170,6 +170,18 @@ class Apkinfo:
         """
         return {call for _, call, _ in method_analysis.get_xref_from()}
 
+    @functools.lru_cache()
+    def lowerfunc(self, method_analysis):
+        """
+        Return the xref from method from given method analysis instance.
+
+        :param method_analysis: the method analysis in androguard
+        :return: a set of all xref from functions
+        """
+        return {
+            (call, offset) for _, call, offset in method_analysis.get_xref_to()
+        }
+
     def get_method_bytecode(self, method_analysis):
         """
         Return the corresponding bytecode according to the

--- a/quark/Objects/quark.py
+++ b/quark/Objects/quark.py
@@ -137,7 +137,7 @@ class Quark:
 
                 seq_table = [
                     (call, number)
-                    for _, call, number in mutual_parent.get_xref_to()
+                    for call, number in self.apkinfo.lowerfunc(mutual_parent)
                     if call in (first_call_method, second_call_method)
                 ]
 

--- a/quark/utils/graph.py
+++ b/quark/utils/graph.py
@@ -9,10 +9,10 @@ from graphviz import Digraph
 from prompt_toolkit.shortcuts import checkboxlist_dialog
 
 
-def wrapper_lookup(wrapper, top_method, native_api):
+def wrapper_lookup(apkinfo, wrapper, top_method, native_api):
     next_level = []
 
-    for _, method, _ in top_method.get_xref_to():
+    for method, _ in apkinfo.lowerfunc(top_method):
         if method == native_api:
             wrapper.append(top_method)
             return
@@ -22,7 +22,7 @@ def wrapper_lookup(wrapper, top_method, native_api):
             next_level.append(method)
 
     for next_level_method in next_level:
-        wrapper_lookup(wrapper, next_level_method, native_api)
+        wrapper_lookup(apkinfo, wrapper, next_level_method, native_api)
 
 
 def call_graph(call_graph_analysis):
@@ -31,6 +31,7 @@ def call_graph(call_graph_analysis):
     """
 
     parent_function = call_graph_analysis["parent"]
+    apkinfo = call_graph_analysis["apkinfo"]
     first_call = call_graph_analysis["first_call"]
     second_call = call_graph_analysis["second_call"]
     first_api = call_graph_analysis["first_api"]
@@ -41,9 +42,9 @@ def call_graph(call_graph_analysis):
     second_wrapper = []
 
     if first_call != first_api:
-        wrapper_lookup(first_wrapper, first_call, first_api)
+        wrapper_lookup(apkinfo, first_wrapper, first_call, first_api)
     if second_call != second_api:
-        wrapper_lookup(second_wrapper, second_call, second_api)
+        wrapper_lookup(apkinfo, second_wrapper, second_call, second_api)
 
     # Initialize the Digraph object
     dot = Digraph(

--- a/quark/utils/output.py
+++ b/quark/utils/output.py
@@ -53,6 +53,10 @@ def _collect_crime_description(call_graph_analysis_list):
 def _search_cross_references(call_graph_analysis_list, search_depth):
     reference_dict = defaultdict(set)
 
+    if not call_graph_analysis_list:
+        return reference_dict
+
+    apkinfo = call_graph_analysis_list[0]["apkinfo"]
     parent_set = {item["parent"] for item in call_graph_analysis_list}
 
     for parent in parent_set:
@@ -62,7 +66,7 @@ def _search_cross_references(call_graph_analysis_list, search_depth):
             for function in expand_queue:
                 next_expand_queue = {
                     child_function
-                    for _, child_function, _ in function.get_xref_to()
+                    for child_function, _ in apkinfo.lowerfunc(function)
                 }
                 called_function_set.update(next_expand_queue)
                 expand_queue = next_expand_queue

--- a/tests/Object/test_apkinfo.py
+++ b/tests/Object/test_apkinfo.py
@@ -169,3 +169,21 @@ class TestApkinfo:
         assert str(check_method.class_name) == expect_class_name
         assert str(check_method.name) == expect_name
         assert str(check_method.descriptor) == expect_descriptor
+
+    def test_lowerfunc(self, apkinfo):
+        method = apkinfo.find_method(
+            "Lcom/example/google/service/WebServiceCalling;",
+            "Send",
+            "(Landroid/os/Handler; Ljava/lang/String;)V",
+        )
+
+        expect_method = apkinfo.find_method(
+            "Ljava/lang/StringBuilder;",
+            "append",
+            "(Ljava/lang/String;)Ljava/lang/StringBuilder;",
+        )
+        expect_offset = 42
+
+        upper_methods = apkinfo.lowerfunc(method)
+
+        assert (expect_method, expect_offset) in upper_methods

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -69,25 +69,28 @@ def leaf_method_2(analysis_object):
 
 
 def test_wrapper_lookup_with_result(
-    parent_method, connect_method_1, leaf_method_1
+    analysis_object, parent_method, connect_method_1, leaf_method_1
 ):
     path = []
 
-    wrapper_lookup(path, parent_method, leaf_method_1)
+    wrapper_lookup(analysis_object, path, parent_method, leaf_method_1)
 
     assert path == [connect_method_1]
 
 
-def test_wrapper_lookup_with_no_result(leaf_method_1, parent_method):
+def test_wrapper_lookup_with_no_result(
+    analysis_object, leaf_method_1, parent_method
+):
     path = []
 
-    wrapper_lookup(path, leaf_method_1, parent_method)
+    wrapper_lookup(analysis_object, path, leaf_method_1, parent_method)
 
     assert path == []
 
 
 def test_call_graph(
     parent_method,
+    analysis_object,
     connect_method_1,
     connect_method_2,
     leaf_method_1,
@@ -95,13 +98,17 @@ def test_call_graph(
 ):
     call_graph_analysis = {
         "parent": parent_method,
+        "apkinfo": analysis_object,
         "first_call": connect_method_1,
         "second_call": connect_method_2,
         "first_api": leaf_method_1,
         "second_api": leaf_method_2,
         "crime": "For test only.",
     }
-    expected_file_name = f"call_graph_image/{parent_method.name}_{connect_method_1.name}_{connect_method_2.name}"
+    expected_file_name = (
+        f"call_graph_image/{parent_method.name}_{connect_method_1.name}"
+        f"_{connect_method_2.name}"
+    )
 
     call_graph(call_graph_analysis)
 

--- a/tests/utils/test_output.py
+++ b/tests/utils/test_output.py
@@ -56,6 +56,7 @@ def analysis_element_1(analysis_object):
     return {
         "crime": "The Crime",
         "parent": parent,
+        "apkinfo": analysis_object,
         "first_call": first_api,
         "first_api": first_api,
         "second_call": second_api,
@@ -84,6 +85,7 @@ def analysis_element_2(analysis_object):
     return {
         "crime": "Another Crime",
         "parent": parent,
+        "apkinfo": analysis_object,
         "first_call": first_api,
         "first_api": first_api,
         "second_call": second_api,


### PR DESCRIPTION
**Description**

This PR deprecates all direct calls to MethodAnalysis's method in Quark.
It ensures that all method information used by Quark is from Apkinfo.

It is the second part of making the analysis code independent of the core library, Androguard. (see the first one [here](https://github.com/quark-engine/quark-engine/pull/194  ))

**Code Changes**

- Add a function lowerfunc in apkinfo.py to get method references.
- Modify the following three files to use lowerfunc instead of get_xref_to.
   1. quark.py
   2. graph.py
   3. output.py

**Test Plans**

- Add a test for lowerfunc in test_apkinfo.py.