### PR TITLE
Make Apkinfo implement the standard APK interface

### DIFF
--- a/quark/Objects/apkinfo.py
+++ b/quark/Objects/apkinfo.py
@@ -3,84 +3,39 @@
 # See the file 'LICENSE' for copying permission.
 
 import functools
-import hashlib
-import os
 import re
+from os import PathLike
+from typing import Dict, List, Optional, Set, Union
 
-from androguard.core import androconf
+from androguard.core.analysis.analysis import MethodAnalysis
 from androguard.misc import AnalyzeAPK, AnalyzeDex
 
+from quark.Objects.interface.baseapkinfo import BaseApkinfo
 from quark.Objects.struct.bytecodeobject import BytecodeObject
+from quark.Objects.struct.methodobject import MethodObject
 
 
-class Apkinfo:
+class AndroguardImp(BaseApkinfo):
     """Information about apk based on androguard analysis"""
 
-    __slots__ = [
-        "ret_type",
-        "apk",
-        "dalvikvmformat",
-        "analysis",
-        "apk_filename",
-        "apk_filepath",
-    ]
+    __slots__ = ("apk", "dalvikvmformat", "analysis")
 
-    def __init__(self, apk_filepath):
-        """Information about apk based on androguard analysis"""
-        self.ret_type = androconf.is_android(apk_filepath)
+    def __init__(self, apk_filepath: Union[str, PathLike]):
+        super().__init__(apk_filepath, "androguard")
 
         if self.ret_type == "APK":
             # return the APK, list of DalvikVMFormat, and Analysis objects
-            self.apk, self.dalvikvmformat, self.analysis = AnalyzeAPK(apk_filepath)
-
-        if self.ret_type == "DEX":
+            self.apk, self.dalvikvmformat, self.analysis = AnalyzeAPK(
+                apk_filepath
+            )
+        elif self.ret_type == "DEX":
             # return the sha256hash, DalvikVMFormat, and Analysis objects
             _, _, self.analysis = AnalyzeDex(apk_filepath)
-
-        self.apk_filename = os.path.basename(apk_filepath)
-        self.apk_filepath = apk_filepath
-
-    def __repr__(self):
-        return f"<Apkinfo-APK:{self.apk_filename}>"
+        else:
+            raise ValueError("Unsupported File type.")
 
     @property
-    def filename(self):
-        """
-        Return the filename of apk.
-
-        :return: a string of apk filename
-        """
-        return os.path.basename(self.apk_filepath)
-
-    @property
-    def filesize(self):
-        """
-        Return the file size of apk file by bytes.
-
-        :return: a number of size bytes
-        """
-        return os.path.getsize(self.apk_filepath)
-
-    @property
-    def md5(self):
-        """
-        Return the md5 checksum of the apk file.
-
-        :return: a string of md5 checksum of the apk file
-        """
-        md5 = hashlib.md5()
-        with open(self.apk_filepath, "rb") as f:
-            for chunk in iter(lambda: f.read(4096), b""):
-                md5.update(chunk)
-        return md5.hexdigest()
-
-    @property
-    def permissions(self):
-        """
-        Return all permissions from given APK.
-
-        :return: a list of all permissions
-        """
+    def permissions(self) -> List[str]:
         if self.ret_type == "APK":
             return self.apk.get_permissions()
 
@@ -88,12 +43,7 @@ class Apkinfo:
             return []
 
     @property
-    def android_apis(self):
-        """
-        Return all Android native APIs from given APK.
-
-        :return: a set of all Android native APIs MethodAnalysis
-        """
+    def android_apis(self) -> Set[MethodObject]:
         apis = set()
 
         for external_cls in self.analysis.get_external_classes():
@@ -101,43 +51,30 @@ class Apkinfo:
                 if meth_analysis.is_android_api():
                     apis.add(meth_analysis)
 
-        return apis
+        return {self._convert_to_method_object(api) for api in apis}
 
     @property
