### PR TITLE
Add a Rizin-based core library

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,6 +21,7 @@ requests = "*"
 pandas = "*"
 plotly = "*"
 prompt-toolkit = "==3.0.19"
+rzpipe = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f7bdf4220651db72afdbe3fc0eccfc8d8eadc5ad5fd437a381e068a4a5cd3538"
+            "sha256": "a3a1c314e00ddfc2db3949aee76a088c289ae2702933ad11bc659996d91c4a7b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,14 +23,6 @@
             ],
             "index": "pypi",
             "version": "==3.4.0a1"
-        },
-        "appnope": {
-            "hashes": [
-                "sha256:93aa393e9d6c54c5cd570ccadd8edad61ea0c4b9ea7a01409020c9aa019eb442",
-                "sha256:dd83cd4b5b460958838f6eb3000c660b1f9caf2a5b1de4264e941512f603258a"
-            ],
-            "markers": "sys_platform == 'darwin'",
-            "version": "==0.1.2"
         },
         "asn1crypto": {
             "hashes": [
@@ -110,11 +102,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:9bc24a99f5d19721fb8a2d1408908e9c0520a17fff2233ffe82620847f17f1b6",
-                "sha256:d513e93327cf8657d6467c81f1f894adc125334ffe0e4ddd1abbb1c78d828703"
+                "sha256:54bbd1fe3882457aaf28ae060a5ccdef97f212a741754e420028d4ec5c2291dc",
+                "sha256:aa21412f2b04ad1a652e30564fff6b4de04726ce875eab222c8430edc6db383a"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==7.24.1"
+            "version": "==7.25.0"
         },
         "ipython-genutils": {
             "hashes": [
@@ -298,28 +290,28 @@
         },
         "pandas": {
             "hashes": [
-                "sha256:10717a3d8afe8624236da9dc2b7bac3f64e04d3e0bd0057977f16cce15bbcd7c",
-                "sha256:113a5320cee40d5ea3ab87e5d81f4fcc06f18b42799858e19757c2669b8e639c",
-                "sha256:357fc2b5674c4fd14dc3ab52c8beb0201c34180df71a15f197ab28583eb8064e",
-                "sha256:3e45975b8606ddaf289bc99864fa30e3c379a7a99282b0e8a8687cdc4bf7a16e",
-                "sha256:43d87dcfef93f9a037f4aae8223667d1d7e084e9209738ef4cf6d0b98d57b23f",
-                "sha256:49f31edad295315de282f7e54fd9c55b2a8338a9cf971154ec490bd3f122f6f9",
-                "sha256:59735a4782ebaf7828554da69e9dbb38b8ecce97d43ee3561f4b61510127da88",
-                "sha256:5b2f9e20f4e5cb963fd82b2279ceeb85fa1e66ff243b56efb6ee25e44e010748",
-                "sha256:6f5abd2ab6d834c84f7d95fc0519bb8b3b2e05c00a791da1742f9483e3aac631",
-                "sha256:70db001d5d33d10775996b1ff97e461fc936c8d65130c121ef940f0de6a9f21a",
-                "sha256:7158e6c15e1cb53875f8de70dead10dcb8f533373afba5fe8da536ca701f4c65",
-                "sha256:8e6ba115ae3304439dbc1d004e6c434b82e9f3a85fa8fafe8665764494ed871a",
-                "sha256:942a489cae28a0a037580549bc9cd19ffe5270ae2c14de682edb4f5b0df82a91",
-                "sha256:9d963cc25d2a3bc3a4b390dece6a5e03bacd3dfe763e2ebc1239bbe189994795",
-                "sha256:d631e5505d01854026c66e10d1c571ffb648a304b13228c75f1ffe75cef81e67",
-                "sha256:d7f6c93ab56977fa38d5f5514610e8412555d47c05db9476e9e62300267a3f51",
-                "sha256:dbb1ffda8581e9c0b4ce984358289a6cd89167b68ea36648b7f4e04eb7cc069f",
-                "sha256:e318968f76a3d68842e1da773b91d16741c7da8b3898dc5dc72636a34686f0e9",
-                "sha256:fd2ed3a51512cbf6fe2398d7c25a45a15adb28a88a352923a83c009e4c6b4a4c"
+                "sha256:08eeff3da6a188e24db7f292b39a8ca9e073bf841fbbeadb946b3ad5c19d843e",
+                "sha256:1ff13eed501e07e7fb26a4ea18a846b6e5d7de549b497025601fd9ccb7c1d123",
+                "sha256:522bfea92f3ef6207cadc7428bda1e7605dae0383b8065030e7b5d0266717b48",
+                "sha256:7897326cae660eee69d501cbfa950281a193fcf407393965e1bc07448e1cc35a",
+                "sha256:798675317d0e4863a92a9a6bc5bd2490b5f6fef8c17b95f29e2e33f28bef9eca",
+                "sha256:7d3cd2c99faa94d717ca00ea489264a291ad7209453dffbf059bfb7971fd3a61",
+                "sha256:823737830364d0e2af8c3912a28ba971296181a07950873492ed94e12d28c405",
+                "sha256:872aa91e0f9ca913046ab639d4181a899f5e592030d954d28c2529b88756a736",
+                "sha256:88864c1e28353b958b1f30e4193818519624ad9a1776921622a6a2a016d5d807",
+                "sha256:92835113a67cbd34747c198d41f09f4b63f6fe11ca5643baebc7ab1e30e89e95",
+                "sha256:98efc2d4983d5bb47662fe2d97b2c81b91566cb08b266490918b9c7d74a5ef64",
+                "sha256:b10d7910ae9d7920a5ff7816d794d99acbc361f7b16a0f017d4fa83ced8cb55e",
+                "sha256:c554e6c9cf2d5ea1aba5979cc837b3649539ced0e18ece186f055450c86622e2",
+                "sha256:c746876cdd8380be0c3e70966d4566855901ac9aaa5e4b9ccaa5ca5311457d11",
+                "sha256:c81b8d91e9ae861eb4406b4e0f8d4dabbc105b9c479b3d1e921fba1d35b5b62a",
+                "sha256:e6b75091fa54a53db3927b4d1bc997c23c5ba6f87acdfe1ee5a92c38c6b2ed6a",
+                "sha256:ed4fc66f23fe17c93a5d439230ca2d6b5f8eac7154198d327dbe8a16d98f3f10",
+                "sha256:f058c786e7b0a9e7fa5e0b9f4422e0ccdd3bf3aa3053c18d77ed2a459bd9a45a",
+                "sha256:fe7a549d10ca534797095586883a5c17d140d606747591258869c56e14d1b457"
             ],
             "index": "pypi",
-            "version": "==1.3.0rc1"
+            "version": "==1.3.0"
         },
         "parso": {
             "hashes": [
@@ -346,51 +338,51 @@
         },
         "pillow": {
             "hashes": [
-                "sha256:01425106e4e8cee195a411f729cff2a7d61813b0b11737c12bd5991f5f14bcd5",
-                "sha256:031a6c88c77d08aab84fecc05c3cde8414cd6f8406f4d2b16fed1e97634cc8a4",
-                "sha256:083781abd261bdabf090ad07bb69f8f5599943ddb539d64497ed021b2a67e5a9",
-                "sha256:0d19d70ee7c2ba97631bae1e7d4725cdb2ecf238178096e8c82ee481e189168a",
-                "sha256:0e04d61f0064b545b989126197930807c86bcbd4534d39168f4aa5fda39bb8f9",
-                "sha256:12e5e7471f9b637762453da74e390e56cc43e486a88289995c1f4c1dc0bfe727",
-                "sha256:22fd0f42ad15dfdde6c581347eaa4adb9a6fc4b865f90b23378aa7914895e120",
-                "sha256:238c197fc275b475e87c1453b05b467d2d02c2915fdfdd4af126145ff2e4610c",
-                "sha256:3b570f84a6161cf8865c4e08adf629441f56e32f180f7aa4ccbd2e0a5a02cba2",
-                "sha256:463822e2f0d81459e113372a168f2ff59723e78528f91f0bd25680ac185cf797",
-                "sha256:4d98abdd6b1e3bf1a1cbb14c3895226816e666749ac040c4e2554231068c639b",
-                "sha256:5afe6b237a0b81bd54b53f835a153770802f164c5570bab5e005aad693dab87f",
-                "sha256:5b70110acb39f3aff6b74cf09bb4169b167e2660dabc304c1e25b6555fa781ef",
-                "sha256:5cbf3e3b1014dddc45496e8cf38b9f099c95a326275885199f427825c6522232",
-                "sha256:624b977355cde8b065f6d51b98497d6cd5fbdd4f36405f7a8790e3376125e2bb",
-                "sha256:63728564c1410d99e6d1ae8e3b810fe012bc440952168af0a2877e8ff5ab96b9",
-                "sha256:66cc56579fd91f517290ab02c51e3a80f581aba45fd924fcdee01fa06e635812",
-                "sha256:6c32cc3145928c4305d142ebec682419a6c0a8ce9e33db900027ddca1ec39178",
-                "sha256:8b56553c0345ad6dcb2e9b433ae47d67f95fc23fe28a0bde15a120f25257e291",
-                "sha256:8bb1e155a74e1bfbacd84555ea62fa21c58e0b4e7e6b20e4447b8d07990ac78b",
-                "sha256:95d5ef984eff897850f3a83883363da64aae1000e79cb3c321915468e8c6add5",
-                "sha256:a013cbe25d20c2e0c4e85a9daf438f85121a4d0344ddc76e33fd7e3965d9af4b",
-                "sha256:a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1",
-                "sha256:a7d5e9fad90eff8f6f6106d3b98b553a88b6f976e51fce287192a5d2d5363713",
-                "sha256:aac00e4bc94d1b7813fe882c28990c1bc2f9d0e1aa765a5f2b516e8a6a16a9e4",
-                "sha256:b91c36492a4bbb1ee855b7d16fe51379e5f96b85692dc8210831fbb24c43e484",
-                "sha256:c03c07ed32c5324939b19e36ae5f75c660c81461e312a41aea30acdd46f93a7c",
-                "sha256:c5236606e8570542ed424849f7852a0ff0bce2c4c8d0ba05cc202a5a9c97dee9",
-                "sha256:c6b39294464b03457f9064e98c124e09008b35a62e3189d3513e5148611c9388",
-                "sha256:cb7a09e173903541fa888ba010c345893cd9fc1b5891aaf060f6ca77b6a3722d",
-                "sha256:d68cb92c408261f806b15923834203f024110a2e2872ecb0bd2a110f89d3c602",
-                "sha256:dc38f57d8f20f06dd7c3161c59ca2c86893632623f33a42d592f097b00f720a9",
-                "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e",
-                "sha256:f217c3954ce5fd88303fc0c317af55d5e0204106d86dea17eb8205700d47dec2"
+                "sha256:063d17a02a0170c2f880fbd373b2738b089c6adcbd1f7418667bc9e97524c11b",
+                "sha256:1037288a22cc8ec9d2918a24ded733a1cc4342fd7f21d15d37e6bbe5fb4a7306",
+                "sha256:25f6564df21d15bcac142b4ed92b6c02e53557539f535f31c1f3bcc985484753",
+                "sha256:28f184c0a65be098af412f78b0b6f3bbafd1614e1dc896e810d8357342a794b7",
+                "sha256:3251557c53c1ed0c345559afc02d2b0a0aa5788042e161366ed90b27bc322d3d",
+                "sha256:331f8321418682386e4f0d0e6369f732053f95abddd2af4e1b1ef74a9537ef37",
+                "sha256:333313bcc53a8a7359e98d5458dfe37bfa301da2fd0e0dc41f585ae0cede9181",
+                "sha256:34ce3d993cb4ca840b1e31165b38cb19c64f64f822a8bc5565bde084baff3bdb",
+                "sha256:490c9236ef4762733b6c2e1f1fcb37793cb9c57d860aa84d6994c990461882e5",
+                "sha256:519b3b24dedc81876d893475bade1b92c4ce7c24b9b82224f0bd8daae682e039",
+                "sha256:53f6e4b73b3899015ac4aa95d99da0f48ea18a6d7c8db672e8bead3fb9570ef5",
+                "sha256:561339ed7c324bbcb29b5e4f4705c97df950785394b3ac181f5bf6a08088a672",
+                "sha256:6f7517a220aca8b822e25b08b0df9546701a606a328da5bc057e5f32a3f9b07c",
+                "sha256:713b762892efa8cd5d8dac24d16ac2d2dbf981963ed1b3297e79755f03f8cbb8",
+                "sha256:72858a27dd7bd1c40f91c4f85db3b9f121c8412fd66573121febb00d074d0530",
+                "sha256:778a819c2d194e08d39d67ddb15ef0d32eba17bf7d0c2773e97bd221b2613a3e",
+                "sha256:803606e206f3e366eea46b1e7ab4dac74cfac770d04de9c35319814e11e47c46",
+                "sha256:856fcbc3201a6cabf0478daa0c0a1a8a175af7e5173e2084ddb91cc707a09dd1",
+                "sha256:8f65d2a98f198e904dbe89ecb10862d5f0511367d823689039e17c4d011de11e",
+                "sha256:94db5ea640330de0945b41dc77fb4847b4ab6e87149126c71b36b112e8400898",
+                "sha256:950e873ceefbd283cbe7bc5b648b832d1dcf89eeded6726ebec42bc7d67966c0",
+                "sha256:a7beda44f177ee602aa27e0a297da1657d9572679522c8fb8b336b734653516e",
+                "sha256:aef0838f28328523e9e5f2c1852dd96fb85768deb0eb8f908c54dad0f44d2f6f",
+                "sha256:b42ea77f4e7374a67e1f27aaa9c62627dff681f67890e5b8f0c1e21b1500d9d2",
+                "sha256:bccd0d604d814e9494f3bf3f077a23835580ed1743c5175581882e7dd1f178c3",
+                "sha256:c2d78c8230bda5fc9f6b1d457c7f8f3432f4fe85bed86f80ba3ed73d59775a88",
+                "sha256:c3529fb98a40f89269175442c5ff4ef81d22e91b2bdcbd33833a350709b5130c",
+                "sha256:cc8e926d6ffa65d0dddb871b7afe117f17bc045951e66afde60eb0eba923db9e",
+                "sha256:ce90aad0a3dc0f13a9ff0ab1f43bcbea436089b83c3fadbe37c6f1733b938bf1",
+                "sha256:cec702974f162026bf8de47f6f4b7ce9584a63c50002b38f195ee797165fea77",
+                "sha256:d9ef8119ce44f90d2f8ac7c58f7da480ada5151f217dc8da03681b73fc91dec3",
+                "sha256:eccaefbd646022b5313ca4b0c5f1ae6e0d3a52ef66de64970ecf3f9b2a1be751",
+                "sha256:fb91deb5121b6dde88599bcb3db3fdad9cf33ff3d4ccc5329ee1fe9655a2f7ff",
+                "sha256:fc25d59ecf23ea19571065306806a29c43c67f830f0e8a121303916ba257f484"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.2.0"
+            "version": "==8.3.0"
         },
         "plotly": {
             "hashes": [
-                "sha256:1dd8cba0c1c57a28056d306bc702926829b0baa056f96c58ccba39db5f65f50e",
-                "sha256:c35467d81070df9b4394f1e922223e709675178ffa3d22b61f3bb31ed9a327f7"
+                "sha256:71f6744acdc524c22236c226d7cf1072d1a58ebacaf749c640998298472c8c44",
+                "sha256:d60412ee21d85102f67e5c7134d59feb5e42a5cbbfb1e580ad67cbdf7589d80c"
             ],
             "index": "pypi",
-            "version": "==5.0.0"
+            "version": "==5.1.0"
         },
         "prettytable": {
             "hashes": [
@@ -444,7 +436,7 @@
                 "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.1"
         },
         "pytz": {
@@ -465,6 +457,15 @@
             ],
             "index": "pypi",
             "version": "==2.25.1"
+        },
+        "rzpipe": {
+            "hashes": [
+                "sha256:065bf7ed8040ce5d57ac02aab8ec62a7a9972af3f70787543562d8cba558c890",
+                "sha256:571f4cd6001bc06cd4788e44184d7391d6c76f11697a5d21323bdfc479cc5ef0",
+                "sha256:bdf2c970c3ff15a016a9ef30b353191fc7d8ef373fc7482afd8fe8d04d2a7cf8"
+            ],
+            "index": "pypi",
+            "version": "==0.1.0"
         },
         "scipy": {
             "hashes": [
@@ -496,7 +497,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "tenacity": {
@@ -524,11 +525,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
-                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
+                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.5"
+            "version": "==1.26.6"
         },
         "wcwidth": {
             "hashes": [
@@ -688,11 +689,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
-                "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.9"
+            "markers": "python_version >= '3.6'",
+            "version": "==21.0"
         },
         "pathspec": {
             "hashes": [
@@ -750,49 +751,45 @@
         },
         "regex": {
             "hashes": [
-                "sha256:01afaf2ec48e196ba91b37451aa353cb7eda77efe518e481707e0515025f0cd5",
-                "sha256:11d773d75fa650cd36f68d7ca936e3c7afaae41b863b8c387a22aaa78d3c5c79",
-                "sha256:18c071c3eb09c30a264879f0d310d37fe5d3a3111662438889ae2eb6fc570c31",
-                "sha256:1e1c20e29358165242928c2de1482fb2cf4ea54a6a6dea2bd7a0e0d8ee321500",
-                "sha256:281d2fd05555079448537fe108d79eb031b403dac622621c78944c235f3fcf11",
-                "sha256:314d66636c494ed9c148a42731b3834496cc9a2c4251b1661e40936814542b14",
-                "sha256:32e65442138b7b76dd8173ffa2cf67356b7bc1768851dded39a7a13bf9223da3",
-                "sha256:339456e7d8c06dd36a22e451d58ef72cef293112b559010db3d054d5560ef439",
-                "sha256:3916d08be28a1149fb97f7728fca1f7c15d309a9f9682d89d79db75d5e52091c",
-                "sha256:3a9cd17e6e5c7eb328517969e0cb0c3d31fd329298dd0c04af99ebf42e904f82",
-                "sha256:47bf5bf60cf04d72bf6055ae5927a0bd9016096bf3d742fa50d9bf9f45aa0711",
-                "sha256:4c46e22a0933dd783467cf32b3516299fb98cfebd895817d685130cc50cd1093",
-                "sha256:4c557a7b470908b1712fe27fb1ef20772b78079808c87d20a90d051660b1d69a",
-                "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb",
-                "sha256:563085e55b0d4fb8f746f6a335893bda5c2cef43b2f0258fe1020ab1dd874df8",
-                "sha256:598585c9f0af8374c28edd609eb291b5726d7cbce16be6a8b95aa074d252ee17",
-                "sha256:619d71c59a78b84d7f18891fe914446d07edd48dc8328c8e149cbe0929b4e000",
-                "sha256:67bdb9702427ceddc6ef3dc382455e90f785af4c13d495f9626861763ee13f9d",
-                "sha256:6d1b01031dedf2503631d0903cb563743f397ccaf6607a5e3b19a3d76fc10480",
-                "sha256:741a9647fcf2e45f3a1cf0e24f5e17febf3efe8d4ba1281dcc3aa0459ef424dc",
-                "sha256:7c2a1af393fcc09e898beba5dd59196edaa3116191cc7257f9224beaed3e1aa0",
-                "sha256:7d9884d86dd4dd489e981d94a65cd30d6f07203d90e98f6f657f05170f6324c9",
-                "sha256:90f11ff637fe8798933fb29f5ae1148c978cccb0452005bf4c69e13db951e765",
-                "sha256:919859aa909429fb5aa9cf8807f6045592c85ef56fdd30a9a3747e513db2536e",
-                "sha256:96fcd1888ab4d03adfc9303a7b3c0bd78c5412b2bfbe76db5b56d9eae004907a",
-                "sha256:97f29f57d5b84e73fbaf99ab3e26134e6687348e95ef6b48cfd2c06807005a07",
-                "sha256:980d7be47c84979d9136328d882f67ec5e50008681d94ecc8afa8a65ed1f4a6f",
-                "sha256:a91aa8619b23b79bcbeb37abe286f2f408d2f2d6f29a17237afda55bb54e7aac",
-                "sha256:ade17eb5d643b7fead300a1641e9f45401c98eee23763e9ed66a43f92f20b4a7",
-                "sha256:b9c3db21af35e3b3c05764461b262d6f05bbca08a71a7849fd79d47ba7bc33ed",
-                "sha256:bd28bc2e3a772acbb07787c6308e00d9626ff89e3bfcdebe87fa5afbfdedf968",
-                "sha256:bf5824bfac591ddb2c1f0a5f4ab72da28994548c708d2191e3b87dd207eb3ad7",
-                "sha256:c0502c0fadef0d23b128605d69b58edb2c681c25d44574fc673b0e52dce71ee2",
-                "sha256:c38c71df845e2aabb7fb0b920d11a1b5ac8526005e533a8920aea97efb8ec6a4",
-                "sha256:ce15b6d103daff8e9fee13cf7f0add05245a05d866e73926c358e871221eae87",
-                "sha256:d3029c340cfbb3ac0a71798100ccc13b97dddf373a4ae56b6a72cf70dfd53bc8",
-                "sha256:e512d8ef5ad7b898cdb2d8ee1cb09a8339e4f8be706d27eaa180c2f177248a10",
-                "sha256:e8e5b509d5c2ff12f8418006d5a90e9436766133b564db0abaec92fd27fcee29",
-                "sha256:ee54ff27bf0afaf4c3b3a62bcd016c12c3fdb4ec4f413391a90bd38bc3624605",
-                "sha256:fa4537fb4a98fe8fde99626e4681cc644bdcf2a795038533f9f711513a862ae6",
-                "sha256:fd45ff9293d9274c5008a2054ecef86a9bfe819a67c7be1afb65e69b405b3042"
+                "sha256:0e46c1191b2eb293a6912269ed08b4512e7e241bbf591f97e527492e04c77e93",
+                "sha256:18040755606b0c21281493ec309214bd61e41a170509e5014f41d6a5a586e161",
+                "sha256:1806370b2bef4d4193eebe8ee59a9fd7547836a34917b7badbe6561a8594d9cb",
+                "sha256:1ccbd41dbee3a31e18938096510b7d4ee53aa9fce2ee3dcc8ec82ae264f6acfd",
+                "sha256:1d386402ae7f3c9b107ae5863f7ecccb0167762c82a687ae6526b040feaa5ac6",
+                "sha256:210c359e6ee5b83f7d8c529ba3c75ba405481d50f35a420609b0db827e2e3bb5",
+                "sha256:268fe9dd1deb4a30c8593cabd63f7a241dfdc5bd9dd0233906c718db22cdd49a",
+                "sha256:361be4d311ac995a8c7ad577025a3ae3a538531b1f2cf32efd8b7e5d33a13e5a",
+                "sha256:3f7a92e60930f8fca2623d9e326c173b7cf2c8b7e4fdcf984b75a1d2fb08114d",
+                "sha256:444723ebaeb7fa8125f29c01a31101a3854ac3de293e317944022ae5effa53a4",
+                "sha256:494d0172774dc0beeea984b94c95389143db029575f7ca908edd74469321ea99",
+                "sha256:4b1999ef60c45357598935c12508abf56edbbb9c380df6f336de38a6c3a294ae",
+                "sha256:4fc86b729ab88fe8ac3ec92287df253c64aa71560d76da5acd8a2e245839c629",
+                "sha256:5049d00dbb78f9d166d1c704e93934d42cce0570842bb1a61695123d6b01de09",
+                "sha256:56bef6b414949e2c9acf96cb5d78de8b529c7b99752619494e78dc76f99fd005",
+                "sha256:59845101de68fd5d3a1145df9ea022e85ecd1b49300ea68307ad4302320f6f61",
+                "sha256:6b8b629f93246e507287ee07e26744beaffb4c56ed520576deac8b615bd76012",
+                "sha256:6c72ebb72e64e9bd195cb35a9b9bbfb955fd953b295255b8ae3e4ad4a146b615",
+                "sha256:7743798dfb573d006f1143d745bf17efad39775a5190b347da5d83079646be56",
+                "sha256:78a2a885345a2d60b5e68099e877757d5ed12e46ba1e87507175f14f80892af3",
+                "sha256:849802379a660206277675aa5a5c327f5c910c690649535863ddf329b0ba8c87",
+                "sha256:8cf6728f89b071bd3ab37cb8a0e306f4de897553a0ed07442015ee65fbf53d62",
+                "sha256:a1b6a3f600d6aff97e3f28c34192c9ed93fee293bd96ef327b64adb51a74b2f6",
+                "sha256:a548bb51c4476332ce4139df8e637386730f79a92652a907d12c696b6252b64d",
+                "sha256:a8a5826d8a1b64e2ff9af488cc179e1a4d0f144d11ce486a9f34ea38ccedf4ef",
+                "sha256:b024ee43ee6b310fad5acaee23e6485b21468718cb792a9d1693eecacc3f0b7e",
+                "sha256:b092754c06852e8a8b022004aff56c24b06310189186805800d09313c37ce1f8",
+                "sha256:b1dbeef938281f240347d50f28ae53c4b046a23389cd1fc4acec5ea0eae646a1",
+                "sha256:bf819c5b77ff44accc9a24e31f1f7ceaaf6c960816913ed3ef8443b9d20d81b6",
+                "sha256:c11f2fca544b5e30a0e813023196a63b1cb9869106ef9a26e9dae28bce3e4e26",
+                "sha256:ce269e903b00d1ab4746793e9c50a57eec5d5388681abef074d7b9a65748fca5",
+                "sha256:d0cf2651a8804f6325747c7e55e3be0f90ee2848e25d6b817aa2728d263f9abb",
+                "sha256:e07e92935040c67f49571779d115ecb3e727016d42fb36ee0d8757db4ca12ee0",
+                "sha256:e80d2851109e56420b71f9702ad1646e2f0364528adbf6af85527bc61e49f394",
+                "sha256:ed77b97896312bc2deafe137ca2626e8b63808f5bedb944f73665c68093688a7",
+                "sha256:f32f47fb22c988c0b35756024b61d156e5c4011cb8004aa53d93b03323c45657",
+                "sha256:fdad3122b69cdabdb3da4c2a4107875913ac78dab0117fc73f988ad589c66b66"
             ],
-            "version": "==2021.4.4"
+            "version": "==2021.7.1"
         },
         "requests": {
             "hashes": [
@@ -878,16 +875,16 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c",
-                "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"
+                "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
+                "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.5"
+            "version": "==1.26.6"
         }
     }
 }

--- a/quark/Objects/axmlreader/__init__.py
+++ b/quark/Objects/axmlreader/__init__.py
@@ -1,0 +1,301 @@
+import enum
+import functools
+import os.path
+
+import rzpipe
+
+# Resource Types Definition
+# Please reference to
+# https://android.googlesource.com/platform/frameworks/base/+/master/libs/androidfw/include/androidfw/ResourceTypes.h
+
+# ResChunk_header types
+RES_NULL_TYPE = 0x0000
+RES_STRING_POOL_TYPE = 0x0001
+RES_TABLE_TYPE = 0x0002
+RES_XML_TYPE = 0x0003
+
+# Chunk types in RES_XML_TYPE
+RES_XML_FIRST_CHUNK_TYPE = 0x0100
+RES_XML_START_NAMESPACE_TYPE = 0x0100
+RES_XML_END_NAMESPACE_TYPE = 0x0101
+RES_XML_START_ELEMENT_TYPE = 0x0102
+RES_XML_END_ELEMENT_TYPE = 0x0103
+RES_XML_CDATA_TYPE = 0x0104
+RES_XML_LAST_CHUNK_TYPE = 0x017F
+RES_XML_RESOURCE_MAP_TYPE = 0x0180
+
+# Chunk types in RES_TABLE_TYPE
+RES_TABLE_PACKAGE_TYPE = 0x0200
+RES_TABLE_TYPE_TYPE = 0x0201
+RES_TABLE_TYPE_SPEC_TYPE = 0x0202
+RES_TABLE_LIBRARY_TYPE = 0x0203
+RES_TABLE_OVERLAYABLE_TYPE = 0x0204
+RES_TABLE_OVERLAYABLE_POLICY_TYPE = 0x0205
+
+
+class Res_value_type(enum.Enum):
+    TYPE_NULL = (0x00,)
+    TYPE_REFERENCE = (0x01,)
+    TYPE_ATTRIBUTE = (0x02,)
+    TYPE_STRING = (0x03,)
+    TYPE_FLOAT = (0x04,)
+    TYPE_DIMENSION = (0x05,)
+    TYPE_FRACTION = (0x06,)
+    TYPE_DYNAMIC_REFERENCE = (0x07,)
+    TYPE_DYNAMIC_ATTRIBUTE = (0x08,)
+    TYPE_FIRST_INT = (0x10,)
+    TYPE_INT_DEC = (0x10,)
+    TYPE_INT_HEX = (0x11,)
+    TYPE_INT_BOOLEAN = (0x12,)
+    TYPE_FIRST_COLOR_INT = (0x1C,)
+    TYPE_INT_COLOR_ARGB8 = (0x1C,)
+    TYPE_INT_COLOR_RGB8 = (0x1D,)
+    TYPE_INT_COLOR_ARGB4 = (0x1E,)
+    TYPE_INT_COLOR_RGB4 = (0x1F,)
+    TYPE_LAST_COLOR_INT = (0x1F,)
+    TYPE_LAST_INT = 0x1F
+
+
+class AxmlException(Exception):
+    """
+    A Exception for AxmlReader
+    """
+
+    def __init__(self, message):
+        super(AxmlException, self).__init__(message)
+
+
+class AxmlReader(object):
+    """
+    A Class that parses the Android XML file
+    """
+
+    def __init__(self, file_path, structure_path=None):
+        if structure_path is None:
+            directory = os.path.dirname(__file__)
+            structure_path = os.path.join(directory, "axml_definition")
+
+        if not os.path.isfile(structure_path):
+            raise AxmlException(
+                f"Cannot find printing format definition file"
+                f" of Rizin in {structure_path}"
+            )
+
+        self._rz = rzpipe.open(file_path)
+        self._rz.cmd(f"pfo {structure_path}")
+
+        self._file_size = int(self._rz.cmd("i~size[1]"), 16)
+        self._ptr = 0
+
+        self._cache = {}
+
+        if self._file_size > 0xFFFF_FFFF:
+            raise AxmlException("Filesize exceeds theoretical upper bound.")
+        elif self._file_size < 8:
+            raise AxmlException("Filesize exceeds theoretical lower bound.")
+
+        # File Header
+        header = self._rz.cmdj("pfj axml_ResChunk_header @ 0x0")
+
+        self._data_type = header[0]["value"]
+        self._axml_size = header[2]["value"]
+        header_size = header[1]["value"]
+
+        if self._data_type != RES_XML_TYPE or header_size != 0x8:
+            raise AxmlException(
+                f"Error parsing first header(type: {self._data_type},"
+                f" size: {header_size})."
+            )
+
+        if self._axml_size > self._file_size:
+            raise AxmlException(
+                f"Decleared size ({self._axml_size} bytes) is"
+                f" larger than total size({self._file_size})."
+            )
+
+        self._ptr += 8
+        if self._ptr >= self._axml_size:
+            return
+
+        # String Pool
+        string_pool_header = self._rz.cmdj("pfj axml_ResStringPool_header @ 8")
+
+        string_pool_size = string_pool_header[0]["value"][2]["value"]
+
+        if string_pool_size > self._axml_size - self._ptr:
+            raise AxmlException(
+                f"Error parsing string pool, there should"
+                f" be {string_pool_size}"
+                f" bytes but only {self._axml_size - self._ptr} bytes."
+            )
+
+        header = string_pool_header[0]["value"]
+        header_type = header[0]["value"]
+        header_size = header[1]["value"]
+
+        if header_type != RES_STRING_POOL_TYPE:
+            raise AxmlException(
+                f"Error parsing string pool, expect string pool"
+                f" data at {self._ptr} bytes."
+            )
+
+        if header_size != 28:
+            raise AxmlException(
+                f"Error parsing string pool, heardsize should "
+                f"be 16 bytes rather than { header_size } bytes."
+            )
+
+        self._stringCount = string_pool_header[1]["value"]
+        stringStart = string_pool_header[4]["value"]
+
+        self._rz.cmd(f"f string_pool_header @ 0x8 ")
+        string_pool_index = header_size + self._ptr
+        self._rz.cmd(f"f string_pool_index @ { string_pool_index }")
+        string_pool_data = stringStart + self._ptr
+        self._rz.cmd(f"f string_pool_data @ { string_pool_data }")
+
+        self._ptr += string_pool_size
+        if self._ptr >= self._axml_size:
+            return
+
+        # Resource Map (Optional)
+        header = self._rz.cmdj(f"pfj axml_ResChunk_header @ {self._ptr}")
+
+        header_type = header[0]["value"]
+        if header_type == RES_XML_RESOURCE_MAP_TYPE:
+            map_size = header[2]["value"]
+
+            # Skip all the resource map
+
+            if map_size > self._axml_size - self._ptr:
+                raise AxmlException(
+                    f"Map size should be {map_size} bytes rather"
+                    f" than {self._axml_size - self._ptr} bytes."
+                )
+
+            self._ptr += map_size
+            if self._ptr >= self._axml_size:
+                return
+
+    def __iter__(self):
+        while self._axml_size - self._ptr >= 16:
+            header = self._rz.cmdj(f"pfj axml_ResXMLTree_node @ {self._ptr}")
+
+            node_type = header[0]["value"][0]["value"]
+            header_size = header[0]["value"][1]["value"]
+            node_size = header[0]["value"][2]["value"]
+
+            if header_size != 16:
+                raise AxmlException(
+                    f"heardsize should be 16 bytes rather"
+                    f" than { header_size } bytes."
+                )
+
+            if node_size > self._axml_size - self._ptr:
+                raise AxmlException(
+                    f"Not enough data left, need {node_size} bytes"
+                    f" but {self._axml_size - self._ptr} bytes left."
+                )
+
+            ext_ptr = self._ptr + 16
+
+            node = {"Address": self._ptr, "Type": node_type}
+
+            if node_type == RES_XML_START_ELEMENT_TYPE:
+                ext = self._rz.cmdj(
+                    f"pfj axml_ResXMLTree_attrExt @ { ext_ptr }"
+                )
+
+                node["Namespace"] = ext[0]["value"][0]["value"]
+                node["Name"] = ext[1]["value"][0]["value"]
+
+                # Attributes
+                # node['AttrCount'] = ext[4]['value']
+
+            elif node_type == RES_XML_END_ELEMENT_TYPE:
+                ext = self._rz.cmdj(
+                    f"pfj axml_ResXMLTree_endElementExt @ { ext_ptr }"
+                )
+
+                node["Namespace"] = ext[0]["value"][0]["value"]
+                node["Name"] = ext[1]["value"][0]["value"]
+
+            elif node_type in [
+                RES_XML_START_NAMESPACE_TYPE,
+                RES_XML_END_NAMESPACE_TYPE,
+            ]:
+                ext = self._rz.cmdj(
+                    f"pfj axml_ResXMLTree_namespaceExt @ { ext_ptr }"
+                )
+
+                node["Prefix"] = ext[0]["value"][0]["value"]
+                node["Uri"] = ext[1]["value"][0]["value"]
+
+            elif node_type == RES_XML_CDATA_TYPE:
+                ext = self._rz.cmdj(
+                    f"pfj axml_ResXMLTree_cdataExt @ { ext_ptr }"
+                )
+
+                node["Data"] = ext[0]["value"][0]["value"]
+                # typedData
+
+            else:
+                self._ptr = self._ptr + node_size
+                continue
+
+            self._ptr = self._ptr + node_size
+            yield node
+
+    @property
+    def file_size(self):
+        return self._file_size
+
+    @property
+    def axml_size(self):
+        return self._axml_size
+
+    @functools.lru_cache()
+    def get_string(self, index):
+        if index < 0 or index >= self._stringCount:
+            return None
+
+        return self._rz.cmdj(
+            f"pfj Z @ string_pool_data + `pfv n4 "
+            f"@ string_pool_index+ {index}*4` + 2"
+        )[0]["string"]
+
+    def get_attributes(self, node):
+        if node["Type"] != RES_XML_START_ELEMENT_TYPE:
+            return None
+        extAddress = int(node["Address"]) + 16
+
+        attrExt = self._rz.cmdj(f"pfj axml_ResXMLTree_attrExt @ {extAddress}")
+
+        attrAddress = extAddress + attrExt[2]["value"]
+        attributeSize = attrExt[3]["value"]
+        attributeCount = attrExt[4]["value"]
+        result = []
+        for _ in range(attributeCount):
+            attr = self._rz.cmdj(
+                f"pfj axml_ResXMLTree_attribute @ {attrAddress}"
+            )
+
+            result.append(
+                {
+                    "Namespace": attr[0]["value"][0]["value"],
+                    "Name": attr[1]["value"][0]["value"],
+                    "Value": attr[2]["value"][0]["value"],
+                    "Type": attr[3]["value"][2]["value"],
+                    "Data": attr[3]["value"][3]["value"],
+                }
+            )
+
+            attrAddress = attrAddress + attributeSize
+
+        return result
+
+    def __del__(self):
+        try:
+            self._rz.quit()
+        except BaseException:
+            pass

--- a/quark/Objects/axmlreader/axml_definition
+++ b/quark/Objects/axmlreader/axml_definition
@@ -1,0 +1,22 @@
+# Base Type
+pf.axml_ResChunk_header n2n2n4 type headersize size
+pf.axml_Res_value n2n1n1n4 size res0 datatype data
+
+# String Pool
+pf.axml_ResStringPool_ref n4 index
+pf.axml_ResStringPool_header ?n4n4n4n4n4 (axml_ResChunk_header)header stringCount styleCount flags stringStart styleStart
+
+# XML Part
+pf.axml_ResXMLTree_header ? (axml_ResChunk_header)header
+pf.axml_ResXMLTree_node ?n4? (axml_ResChunk_header)header lineNumber (axml_ResStringPool_ref)comment
+
+pf.axml_ResXMLTree_cdataExt ?? (axml_ResStringPool_ref)data (axml_Res_value)typedData
+pf.axml_ResXMLTree_namespaceExt ?? (axml_ResStringPool_ref)prefix (axml_ResStringPool_ref)uri
+pf.axml_ResXMLTree_endElementExt ?? (axml_ResStringPool_ref)ns (axml_ResStringPool_ref)name
+pf.axml_ResXMLTree_attrExt ??n2n2n2n2n2n2 (axml_ResStringPool_ref)ns (axml_ResStringPool_ref)name attributeStart attributeSize attributeCount idIndex classIndex styleIndex
+
+pf.axml_ResXMLTree_attribute ???? (axml_ResStringPool_ref)ns (axml_ResStringPool_ref)name (axml_ResStringPool_ref)rawValue (axml_Res_value)typedValue
+
+# Resource Table
+pf.axml_ResTable_header ?n4 (axml_ResChunk_header)header packageCount
+pf.axml_ResTable_package ?n4[128]n2n4n4n4n4n4 (axml_ResChunk_header)header id name typeStrings lastPublicType keyStrings lastPublicKey typeIdOffset

--- a/quark/Objects/quark.py
+++ b/quark/Objects/quark.py
@@ -309,6 +309,10 @@ class Quark:
         first_api_xref_from = self.apkinfo.upperfunc(first_api)
         second_api_xref_from = self.apkinfo.upperfunc(second_api)
 
+        if not (first_api_xref_from and second_api_xref_from):
+            # Exit if the upper function is not found (for Rizin library).
+            return
+
         mutual_parent_function_list = self.find_intersection(
             first_api_xref_from, second_api_xref_from
         )

--- a/quark/Objects/quark.py
+++ b/quark/Objects/quark.py
@@ -10,7 +10,8 @@ import pandas as pd
 
 from quark.Evaluator.pyeval import PyEval
 from quark.Objects.analysis import QuarkAnalysis
-from quark.Objects.apkinfo import AndroguardImp as Apkinfo
+from quark.Objects.apkinfo import AndroguardImp
+from quark.Objects.rzapkinfo import RizinImp
 from quark.utils import tools
 from quark.utils.colors import (
     red,
@@ -37,12 +38,20 @@ MAX_SEARCH_LAYER = 3
 class Quark:
     """Quark module is used to check quark's five-stage theory"""
 
-    def __init__(self, apk):
+    def __init__(self, apk, core_library="androguard"):
         """
 
         :param apk: the filename of the apk.
         """
-        self.apkinfo = Apkinfo(apk)
+        core_library = core_library.lower()
+        if core_library == "rizin":
+            self.apkinfo = RizinImp(apk)
+        elif core_library == "androguard":
+            self.apkinfo = AndroguardImp(apk)
+        else:
+            raise ValueError(
+                f"Unsupported core library for Quark: {core_library}"
+            )
 
         self.quark_analysis = QuarkAnalysis()
 

--- a/quark/Objects/rzapkinfo.py
+++ b/quark/Objects/rzapkinfo.py
@@ -1,0 +1,390 @@
+import functools
+import logging
+import os.path
+import re
+import tempfile
+import zipfile
+from collections import defaultdict, namedtuple
+from os import PathLike
+from typing import Dict, Generator, List, Optional, Set, Union
+
+import rzpipe
+
+from quark.Objects.axmlreader import AxmlReader
+from quark.Objects.interface.baseapkinfo import BaseApkinfo
+from quark.Objects.struct.bytecodeobject import BytecodeObject
+from quark.Objects.struct.methodobject import MethodObject
+
+RizinCache = namedtuple("rizin_cache", "address dexindex is_imported")
+
+
+class RizinImp(BaseApkinfo):
+
+    __slots__ = ["_tmp_dir", "_dex_list", "_number_of_dex", "_manifest"]
+
+    def __init__(
+        self,
+        apk_filepath: Union[str, PathLike],
+        tmp_dir: Union[str, PathLike] = None,
+    ):
+        super().__init__(apk_filepath, "rizin")
+
+        if self.ret_type == "DEX":
+            self._tmp_dir = None
+            self._dex_list = [apk_filepath]
+
+        elif self.ret_type == "APK":
+            self._tmp_dir = tempfile.mkdtemp() if tmp_dir is None else tmp_dir
+
+            with zipfile.ZipFile(self.apk_filepath) as apk:
+                apk.extract("AndroidManifest.xml", path=self._tmp_dir)
+
+                self._manifest = os.path.join(
+                    self._tmp_dir, "AndroidManifest.xml"
+                )
+
+                dex_files = [
+                    file
+                    for file in apk.namelist()
+                    if file.startswith("classes") and file.endswith(".dex")
+                ]
+
+                for dex in dex_files:
+                    apk.extract(dex, path=self._tmp_dir)
+
+                self._dex_list = [
+                    os.path.join(self._tmp_dir, dex) for dex in dex_files
+                ]
+
+        else:
+            raise ValueError("Unsupported File type.")
+
+        self._number_of_dex = len(self._dex_list)
+
+    @functools.lru_cache
+    def _get_rz(self, index):
+        rz = rzpipe.open(self._dex_list[index])
+        rz.cmd("aa")
+        return rz
+
+    @functools.lru_cache
+    def _get_methods_classified(self, dexindex):
+        rz = self._get_rz(dexindex)
+
+        method_json_list = rz.cmdj("isj")
+        method_dict = defaultdict(list)
+        for json_obj in method_json_list:
+            if json_obj.get("type") not in ["FUNC", "METH"]:
+                continue
+
+            full_name = json_obj["realname"]
+            class_name, method_descriptor = full_name.split(
+                ".method.", maxsplit=1
+            )
+            class_name = class_name + ";"
+
+            l_index = method_descriptor.index("(")
+            r_index = method_descriptor.index(")")
+            methodname = method_descriptor[:l_index]
+            argument_string = method_descriptor[l_index:r_index]
+            argument_string = (
+                "("
+                + " ".join(re.findall(r"L.+?;|[ZBCSIJFD]|\[", argument_string))
+                + ")"
+            )
+
+            argument_string = re.sub(r"\[ ", "[", argument_string)
+
+            return_value = method_descriptor[
+                method_descriptor.index(")") + 1:
+            ]
+            descriptor = argument_string + return_value
+
+            is_imported = json_obj["is_imported"]
+
+            method = MethodObject(
+                class_name=class_name,
+                name=methodname,
+                descriptor=descriptor,
+                cache=RizinCache(json_obj["vaddr"], dexindex, is_imported),
+            )
+            method_dict[class_name].append(method)
+
+        return method_dict
+
+    @property
+    def permissions(self) -> List[str]:
+        axml = AxmlReader(self._manifest)
+        permission_list = set()
+
+        for tag in axml:
+            label = tag.get("Name")
+            if label and axml.get_string(label) == "uses-permission":
+                attrs = axml.get_attributes(tag)
+
+                if attrs:
+                    permission = axml.get_string(attrs[0]["Value"])
+                    permission_list.add(permission)
+
+        return permission_list
+
+    @property
+    def android_apis(self) -> Set[MethodObject]:
+        return {
+            method
+            for method in self.all_methods
+            if method.is_android_api() and method.cache.is_imported
+        }
+
+    @property
+    def custom_methods(self) -> Set[MethodObject]:
+        return {
+            method
+            for method in self.all_methods
+            if not method.cache.is_imported
+        }
+
+    @property
+    def all_methods(self) -> Set[MethodObject]:
+        method_set = set()
+        for dex_index in range(self._number_of_dex):
+            for method_list in self._get_methods_classified(
+                dex_index
+            ).values():
+                method_set.update(method_list)
+
+        return method_set
+
+    def find_method(
+        self,
+        class_name: Optional[str] = ".*",
+        method_name: Optional[str] = ".*",
+        descriptor: Optional[str] = ".*",
+    ) -> MethodObject:
+        def method_filter(method):
+            return (not method_name or method_name == method.name) and (
+                not descriptor or descriptor == method.descriptor
+            )
+
+        dex_list = range(self._number_of_dex)
+
+        for dex_index in dex_list:
+            method_dict = self._get_methods_classified(dex_index)
+            filtered_methods = filter(method_filter, method_dict[class_name])
+            try:
+                return next(filtered_methods)
+            except StopIteration:
+                continue
+
+    @functools.lru_cache
+    def upperfunc(self, method_object: MethodObject) -> Set[MethodObject]:
+        cache = method_object.cache
+
+        r2 = self._get_rz(cache.dexindex)
+
+        xrefs = r2.cmdj(f"axtj @ {cache.address}")
+
+        upperfunc_set = set()
+        for xref in xrefs:
+            if xref["type"] != "CALL":
+                continue
+
+            if "fcn_addr" in xref:
+                upperfunc_set.add(
+                    self._get_method_by_address(xref["fcn_addr"])
+                )
+            else:
+                logging.debug(
+                    f"Key from was not found at searching"
+                    f" upper methods for {method_object}."
+                )
+
+        return upperfunc_set
+
+    @functools.lru_cache
+    def lowerfunc(self, method_object: MethodObject) -> Set[MethodObject]:
+        cache = method_object.cache
+
+        r2 = self._get_rz(cache.dexindex)
+
+        xrefs = r2.cmdj(f"axffj @ {cache.address}")
+
+        if not xrefs:
+            return set()
+
+        lowerfunc_set = set()
+        for xref in xrefs:
+            if xref["type"] != "CALL":
+                continue
+
+            if "to" in xref:
+                lowerfunc_set.add(
+                    (
+                        self._get_method_by_address(xref["to"]),
+                        xref["from"] - cache.address,
+                    )
+                )
+            else:
+                logging.debug(
+                    f"Key from was not found at searching"
+                    f" upper methods for {method_object}."
+                )
+
+        return lowerfunc_set
+
+    def get_method_bytecode(
+        self, method_object: MethodObject
+    ) -> Generator[BytecodeObject, None, None]:
+        cache = method_object.cache
+
+        if not cache.is_imported:
+
+            rz = self._get_rz(cache.dexindex)
+
+            instruct_flow = rz.cmdj(f"pdfj @ {cache.address}")["ops"]
+
+            if instruct_flow:
+                for ins in instruct_flow:
+                    yield self._parse_smali(ins["disasm"])
+
+    def get_strings(self) -> Set[str]:
+        strings = set()
+        for dex_index in range(self._number_of_dex):
+            rz = self._get_rz(dex_index)
+
+            string_detail_list = rz.cmdj("izzj")
+            strings.update(
+                [
+                    string_detail["string"]
+                    for string_detail in string_detail_list
+                ]
+            )
+
+        return strings
+
+    def get_wrapper_smali(
+        self,
+        parent_method: MethodObject,
+        first_method: MethodObject,
+        second_method: MethodObject,
+    ) -> Dict[str, Union[BytecodeObject, str]]:
+        def convert_bytecode_to_list(bytecode):
+            return (
+                [bytecode.mnemonic] + bytecode.registers + [bytecode.parameter]
+            )
+
+        cache = parent_method.cache
+
+        result = {
+            "first": None,
+            "first_hex": None,
+            "second": None,
+            "second_hex": None,
+        }
+
+        search_pattern = "{class_name}.{name}{descriptor}"
+        first_method_pattern = search_pattern.format(
+            class_name=first_method.class_name[:-1],
+            name=first_method.name,
+            descriptor=first_method.descriptor,
+        )
+        second_method_pattern = search_pattern.format(
+            class_name=second_method.class_name[:-1],
+            name=second_method.name,
+            descriptor=second_method.descriptor,
+        )
+
+        if cache.is_imported:
+            return {}
+
+        rz = self._get_rz(cache.dexindex)
+
+        instruction_flow = rz.cmdj(f"pdfj @ {cache.address}")["ops"]
+
+        if instruction_flow:
+            for ins in instruction_flow:
+                if ins["disasm"].startswith("invoke"):
+                    if ";" in ins["disasm"]:
+                        index = ins["disasm"].rindex(";")
+                        instrcution_string = ins["disasm"][:index]
+
+                    if first_method_pattern in instrcution_string:
+                        result["first"] = convert_bytecode_to_list(
+                            self._parse_smali(instrcution_string)
+                        )
+                        result["first_hex"] = " ".join(
+                            map(
+                                lambda r: r.group(0),
+                                re.finditer(r"\w{2}", ins["bytes"]),
+                            )
+                        )
+                    if second_method_pattern in instrcution_string:
+                        result["second"] = convert_bytecode_to_list(
+                            self._parse_smali(instrcution_string)
+                        )
+                        result["second_hex"] = " ".join(
+                            map(
+                                lambda r: r.group(0),
+                                re.finditer(r"\w{2}", ins["bytes"]),
+                            )
+                        )
+
+        return result
+
+    def _get_method_by_address(self, address: int) -> MethodObject:
+        if address < 0:
+            return None
+
+        for method in self.all_methods:
+            if method.cache.address == address:
+                return method
+
+    @staticmethod
+    def _parse_smali(smali: str) -> BytecodeObject:
+        if smali == "":
+            raise ValueError("Argument cannot be empty.")
+
+        if " " not in smali:
+            return BytecodeObject(smali, None, None)
+
+        mnemonic, args = smali.split(maxsplit=1)  # Split into twe parts
+
+        # invoke-kind instruction may left method index at the last
+        if mnemonic.startswith("invoke"):
+            args = args[: args.rfind(" ;")]
+
+        args = [arg.strip() for arg in re.split("[{},]+", args) if arg]
+
+        parameter = None
+        # Remove the parameter at the last
+        if args and not args[-1].startswith("v"):
+            parameter = args[-1]
+            args = args[:-1]
+
+            if mnemonic.startswith("invoke"):
+                parameter = re.sub(r"\.", ";->", parameter, count=1)
+
+        register_list = None
+        # Ranged registers
+        if len(args) == 1 and (":" in args[0] or ".." in args[0]):
+            register_list = args[0]
+            register_list = [
+                int(reg[1:]) for reg in re.split("[:.]+", register_list) if reg
+            ]
+
+            if ".." in args[0]:
+                register_list = range(register_list[0], register_list[1] + 1)
+
+        # Simple registers
+        elif len(args) != 0:
+            try:
+                register_list = [int(arg[1:]) for arg in args]
+            except ValueError:
+                raise ValueError(
+                    f"Cannot parse bytecode. Unknown smali {smali}."
+                )
+
+        if register_list:
+            register_list = [f"v{index}" for index in register_list]
+
+        return BytecodeObject(mnemonic, register_list, parameter)

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -111,6 +111,14 @@ logo()
     required=False,
     is_flag=True,
 )
+@click.option(
+    "--core-library",
+    "core_library",
+    help="Specify the core library used to analyze an APK",
+    type=click.Choice(("androguard", "rizin"), case_sensitive=False),
+    required=False,
+    default="androguard",
+)
 def entry_point(
     summary,
     detail,
@@ -124,11 +132,12 @@ def entry_point(
     permission,
     label,
     comparison,
+    core_library,
 ):
     """Quark is an Obfuscation-Neglect Android Malware Scoring System"""
 
     # Load APK
-    data = Quark(apk[0])
+    data = Quark(apk[0], core_library)
 
     # Load rules
     rules_list = [file for file in os.listdir(rule) if file.endswith("json")]

--- a/quark/forensic/forensic.py
+++ b/quark/forensic/forensic.py
@@ -2,7 +2,8 @@
 # This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
 # See the file 'LICENSE' for copying permission.
 
-from quark.Objects.apkinfo import AndroguardImp as Apkinfo
+from quark.Objects.apkinfo import AndroguardImp
+from quark.Objects.rzapkinfo import RizinImp
 from quark.utils.regex import (
     extract_url,
     extract_ip,
@@ -15,8 +16,12 @@ from quark.utils.regex import (
 class Forensic:
     __slots__ = ["apk", "all_strings"]
 
-    def __init__(self, apkpath):
-        self.apk = Apkinfo(apkpath)
+    def __init__(self, apkpath, core_library="androguard"):
+        if core_library == "rizin":
+            self.apk = RizinImp(apkpath)
+        elif core_library == "androguard":
+            self.apk = AndroguardImp(apkpath)
+
         self.all_strings = self.apk.get_strings()
 
     def get_all_strings(self):

--- a/quark/report.py
+++ b/quark/report.py
@@ -16,7 +16,7 @@ class Report:
     def __init__(self):
         self.quark = None
 
-    def analysis(self, apk, rule):
+    def analysis(self, apk, rule, core_library="androguard"):
         """
         The main function of Quark-Engine analysis, the analysis is based on the provided APK file.
 
@@ -25,7 +25,7 @@ class Report:
         :return: None
         """
 
-        self.quark = Quark(apk)
+        self.quark = Quark(apk, core_library)
 
         if os.path.isdir(rule):
 

--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,6 @@ setuptools.setup(
         "pandas",
         "prompt-toolkit==3.0.19",
         "plotly",
+        "rzpipe",
     ],
 )


### PR DESCRIPTION
**Description**

Quark needs an alternate core library apart from Androguard. Here are the concerns of the Quark team.

1. Androguard is no longer maintained. ([#833](https://github.com/androguard/androguard/issues/833#issue-748070493) from Androguard)
2. Androguard takes up too much memory during analysis. ([#130](https://github.com/quark-engine/quark-engine/issues/130#issue-809891871))

Hence, this PR aims to add a core library based on [Rizin](https://github.com/rizinorg/rizin).

**Why is Rizin?**

Rizin is a fork of the radare2 reverse engineering tools. Here are the advantages.

1. A strong community supports the project.
2. It provides analysis assists that cover the functions of Androguard.
3. It focuses on usability and working features.

**How to enable it?**

**Command Line**

Add an option --core-library with the parameter Rizin.

```bash
quark --core-library "Rizin" -a APK_FILE -s
```

**Python Module**

Add a keyword argument named "core_library" with the string Rizin.

```python
from quark.report import Report

report = Report(APK_FILE, core_library="Rizin")
```

**How accurate is the Rizin-based core library?**

For now, most of the analysis results are not correct.

The reason is that Rizin doesn't fully support the following analysis on APKs.

1. Multi-dex analysis
2. Comprehensive cross-references between methods

I have reported these issues to the Rizin community. They are currently working on them.

Also, to ensure the core library works with those functions in the future, I made two assumptions to build the core library.

1. The commands in Rizin have handled the multi-dex issue.
2. The cross-reference provided by Rizin is correct.

Once Rizin fixes the above issues, the core library will work as expected.

**How do you prove your code is reliable?**

I collected a set of rules that are not impacted by the above issues to verify the analysis results.

For example, 0007.json is one of these rules.

The confidence has been confirmed 100% by the Androguard-based core library.

![](https://i.imgur.com/BUcdIYY.png)

Then, I will ensure that the Rizin-based core library reports the same confidence.

![](https://i.imgur.com/53GdkUB.png)

**Code Changes**

+ **quark/Objects/axmlreader/\***

   - A Rizin-based AndroidManifest Reader for the core library

+ **quark/Objects/rzapkinfo.py**
   - A file that stores the Rizin-based core library

+ **quark/Objects/quark.py**
  - Add an if-statement to check if the references exist.
  - Add a keyword argument to specify the core library.

+ **quark/Objects/forensic.py** and **quark/report.py**
  - Add a keyword argument to specify the core library.
  
+ **quark/cli.py**
  - Add an option --core-library to specify the core library.

+ **Pipfile** and **setup.py**
  + Add rzpipe package.

**Test Plans**
+ Ensure the PR passes all existing tests.