### PR TITLE
Improve the tainted analysis of Quark

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -72,9 +72,9 @@ jobs:
           fi
           
       - name: Check 14d9f1a92dd984d6040cc41ed06e273e.apk Result
-        # This sample should have 12 behaviors with 100% confidence
+        # This sample should have 14 behaviors with 100% confidence
         run: |
-          if [ "${{ env.e273e_RESULT }}" == "12" ]; then
+          if [ "${{ env.e273e_RESULT }}" == "14" ]; then
             exit 0
           else
             exit 1

--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -53,6 +53,8 @@ class PyEval:
             "new-instance": self.NEW_INSTANCE,
             # const-kind
             "const-string": self.CONST_STRING,
+            "const-string/jumbo": self.CONST_STRING,
+            "const-class": self.CONST,
             "const": self.CONST,
             "const/4": self.CONST_FOUR,
             "const/16": self.CONST_SIXTEEN,

--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -43,6 +43,8 @@ class PyEval:
             "invoke-static": self.INVOKE_STATIC,
             "invoke-virtual/range": self.INVOKE_VIRTUAL_RANGE,
             "invoke-interface": self.INVOKE_INTERFACE,
+            "invoke-polymorphic": self.INVOKE_POLYMORPHIC,
+            "invoke-custom": self.INVOKE_CUSTOM,
             # move-result-kind
             "move-result": self.MOVE_RESULT,
             "move-result-wide": self.MOVE_RESULT_WIDE,
@@ -172,6 +174,12 @@ class PyEval:
         invoke-interface { parameters }, methodtocall
         Invokes a interface method with parameters.
         """
+        self._invoke(instruction)
+
+    def INVOKE_POLYMORPHIC(self, instruction):
+        self._invoke(instruction)
+
+    def INVOKE_CUSTOM(self, instruction):
         self._invoke(instruction)
 
     @logger

--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -13,12 +13,12 @@ from quark.Objects.struct.registerobject import RegisterObject
 from quark.Objects.struct.tableobject import TableObject
 
 MAX_REG_COUNT = 40
-TIMESTAMPS = datetime.now().strftime('%Y-%m-%d')
+TIMESTAMPS = datetime.now().strftime("%Y-%m-%d")
 LOG_FILENAME = f"{TIMESTAMPS}.quark.log"
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
-handler = logging.FileHandler(LOG_FILENAME, mode='w')
-format_str = '%(asctime)s %(levelname)s [%(lineno)d]: %(message)s'
+handler = logging.FileHandler(LOG_FILENAME, mode="w")
+format_str = "%(asctime)s %(levelname)s [%(lineno)d]: %(message)s"
 handler.setFormatter(logging.Formatter(format_str))
 log.addHandler(handler)
 
@@ -151,7 +151,9 @@ class PyEval:
             if obj_stack:
                 # add the function name into each parameter table
                 var_obj = self.table_obj.pop(index)
-                var_obj.called_by_func = f"{executed_fuc}({','.join(value_of_reg_list)})"
+                var_obj.called_by_func = (
+                    f"{executed_fuc}({','.join(value_of_reg_list)})"
+                )
 
         # push the return value into ret_stack
         self.ret_stack.append(f"{executed_fuc}({','.join(value_of_reg_list)})")

--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -60,7 +60,7 @@ class PyEval:
             "const-wide/32": self.CONST_WIDE_THIRTY_TWO,
             "const-wide/high16": self.CONST_WIDE_HIGHSIXTEEN,
             # array
-            "aget-object": self.AGET_OBJECT,
+            "aget-object": self.AGET_KIND,
         }
 
         self.table_obj = TableObject(MAX_REG_COUNT)
@@ -318,9 +318,9 @@ class PyEval:
         self._assign_value_wide(instruction)
 
     @logger
-    def AGET_OBJECT(self, instruction):
+    def AGET_KIND(self, instruction):
         """
-        aget-object vx,vy,vz
+        aget-kind vx,vy,vz
 
         Gets an object reference value of an object reference array into vx. The array is referenced by vy and is
         indexed by vz.