-    def custom_methods(self):
-        """
-        Return all custom methods from given APK.
-
-        :return: a set of all custom methods MethodAnalysis
-        """
+    def custom_methods(self) -> Set[MethodObject]:
         return {
-            meth_analysis
+            self._convert_to_method_object(meth_analysis)
             for meth_analysis in self.analysis.get_methods()
             if not meth_analysis.is_external()
         }
 
     @property
-    def all_methods(self):
-        """
-        Return all methods including Android native API and custom methods from given APK.
-
-        :return: a set of all method MethodAnalysis
-        """
-
-        return {meth_analysis for meth_analysis in self.analysis.get_methods()}
+    def all_methods(self) -> Set[MethodObject]:
+        return {
+            self._convert_to_method_object(meth_analysis)
+            for meth_analysis in self.analysis.get_methods()
+        }
 
     @functools.lru_cache()
-    def find_method(self, class_name=".*", method_name=".*", descriptor=".*"):
-        """
-        Find method from given class_name, method_name and the descriptor.
-        default is find all method.
-
-        :param class_name: the class name of the Android API
-        :param method_name: the method name of the Android API
-        :param descriptor: the descriptor of the Android API
-        :return: a generator of MethodClassAnalysis
-        """
-
+    def find_method(
+        self,
+        class_name: Optional[str] = ".*",
+        method_name: Optional[str] = ".*",
+        descriptor: Optional[str] = ".*",
+    ) -> MethodObject:
         regex_class_name = re.escape(class_name)
         regex_method_name = f"^{re.escape(method_name)}$"
         regex_descriptor = re.escape(descriptor)
@@ -156,43 +93,35 @@ class Apkinfo:
                 )
             )
 
-            return result
+            return self._convert_to_method_object(result)
         else:
             return None
 
     @functools.lru_cache()
-    def upperfunc(self, method_analysis):
-        """
-        Return the xref from method from given method analysis instance.
-
-        :param method_analysis: the method analysis in androguard
-        :return: a set of all xref from functions
-        """
-        return {call for _, call, _ in method_analysis.get_xref_from()}
-
-    @functools.lru_cache()
-    def lowerfunc(self, method_analysis):
-        """
-        Return the xref from method from given method analysis instance.
-
-        :param method_analysis: the method analysis in androguard
-        :return: a set of all xref from functions
-        """
+    def upperfunc(self, method_object: MethodObject) -> Set[MethodObject]:
+        method_analysis = method_object.cache
         return {
-            (call, offset) for _, call, offset in method_analysis.get_xref_to()
+            self._convert_to_method_object(call)
+            for _, call, _ in method_analysis.get_xref_from()
         }
 
-    def get_method_bytecode(self, method_analysis):
-        """
-        Return the corresponding bytecode according to the
-        given class name and method name.
+    def lowerfunc(self, method_object: MethodObject) -> Set[MethodObject]:
+        method_analysis = method_object.cache
+        return {
+            (self._convert_to_method_object(call), offset)
+            for _, call, offset in method_analysis.get_xref_to()
+        }
 
-        :param method_analysis: the method analysis in androguard
-        :return: a generator of all bytecode instructions
-        """
+    def get_method_bytecode(
+        self, method_object: MethodObject
+    ) -> Set[MethodObject]:
+        method_analysis = method_object.cache
 
         try:
-            for _, ins in method_analysis.get_method().get_instructions_idx():
+            for (
+                _,
+                ins,
+            ) in method_analysis.get_method().get_instructions_idx():
                 bytecode_obj = None
                 reg_list = []
 
@@ -224,7 +153,9 @@ class Apkinfo:
                         reg_list.append(
                             "v" + str(ins.get_operands()[i][1]),
                         )
-                    parameter = parameter[2] if len(parameter) == 3 else parameter[1]
+                    parameter = (
+                        parameter[2] if len(parameter) == 3 else parameter[1]
+                    )
                     bytecode_obj = BytecodeObject(
                         ins.get_name(),
                         reg_list,
@@ -232,19 +163,18 @@ class Apkinfo:
                     )
 
                 yield bytecode_obj
-        except AttributeError as error:
+        except AttributeError:
             # TODO Log the rule here
             pass
 
