### PR TITLE
Update travis.yml to set up Rizin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ language: python
 python: 3.8
 
 before-install:
+  - RIZIN_LATEST=https://github.com/rizinorg/rizin/releases/latest
+  - DOWNLOAD_URL='https://github.com'`curl -sfL $RIZIN_LATEST | grep 'href=\"/rizinorg/rizin/releases/'| grep 'static-x86_64'| cut -d \" -f 2`
+  - curl -sSfL --retry 5 -o rizin.tar.xz $DOWNLOAD_URL
+  - sudo mkdir -p /opt/rizin
+  - sudo tar -Jxf rizin.tar.xz --directory /opt/rizin
+  - PATH="/opt/rizin/bin:$PATH"
+  - export PATH
   - sudo apt-get -y install graphviz
 
 # Installation


### PR DESCRIPTION
**Descriptions**
This PR makes Travis CI set up the latest release of Rizin when it starts a test.

Since there is no official Rizin package on `apt`,
it uses a series of commands to download it via [the Github release page](https://github.com/rizinorg/rizin/releases).

Here are the details:
1. Query the file link to the latest version of Rizin via the release page.
2. Use it to download the latest binaries.
3. Unzip the binaries into /opt/rizin and add the executable rizin to the system variable PATH.