@@ -346,7 +346,7 @@ class PyEval:
             self.table_obj.insert(index, variable_object)
 
         except IndexError as e:
-            log.exception(f"{e} in AGET_OBJECT")
+            log.exception(f"{e} in AGET_KIND")
 
     def show_table(self):
         return self.table_obj.get_table()

--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -96,7 +96,7 @@ class PyEval:
         # push the return value into ret_stack
         self.ret_stack.append(f"{executed_fuc}({','.join(value_of_reg_list)})")
 
-    def _move(self, instruction):
+    def _move_result(self, instruction):
 
         reg = instruction[1]
         index = int(reg[1:])
@@ -106,7 +106,7 @@ class PyEval:
             self.table_obj.insert(index, variable_object)
         except IndexError as e:
 
-            log.exception(f"{e} in _move")
+            log.exception(f"{e} in _move_result")
 
     def _assign_value(self, instruction):
 
@@ -184,7 +184,7 @@ class PyEval:
         Save the value returned by the previous function call to the vx register,and then insert the VariableObject
         into table.
         """
-        self._move(instruction)
+        self._move_result(instruction)
 
     @logger
     def MOVE_RESULT_WIDE(self, instruction):
@@ -215,7 +215,7 @@ class PyEval:
         into table.
         """
 
-        self._move(instruction)
+        self._move_result(instruction)
 
     @logger
     def NEW_INSTANCE(self, instruction):

--- a/quark/Objects/apkinfo.py
+++ b/quark/Objects/apkinfo.py
@@ -8,6 +8,7 @@ from os import PathLike
 from typing import Dict, List, Optional, Set, Union
 
 from androguard.core.analysis.analysis import MethodAnalysis
+from androguard.core.bytecodes.dvm_types import Operand
 from androguard.misc import AnalyzeAPK, AnalyzeDex
 
 from quark.Objects.interface.baseapkinfo import BaseApkinfo
@@ -146,20 +147,28 @@ class AndroguardImp(BaseApkinfo):
                         None,
                     )
                 elif length_operands >= 2:
-                    # the last one is parameter, the other are registers.
-
-                    parameter = ins.get_operands()[length_operands - 1]
-                    for i in range(length_operands - 1):
-                        reg_list.append(
-                            "v" + str(ins.get_operands()[i][1]),
+                    # if the last one's type is not Operand, it is a parameter.
+                    if not isinstance(ins.get_operands()[-1][0], Operand):
+                        parameter = ins.get_operands()[-1]
+                        parameter = (
+                            parameter[2]
+                            if len(parameter) == 3
+                            else parameter[1]
                         )
-                    parameter = (
-                        parameter[2] if len(parameter) == 3 else parameter[1]
-                    )
+
+                        for i in range(length_operands - 1):
+                            reg_list.append(
+                                "v" + str(ins.get_operands()[i][1]),
+                            )
+                    else:
+                        parameter = None
+                        for i in range(length_operands):
+                            reg_list.append(
+                                "v" + str(ins.get_operands()[i][1]),
+                            )
+
                     bytecode_obj = BytecodeObject(
-                        ins.get_name(),
-                        reg_list,
-                        parameter,
+                        ins.get_name(), reg_list, parameter
                     )
 
                 yield bytecode_obj

--- a/quark/Objects/struct/bytecodeobject.py
+++ b/quark/Objects/struct/bytecodeobject.py
@@ -23,6 +23,14 @@ class BytecodeObject:
     def __repr__(self):
         return f"<BytecodeObject-mnemonic:{self._mnemonic}, registers:{self._registers}, parameter:{self._parameter}>"
 
+    def __eq__(self, obj):
+        return (
+            isinstance(obj, BytecodeObject)
+            and obj.mnemonic == self.mnemonic
+            and obj.registers == self.registers
+            and obj.parameter == self.parameter
+        )
+
     @property
     def mnemonic(self):
         """

--- a/quark/Objects/struct/registerobject.py
+++ b/quark/Objects/struct/registerobject.py
@@ -30,6 +30,14 @@ class RegisterObject:
     def __repr__(self):
         return f"<VarabileObject-register:{self._register_name}, value:{self._value}, called_by_func:{','.join(self._called_by_func)}>"
 
+    def __eq__(self, obj):
+        return (
+            isinstance(obj, RegisterObject)
+            and obj.called_by_func == self.called_by_func
+            and obj.register_name == self.register_name
+            and obj.value == self.value
+        )
+
     @property
     def called_by_func(self):
         """

--- a/tests/Evaluator/test_pyeval.py
+++ b/tests/Evaluator/test_pyeval.py
@@ -296,6 +296,32 @@ class TestPyEval:
         )
         assert pyeval.table_obj.pop(8).called_by_func == []
 