-    def get_strings(self):
-
+    def get_strings(self) -> str:
         return {
             str(string_analysis.get_orig_value())
             for string_analysis in self.analysis.get_strings()
         }
 
     @functools.lru_cache()
-    def construct_bytecode_instruction(self, instruction):
+    def _construct_bytecode_instruction(self, instruction):
         """
         Construct a list of strings from the given bytecode instructions.
 
@@ -263,7 +193,9 @@ class Apkinfo:
         elif length_operands == 1:
             # Only one register
 
-            reg_list.append(f"v{instruction.get_operands()[length_operands - 1][1]}")
+            reg_list.append(
+                f"v{instruction.get_operands()[length_operands - 1][1]}"
+            )
 
             instruction_list.extend(reg_list)
 
@@ -283,32 +215,49 @@ class Apkinfo:
             return instruction_list
 
     @functools.lru_cache()
-    def get_wrapper_smali(self, method_analysis, first_method, second_method):
-        """
-        Return the dict of two method smali code from given method analysis object, only for self-defined
-        method.
-        :param method_analysis:
-        :return:
+    def get_wrapper_smali(
+        self,
+        parent_method: MethodObject,
+        first_method: MethodObject,
+        second_method: MethodObject,
+    ) -> Dict[str, Union[BytecodeObject, str]]:
+        method_analysis = parent_method.cache
 