+    def test_const_string_jumbo(self, pyeval):
+        instruction = [
+            "const-string/jumbo",
+            "v8",
+            "https://github.com/quark-engine/quark-engine",
+        ]
+
+        pyeval.eval[instruction[0]](instruction)
+
+        assert pyeval.table_obj.pop(8) == RegisterObject(
+            "v8", "https://github.com/quark-engine/quark-engine"
+        )
+
+    def test_const_class(self, pyeval):
+        instruction = [
+            "const-class",
+            "v8",
+            "Ljava/lang/Object;->toString()",
+        ]
+
+        pyeval.eval[instruction[0]](instruction)
+
+        assert pyeval.table_obj.pop(8) == RegisterObject(
+            "v8", "Ljava/lang/Object;->toString()"
+        )
+
     # Tests for const
     def test_const(self, pyeval):
         instruction = ["const", "v1", "string value"]

--- a/tests/Evaluator/test_pyeval.py
+++ b/tests/Evaluator/test_pyeval.py
@@ -116,7 +116,9 @@ class TestPyEval:
 
         pyeval._invoke(instruction)
 
-        assert pyeval.table_obj.pop(9).called_by_func == ["java.io.file.close()"]
+        assert pyeval.table_obj.pop(9).called_by_func == [
+            "java.io.file.close()"
+        ]
         assert pyeval.ret_stack == ["some-func()Lclass;()"]
 
     # Tests for invoke_virtual
@@ -151,31 +153,33 @@ class TestPyEval:
             pyeval.INVOKE_INTERFACE(instruction)
             mock.assert_called_once_with(instruction)
 
-    # Tests for _move
+    # Tests for _move_result
     def test_move_with_non_list_object(self, pyeval):
         instruction = None
 
         with pytest.raises(TypeError):
-            pyeval._move(instruction)
+            pyeval._move_result(instruction)
 
     def test_move_with_empty_list(self, pyeval):
         instruction = []
 
         with pytest.raises(IndexError):
-            pyeval._move(instruction)
+            pyeval._move_result(instruction)
 
     def test_move_with_invalid_instrcution(self, pyeval):
         instruction = ["move-kind", "", ""]
 
         with pytest.raises(ValueError):
-            pyeval._move(instruction)
+            pyeval._move_result(instruction)
 
     def test_move_with_valid_instrcution(self, pyeval):
         instruction = ["move-result-object", "v1"]
-        expected_return_value = "some_function()V(used_register_1, used_register_2)"
+        expected_return_value = (
+            "some_function()V(used_register_1, used_register_2)"
+        )
         pyeval.ret_stack.append(expected_return_value)
 
-        pyeval._move(instruction)
+        pyeval._move_result(instruction)
 
         assert pyeval.table_obj.pop(1).value == expected_return_value
         assert pyeval.table_obj.pop(1).called_by_func == []
@@ -184,7 +188,7 @@ class TestPyEval:
     def test_move_result_with_valid_mnemonic(self, pyeval):
         instruction = ["move-result", "v1"]
 
-        with patch("quark.Evaluator.pyeval.PyEval._move") as mock:
+        with patch("quark.Evaluator.pyeval.PyEval._move_result") as mock:
             pyeval.MOVE_RESULT(instruction)
             mock.assert_called_once_with(instruction)
 
@@ -203,7 +207,7 @@ class TestPyEval:
     def test_move_result_object_with_valid_mnemonic(self, pyeval):
         instruction = ["move-result-object", "v1"]
 
-        with patch("quark.Evaluator.pyeval.PyEval._move") as mock:
+        with patch("quark.Evaluator.pyeval.PyEval._move_result") as mock:
             pyeval.MOVE_RESULT_OBJECT(instruction)
             mock.assert_called_once_with(instruction)
 

--- a/tests/Evaluator/test_pyeval.py
+++ b/tests/Evaluator/test_pyeval.py
@@ -58,6 +58,24 @@ def pyeval():
     del pyeval
 
 
+MOVE_KIND = [
+    prefix + postfix
+    for prefix, postfix in itertools.product(
+        ["move", "move-object"], ["", "/from16", "/16"]
+    )
+] + ["array-length"]
+MOVE_WIDE_KIND = ["move-wide" + postfix for postfix in ["", "/from16", "/16"]]
+
+
+@pytest.fixture(scope="module", params=MOVE_KIND)
+def move_kind(request):
+    return request.param
+
+
+@pytest.fixture(scope="module", params=MOVE_WIDE_KIND)
+def move_wide_kind(request):
+    return request.param
+
 class TestPyEval:
     def test_init(self):
         pyeval = PyEval()
@@ -358,8 +376,26 @@ class TestPyEval:
             pyeval.CONST_HIGHSIXTEEN(instruction)
             mock.assert_called_once_with(instruction)
 