-        {
-        "first": "invoke-virtual v5, Lcom/google/progress/Locate;->getLocation()Ljava/lang/String;",
-        "second": "invoke-virtual v3, v0, v4, Lcom/google/progress/SMSHelper;->sendSms(Ljava/lang/String; Ljava/lang/String;)I"
+        result = {
+            "first": None,
+            "first_hex": None,
+            "second": None,
+            "second_hex": None,
         }
-        """
-
-        result = {"first": None, "first_hex": None, "second": None, "second_hex": None}
 
         first_method_pattern = (
-            f"{first_method.class_name}->{first_method.name}{first_method.descriptor}"
+            f"{first_method.class_name}"
+            f"->{first_method.name}{first_method.descriptor}"
         )
-        second_method_pattern = f"{second_method.class_name}->{second_method.name}{second_method.descriptor}"
+        second_method_pattern = (
+            f"{second_method.class_name}"
+            f"->{second_method.name}{second_method.descriptor}"
+        )
 
         for _, ins in method_analysis.get_method().get_instructions_idx():
             if first_method_pattern in str(ins):
-                result["first"] = self.construct_bytecode_instruction(ins)
+                result["first"] = self._construct_bytecode_instruction(ins)
                 result["first_hex"] = ins.get_hex()
             if second_method_pattern in str(ins):
-                result["second"] = self.construct_bytecode_instruction(ins)
+                result["second"] = self._construct_bytecode_instruction(ins)
                 result["second_hex"] = ins.get_hex()
 
         return result
+
+    @staticmethod
+    @functools.lru_cache
+    def _convert_to_method_object(
+        method_analysis: MethodAnalysis,
+    ) -> MethodObject:
+        return MethodObject(
+            access_flags=method_analysis.access,
+            class_name=str(method_analysis.class_name),
+            name=str(method_analysis.name),
+            descriptor=str(method_analysis.descriptor),
+            cache=method_analysis,
+        )

--- a/quark/Objects/quark.py
+++ b/quark/Objects/quark.py
@@ -10,7 +10,7 @@ import pandas as pd
 
 from quark.Evaluator.pyeval import PyEval
 from quark.Objects.analysis import QuarkAnalysis
-from quark.Objects.apkinfo import Apkinfo
+from quark.Objects.apkinfo import AndroguardImp as Apkinfo
 from quark.utils import tools
 from quark.utils.colors import (
     red,

--- a/quark/forensic/forensic.py
+++ b/quark/forensic/forensic.py
@@ -2,7 +2,7 @@
 # This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
 # See the file 'LICENSE' for copying permission.
 
-from quark.Objects.apkinfo import Apkinfo
+from quark.Objects.apkinfo import AndroguardImp as Apkinfo
 from quark.utils.regex import (
     extract_url,
     extract_ip,

--- a/quark/utils/graph.py
+++ b/quark/utils/graph.py
@@ -77,7 +77,7 @@ def call_graph(call_graph_analysis):
         p, r = str(parent_function.descriptor).split(")")
         mutual_parent_function_description.node(
             f"{parent_function.full_name}",
-            label=f"Access: {parent_function.access}\nClass: {parent_function.class_name}\nMethod: {parent_function.name}\n Parameter: {p})\n Return: {r}",
+            label=f"Access: {parent_function.access_flags}\nClass: {parent_function.class_name}\nMethod: {parent_function.name}\n Parameter: {p})\n Return: {r}",
             shape="none",
             fontcolor="blue",
             fontname="Courier New",
@@ -96,7 +96,7 @@ def call_graph(call_graph_analysis):
 
                 wrapper.node(
                     f"{wp_func.full_name}",
-                    label=f"Access: {wp_func.access}\nClass: {wp_func.class_name}\nMethod: {wp_func.name}\n Parameter: {p})\n Return: {r}",
+                    label=f"Access: {wp_func.access_flags}\nClass: {wp_func.class_name}\nMethod: {wp_func.name}\n Parameter: {p})\n Return: {r}",
                     style="rounded",
                     fontcolor="blue",
                     penwidth="1",
@@ -120,7 +120,7 @@ def call_graph(call_graph_analysis):
                 p, r = str(wp_func.descriptor).split(")")
                 wrapper.node(
                     f"{wp_func.full_name}",
-                    label=f"Access: {wp_func.access}\nClass: {wp_func.class_name}\nMethod: {wp_func.name}\n Parameter: {p})\n Return: {r}",
+                    label=f"Access: {wp_func.access_flags}\nClass: {wp_func.class_name}\nMethod: {wp_func.name}\n Parameter: {p})\n Return: {r}",
                     style="rounded",
                     fontcolor="blue",
                     penwidth="1",

--- a/tests/Object/test_apkinfo.py
+++ b/tests/Object/test_apkinfo.py
@@ -4,9 +4,9 @@ import zipfile
 import pytest
 import requests
 from quark.Objects.apkinfo import AndroguardImp as Apkinfo
-from quark.Objects.baseapkinfo import BaseApkinfo
-from quark.Objects.bytecodeobject import BytecodeObject
-from quark.Objects.methodobject import MethodObject
+from quark.Objects.interface.baseapkinfo import BaseApkinfo
+from quark.Objects.struct.bytecodeobject import BytecodeObject
+from quark.Objects.struct.methodobject import MethodObject
 
 APK_SOURCE = (
     "https://github.com/quark-engine/apk-malware-samples"

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -2,7 +2,7 @@ import os.path
 
 import pytest
 import requests
-from quark.Objects.apkinfo import Apkinfo
+from quark.Objects.apkinfo import AndroguardImp as Apkinfo
 from quark.utils.graph import call_graph, wrapper_lookup
 
 

--- a/tests/utils/test_output.py
+++ b/tests/utils/test_output.py
@@ -3,7 +3,7 @@ import os
 
 import pytest
 import requests
-from quark.Objects.apkinfo import Apkinfo
+from quark.Objects.apkinfo import AndroguardImp as Apkinfo
 from quark.Objects.quark import MAX_SEARCH_LAYER
 from quark.utils.output import (
     get_rule_classification_data,


### PR DESCRIPTION
**Description**

This PR modifies Apkinfo class to implement the standard APK interface.

The goal is to make the analysis code independent to Androguard. It enables the possibility to use other libraries to support Quark analysis.

**Code Changes**

+ **apkinfo.py**
  + Rename Apkinfo to AndroguardImp
  + Remove the duplicated properties and docstrings.
  + Add a method to convert MethodAnalysis to MethodObject. 
+ **graph.py**
  + Replace access property with access_flags from MethodObject.
+ **quark.py**, **forensic.py**, **test_graph.py** and **test_output.py**
  + Update their imports.

**Test Plans**

+ Ensure the PR passes all existing tests.