-    # Tests for aget-object
-    def test_aget_object(self, pyeval):
+    # Tests for move-kind
+    def test_move_kind(self, pyeval, move_kind):
+        instruction = [move_kind, "v1", "v4"]
+
+        pyeval.eval[instruction[0]](instruction)
+
+        assert pyeval.table_obj.pop(1) == RegisterObject(
+            "v1", "Lcom/google/progress/SMSHelper;"
+        )
+
+    def test_move_wide_kind(self, pyeval, move_wide_kind):
+        instruction = [move_wide_kind, "v1", "v4"]
+
+        pyeval.eval[instruction[0]](instruction)
+
+        assert pyeval.table_obj.pop(1) == RegisterObject(
+            "v1", "Lcom/google/progress/SMSHelper;"
+        )
+        assert pyeval.table_obj.pop(2) == RegisterObject("v2", "some_number")
+
         """
         aget-object vx,vy,vz
 

--- a/tests/Evaluator/test_pyeval.py
+++ b/tests/Evaluator/test_pyeval.py
@@ -318,7 +318,7 @@ class TestPyEval:
 
         instruction = ["aget-object", "v1", "v2", "v3"]
 
-        pyeval.AGET_OBJECT(instruction)
+        pyeval.AGET_KIND(instruction)
 
         pyeval.table_obj.pop(1).register_name == "v1"
         pyeval.table_obj.pop(1).value = "some_list_like[1,2,3,4][2]"

--- a/tests/Evaluator/test_pyeval.py
+++ b/tests/Evaluator/test_pyeval.py
@@ -619,7 +619,10 @@ class TestPyEval:
 
         assert pyeval.table_obj.pop(6) == RegisterObject(
             "v6",
-            "an_array[some_number]:(Lcom/google/progress/SMSHelper;, some_number)",
+            (
+                "an_array[some_number]:"
+                "(Lcom/google/progress/SMSHelper;, some_number)"
+            ),
         )
 
     # Tests for neg-kind and not-kind

--- a/tests/Object/test_apkinfo.py
+++ b/tests/Object/test_apkinfo.py
@@ -196,29 +196,28 @@ class TestApkinfo:
         expected_bytecode_list = [
             BytecodeObject(
                 "iput-object",
-                ["v1", "v0"],
-                "Lcom/example/google/service/WebServiceCalling$1;->this$0 Lcom/example/google/service/WebServiceCalling;",
+                ["v15", "v14"],
+                "Lcom/example/google/service/SMSReceiver;->_Context Landroid/content/Context;",
             ),
             BytecodeObject(
-                "invoke-direct", ["v0"], "Landroid/os/Handler;-><init>()V"
+                "invoke-direct",
+                ["v14", "v8"],
+                "Lcom/example/google/service/SMSReceiver;->isContact(Ljava/lang/String;)Ljava/lang/Boolean;",
             ),
+            BytecodeObject("array-length", ["v10", "v6"], None),
             BytecodeObject("return-void", None, None),
         ]
 
         method = apkinfo.find_method(
-            class_name="Lcom/example/google/service/WebServiceCalling$1;",
-            method_name="<init>",
-            descriptor="(Lcom/example/google/service/WebServiceCalling;)V",
+            class_name="Lcom/example/google/service/SMSReceiver;",
+            method_name="onReceive",
+            descriptor="(Landroid/content/Context; Landroid/content/Intent;)V",
         )
 
         bytecodes = list(apkinfo.get_method_bytecode(method))
 
-        for bytecode, expected_bytecode in zip(
-            bytecodes, expected_bytecode_list
-        ):
-            assert bytecode.mnemonic == expected_bytecode.mnemonic
-            assert bytecode.registers == expected_bytecode.registers
-            assert bytecode.parameter == expected_bytecode.parameter
+        for expected in expected_bytecode_list:
+            assert expected in bytecodes
 
     def test_lowerfunc(self, apkinfo):
         method = apkinfo.find_method(

--- a/tests/Object/test_apkinfo.py
+++ b/tests/Object/test_apkinfo.py
@@ -197,12 +197,18 @@ class TestApkinfo:
             BytecodeObject(
                 "iput-object",
                 ["v15", "v14"],
-                "Lcom/example/google/service/SMSReceiver;->_Context Landroid/content/Context;",
+                (
+                    "Lcom/example/google/service/SMSReceiver;->"
+                    "_Context Landroid/content/Context;"
+                ),
             ),
             BytecodeObject(
                 "invoke-direct",
                 ["v14", "v8"],
-                "Lcom/example/google/service/SMSReceiver;->isContact(Ljava/lang/String;)Ljava/lang/Boolean;",
+                (
+                    "Lcom/example/google/service/SMSReceiver;"
+                    "->isContact(Ljava/lang/String;)Ljava/lang/Boolean;"
+                ),
             ),
             BytecodeObject("array-length", ["v10", "v6"], None),
             BytecodeObject("return-void", None, None),


### PR DESCRIPTION
**Description**

This PR aims to add bytecode supports to enhance the tainted analysis. It introduced 227 instructions in total.

The selection principle is to cover all the instructions that make changes to registers.

All of them can be classified into the following five groups.
1. Transfer values between registers. (`move-kind`)
2. Create/access an array. (`new-array-kind`, `filled-array-kind`, `aput-kind`)
3. Perform binary and arithmetic operations.(`unop-kind`, `binop-kind`)
4. Function calls. (`invoke-polymorphic`, `invoke-custom`)
5. Load Java exceptions. (`move-exception`)

However, based on reasonable considerations, the PR excludes several instructions:

1. Instructions for branches - adding them would make the bytecode loader too complex.
2. Instructions for accessing objects - they are beyond the scope of Quark analysis.
3. Instructions that are for debug purposes. (`monitor-start`, `monitor-end`)
4. invoke-super - It requires Quark to support the Class inheritance mechanism

**Code changes**

1. **quark/Objects/pyeval.py**
   + Rename method _move() and AGET_OBJECT() to make them distinct from others.
   + Add all the instructions mentioned above.
2. **quark/Objects/apkinfo.py**
   + Fix that method get_method_bytecode generates incorrect Bytecode objects.
3. **quark/Objects/struct/bytecodeobject.py** and **registerobject.py**
   + Add \_\_ep\_\_ to have the tests of pyeval.py concise.

**Test Plans**

1. **tests/quark/Objects/test_pyeval.py**
   + Add tests for each instruction.
2. **tests/quark/Objects/apkinfo.py**
   + Modify the test to identify the issues of get_method_bytecode.
