### PR TITLE
Enhance the Simulation Accuracy of the Bytecode Loader

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Check 13667fe3b0ad496a0cd157f34b7e0c991d72a4db.apk Result
         # This sample should have 9 behaviors with 100% confidence
         run: |
-          if [ "${{ env.a4db_RESULT }}" == "9" ]; then
+          if [ "${{ env.a4db_RESULT }}" == "11" ]; then
             exit 0
           else
             exit 1

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -63,7 +63,7 @@ jobs:
           fi
 
       - name: Check 13667fe3b0ad496a0cd157f34b7e0c991d72a4db.apk Result
-        # This sample should have 9 behaviors with 100% confidence
+        # This sample should have 11 behaviors with 100% confidence
         run: |
           if [ "${{ env.a4db_RESULT }}" == "11" ]; then
             exit 0
@@ -72,9 +72,9 @@ jobs:
           fi
           
       - name: Check 14d9f1a92dd984d6040cc41ed06e273e.apk Result
-        # This sample should have 14 behaviors with 100% confidence
+        # This sample should have 15 behaviors with 100% confidence
         run: |
-          if [ "${{ env.e273e_RESULT }}" == "14" ]; then
+          if [ "${{ env.e273e_RESULT }}" == "15" ]; then
             exit 0
           else
             exit 1

--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -677,7 +677,7 @@ class PyEval:
                 if method:
                     return (
                         f"{method.class_name}->"
-                        "{method.name}{method.descriptor}"
+                        f"{method.name}{method.descriptor}"
                     )
 
                 next_class_pool.update(

--- a/quark/Evaluator/pyeval.py
+++ b/quark/Evaluator/pyeval.py
@@ -162,7 +162,7 @@ class PyEval:
                 pass
 
         executed_fuc = instruction[-1]
-        reg_list = instruction[1 : len(instruction) - 1]
+        reg_list = instruction[1: len(instruction) - 1]
         value_of_reg_list = []
 
         # query the value from hash table based on register index.
@@ -188,7 +188,7 @@ class PyEval:
         self.ret_stack.append(f"{executed_fuc}({','.join(value_of_reg_list)})")
 
         # Extract the type of return value
-        self.ret_type = executed_fuc[executed_fuc.index(")") + 1 :]
+        self.ret_type = executed_fuc[executed_fuc.index(")") + 1:]
 
     def _move_result(self, instruction):
 
@@ -675,7 +675,10 @@ class PyEval:
                 )
 
                 if method:
-                    return f"{method.class_name}->{method.name}{method.descriptor}"
+                    return (
+                        f"{method.class_name}->"
+                        "{method.name}{method.descriptor}"
+                    )
 
                 next_class_pool.update(
                     (self.apkinfo.class_hierarchy[class_name])
@@ -685,7 +688,8 @@ class PyEval:
             class_pool = set(next_class_pool)
 
         raise ValueError(
-            "The implement of method {signature} was not found. Instance type: {instance_type}"
+            "The implement of method {signature} was"
+            "not found. Instance type: {instance_type}"
         )
 
     def _move_value_and_data_to_register(

--- a/quark/Objects/apkinfo.py
+++ b/quark/Objects/apkinfo.py
@@ -4,6 +4,7 @@
 
 import functools
 import re
+from collections import defaultdict
 from os import PathLike
 from typing import Dict, List, Optional, Set, Union
 
@@ -252,6 +253,18 @@ class AndroguardImp(BaseApkinfo):
                 result["second_hex"] = ins.get_hex()
 
         return result
+
+    @property
+    def class_hierarchy(self) -> Dict[str, Set[str]]:
+        hierarchy_dict = defaultdict(set)
+
+        for _class in self.analysis.get_classes():
+            hierarchy_dict[str(_class.name)].add(str(_class.extends))
+            hierarchy_dict[str(_class.name)].union(
+                str(implements) for implements in _class.implements
+            )
+
+        return hierarchy_dict
 
     @staticmethod
     @functools.lru_cache

--- a/quark/Objects/apkinfo.py
+++ b/quark/Objects/apkinfo.py
@@ -117,7 +117,6 @@ class AndroguardImp(BaseApkinfo):
         self, method_object: MethodObject
     ) -> Set[MethodObject]:
         method_analysis = method_object.cache
-
         try:
             for (
                 _,
@@ -135,28 +134,24 @@ class AndroguardImp(BaseApkinfo):
                         None,
                         None,
                     )
-                elif length_operands == 1:
-                    # Only one register
+                else:
+                    index_of_parameter_starts = None
+                    for i in range(length_operands - 1, -1, -1):
+                        if not isinstance(ins.get_operands()[i][0], Operand):
+                            index_of_parameter_starts = i
+                            break
 
-                    reg_list.append(
-                        f"v{ins.get_operands()[length_operands - 1][1]}",
-                    )
-                    bytecode_obj = BytecodeObject(
-                        ins.get_name(),
-                        reg_list,
-                        None,
-                    )
-                elif length_operands >= 2:
-                    # if the last one's type is not Operand, it is a parameter.
-                    if not isinstance(ins.get_operands()[-1][0], Operand):
-                        parameter = ins.get_operands()[-1]
+                    if index_of_parameter_starts is not None:
+                        parameter = ins.get_operands()[
+                            index_of_parameter_starts
+                        ]
                         parameter = (
                             parameter[2]
                             if len(parameter) == 3
                             else parameter[1]
                         )
 
-                        for i in range(length_operands - 1):
+                        for i in range(index_of_parameter_starts):
                             reg_list.append(
                                 "v" + str(ins.get_operands()[i][1]),
                             )

--- a/quark/Objects/interface/baseapkinfo.py
+++ b/quark/Objects/interface/baseapkinfo.py
@@ -171,6 +171,11 @@ class BaseApkinfo:
         """
         pass
 
+    @property
+    @abstractmethod
+    def class_hierarchy(self) -> Dict[str, Set[str]]:
+        pass
+
     @staticmethod
     def _check_file_signature(raw: bytes) -> Optional[str]:
         if raw[0:3] == b"dex":

--- a/quark/Objects/quark.py
+++ b/quark/Objects/quark.py
@@ -13,22 +13,13 @@ from quark.Objects.analysis import QuarkAnalysis
 from quark.Objects.apkinfo import AndroguardImp
 from quark.Objects.rzapkinfo import RizinImp
 from quark.utils import tools
-from quark.utils.colors import (
-    red,
-    yellow,
-    green,
-    lightblue,
-    magenta,
-    lightyellow,
-    colorful_report,
-)
+from quark.utils.colors import (colorful_report, green, lightblue, lightyellow,
+                                magenta, red, yellow)
 from quark.utils.graph import call_graph
-from quark.utils.output import (
-    get_rule_classification_data,
-    output_parent_function_graph,
-    output_parent_function_table,
-    output_parent_function_json,
-)
+from quark.utils.output import (get_rule_classification_data,
+                                output_parent_function_graph,
+                                output_parent_function_json,
+                                output_parent_function_table)
 from quark.utils.pprint import print_info, print_success
 from quark.utils.weight import Weight
 
@@ -186,7 +177,7 @@ class Quark:
         for first_call_method in first_method_list:
             for second_call_method in second_method_list:
 
-                pyeval = PyEval()
+                pyeval = PyEval(self.apkinfo)
                 # Check if there is an operation of the same register
 
                 for bytecode_obj in self.apkinfo.get_method_bytecode(parent_function):

--- a/quark/Objects/rzapkinfo.py
+++ b/quark/Objects/rzapkinfo.py
@@ -96,7 +96,7 @@ class RizinImp(BaseApkinfo):
             argument_string = re.sub(r"\[ ", "[", argument_string)
 
             return_value = method_descriptor[
-                method_descriptor.index(")") + 1:
+                method_descriptor.index(")") + 1 :
             ]
             descriptor = argument_string + return_value
 
@@ -364,7 +364,7 @@ class RizinImp(BaseApkinfo):
             if mnemonic.startswith("invoke"):
                 parameter = re.sub(r"\.", ";->", parameter, count=1)
 
-        register_list = None
+        register_list = []
         # Ranged registers
         if len(args) == 1 and (":" in args[0] or ".." in args[0]):
             register_list = args[0]
@@ -384,7 +384,6 @@ class RizinImp(BaseApkinfo):
                     f"Cannot parse bytecode. Unknown smali {smali}."
                 )
 
-        if register_list:
-            register_list = [f"v{index}" for index in register_list]
+        register_list = [f"v{index}" for index in register_list]
 
         return BytecodeObject(mnemonic, register_list, parameter)

--- a/quark/Objects/rzapkinfo.py
+++ b/quark/Objects/rzapkinfo.py
@@ -96,7 +96,7 @@ class RizinImp(BaseApkinfo):
             argument_string = re.sub(r"\[ ", "[", argument_string)
 
             return_value = method_descriptor[
-                method_descriptor.index(")") + 1 :
+                method_descriptor.index(")") + 1:
             ]
             descriptor = argument_string + return_value
 

--- a/quark/Objects/rzapkinfo.py
+++ b/quark/Objects/rzapkinfo.py
@@ -331,6 +331,28 @@ class RizinImp(BaseApkinfo):
 
         return result
 
+    @property
+    def class_hierarchy(self) -> Dict[str, Set[str]]:
+        hierarchy_dict = defaultdict(set)
+
+        for dex_index in range(self._number_of_dex):
+
+            rz = self._get_rz(dex_index)
+
+            hierarchy_graph = rz.cmd("icg").split("\n")
+
+            for element in hierarchy_graph:
+                if element.startswith("age"):
+                    element_part = element.split()
+                    for index, class_name in enumerate(element_part):
+                        if not class_name.endswith(";"):
+                            element_part[index] = class_name + ";"
+
+                    for subclass in element_part[2:]:
+                        hierarchy_dict[subclass].add(element_part[1])
+
+        return hierarchy_dict
+
     def _get_method_by_address(self, address: int) -> MethodObject:
         if address < 0:
             return None

--- a/quark/Objects/struct/registerobject.py
+++ b/quark/Objects/struct/registerobject.py
@@ -6,9 +6,17 @@
 class RegisterObject:
     """The RegisterObject is used to record the state of each register"""
 
-    __slots__ = ["_register_name", "_value", "_called_by_func"]
+    __slots__ = [
+        "_register_name",
+        "_value",
+        "_called_by_func",
+        "_current_type",
+        "_type_history",
+    ]
 
-    def __init__(self, register_name, value, called_by_func=None):
+    def __init__(
+        self, register_name, value, called_by_func=None, value_type=None
+    ):
         """
         A data structure for creating the bytecode variable object, which
         used to record the state of each register.
@@ -23,12 +31,14 @@ class RegisterObject:
         """
         self._register_name = register_name
         self._value = value
+        self._current_type = value_type
+        self._type_history = []
         self._called_by_func = []
         if called_by_func is not None:
             self._called_by_func.append(called_by_func)
 
     def __repr__(self):
-        return f"<VarabileObject-register:{self._register_name}, value:{self._value}, called_by_func:{','.join(self._called_by_func)}>"
+        return f"<VarabileObject-register:{self._register_name}, value:{self._value}, called_by_func:{','.join(self._called_by_func)}, current_type:{self._value_type}>"
 
     def __eq__(self, obj):
         return (
@@ -36,6 +46,7 @@ class RegisterObject:
             and obj.called_by_func == self.called_by_func
             and obj.register_name == self.register_name
             and obj.value == self.value
+            and obj.current_type == self.current_type
         )
 
     @property
@@ -56,6 +67,7 @@ class RegisterObject:
         :return: None
         """
         self._called_by_func.append(called_by_func)
+        self._type_history.append(self._current_type)
 
     @property
     def register_name(self):
@@ -94,6 +106,24 @@ class RegisterObject:
         :return: None
         """
         self._value = value
+
+    @property
+    def current_type(self):
+        """
+        Get the type of the value in the register
+
+        :return: a plant text that describes a data type
+        :rtype: str
+        """
+        return self._current_type
+
+    @current_type.setter
+    def current_type(self, value):
+        self._current_type = value
+
+    @property
+    def type_histroy(self):
+        return self._type_history
 
     @property
     def hash_index(self):

--- a/tests/Evaluator/test_pyeval.py
+++ b/tests/Evaluator/test_pyeval.py
@@ -437,34 +437,27 @@ class TestPyEval:
         override_original_instruction = [
             "new-instance",
             "v4",
-            "override_value",
+            "Ljava/lang/Object;",
         ]
 
         pyeval.NEW_INSTANCE(instruction)
 
-        assert pyeval.table_obj.pop(3).register_name == "v3"
-        assert (
-            pyeval.table_obj.pop(
-                3,
-            ).value
-            == "Lcom/google/progress/SMSHelper;"
+        assert pyeval.table_obj.pop(3) == RegisterObject(
+            "v3",
+            "Lcom/google/progress/SMSHelper;",
+            value_type="Lcom/google/progress/SMSHelper;",
         )
-        assert pyeval.table_obj.pop(3).called_by_func == []
-
-        assert pyeval.table_obj.pop(4).register_name == "v4"
-        assert (
-            pyeval.table_obj.pop(
-                4,
-            ).value
-            == "Lcom/google/progress/SMSHelper;"
+        assert pyeval.table_obj.pop(4) == RegisterObject(
+            "v4",
+            "Lcom/google/progress/SMSHelper;",
+            value_type="Lcom/google/progress/SMSHelper;",
         )
-        assert pyeval.table_obj.pop(4).called_by_func == []
 
         pyeval.NEW_INSTANCE(override_original_instruction)
 
-        assert pyeval.table_obj.pop(4).register_name == "v4"
-        assert pyeval.table_obj.pop(4).value == "override_value"
-        assert pyeval.table_obj.pop(4).called_by_func == []
+        assert pyeval.table_obj.pop(4) == RegisterObject(
+            "v4", "Ljava/lang/Object;", value_type="Ljava/lang/Object;"
+        )
 
     # Tests for const_string
     def test_const_string(self, pyeval):
@@ -476,12 +469,11 @@ class TestPyEval:
 
         pyeval.CONST_STRING(instruction)
 
-        assert pyeval.table_obj.pop(8).register_name == "v8"
-        assert (
-            pyeval.table_obj.pop(8).value
-            == "https://github.com/quark-engine/quark-engine"
+        assert pyeval.table_obj.pop(8) == RegisterObject(
+            "v8",
+            "https://github.com/quark-engine/quark-engine",
+            value_type="Ljava/lang/String;",
         )
-        assert pyeval.table_obj.pop(8).called_by_func == []
 
     def test_const_string_jumbo(self, pyeval):
         instruction = [
@@ -493,20 +485,24 @@ class TestPyEval:
         pyeval.eval[instruction[0]](instruction)
 
         assert pyeval.table_obj.pop(8) == RegisterObject(
-            "v8", "https://github.com/quark-engine/quark-engine"
+            "v8",
+            "https://github.com/quark-engine/quark-engine",
+            value_type="Ljava/lang/String;",
         )
 
     def test_const_class(self, pyeval):
         instruction = [
             "const-class",
             "v8",
-            "Ljava/lang/Object;->toString()",
+            "Landroid/telephony/SmsMessage;",
         ]
 
         pyeval.eval[instruction[0]](instruction)
 
         assert pyeval.table_obj.pop(8) == RegisterObject(
-            "v8", "Ljava/lang/Object;->toString()"
+            "v8",
+            "Landroid/telephony/SmsMessage;",
+            value_type="Ljava/lang/Class;",
         )
 
     # Tests for const

--- a/tests/Evaluator/test_pyeval.py
+++ b/tests/Evaluator/test_pyeval.py
@@ -348,7 +348,10 @@ class TestPyEval:
             "invoke-virtual",
             "v4",
             "v9",
-            "Landroid/support/v4/util/ArrayMap;->entrySet()Ljava/util/Set;(ArrayMap object)",
+            (
+                "Landroid/support/v4/util/ArrayMap;"
+                "->entrySet()Ljava/util/Set;(ArrayMap object)"
+            ),
         ]
 
         with patch("quark.Evaluator.pyeval.PyEval._invoke") as mock:
@@ -365,7 +368,10 @@ class TestPyEval:
         pyeval.eval[instruction[0]](instruction)
 
         assert pyeval.ret_stack == [
-            "Landroid/support/v4/util/SimpleArrayMap;->isEmpty()Z(ArrayMap object)"
+            (
+                "Landroid/support/v4/util/SimpleArrayMap;"
+                "->isEmpty()Z(ArrayMap object)"
+            )
         ]
         assert pyeval.ret_type == "Z"
 
@@ -375,7 +381,10 @@ class TestPyEval:
             "invoke-direct",
             "v4",
             "v9",
-            "Landroid/support/v4/util/ArrayMap;->entrySet()Ljava/util/Set;(ArrayMap object)",
+            (
+                "Landroid/support/v4/util/ArrayMap;"
+                "->entrySet()Ljava/util/Set;(ArrayMap object)"
+            ),
         ]
 
         with patch("quark.Evaluator.pyeval.PyEval._invoke") as mock:
@@ -388,7 +397,10 @@ class TestPyEval:
             "invoke-static",
             "v4",
             "v9",
-            "Landroid/support/v4/util/ArrayMap;->entrySet()Ljava/util/Set;(ArrayMap object)",
+            (
+                "Landroid/support/v4/util/ArrayMap;"
+                "->entrySet()Ljava/util/Set;(ArrayMap object)"
+            ),
         ]
 
         with patch("quark.Evaluator.pyeval.PyEval._invoke") as mock:
@@ -401,7 +413,10 @@ class TestPyEval:
             "invoke-interface",
             "v4",
             "v9",
-            "Landroid/support/v4/util/ArrayMap;->entrySet()Ljava/util/Set;(ArrayMap object)",
+            (
+                "Landroid/support/v4/util/ArrayMap;"
+                "->entrySet()Ljava/util/Set;(ArrayMap object)"
+            ),
         ]
 
         with patch("quark.Evaluator.pyeval.PyEval._invoke") as mock:
@@ -418,7 +433,10 @@ class TestPyEval:
         pyeval.eval[instruction[0]](instruction)
 
         assert pyeval.ret_stack == [
-            "Landroid/support/v4/util/ArrayMap;->entrySet()Ljava/util/Set;(ArrayMap object)"
+            (
+                "Landroid/support/v4/util/ArrayMap;"
+                "->entrySet()Ljava/util/Set;(ArrayMap object)"
+            )
         ]
         assert pyeval.ret_type == "Ljava/util/Set;"
 
@@ -442,7 +460,10 @@ class TestPyEval:
         pyeval.eval[instruction[0]](instruction)
 
         assert pyeval.ret_stack == [
-            "Landroid/support/v4/util/SimpleArrayMap;->toString()Ljava/lang/String;(ArrayMap object)"
+            (
+                "Landroid/support/v4/util/SimpleArrayMap;"
+                "->toString()Ljava/lang/String;(ArrayMap object)"
+            )
         ]
         assert pyeval.ret_type == "Ljava/lang/String;"
 
@@ -951,6 +972,9 @@ class TestPyEval:
 
         assert pyeval.table_obj.pop(1) == RegisterObject(
             "v1",
-            "Lcom/google/progress/ContactsCollector;->getContactList()Ljava/lang/String;(some_string)",
+            (
+                "Lcom/google/progress/ContactsCollector;"
+                "->getContactList()Ljava/lang/String;(some_string)"
+            ),
             value_type="Ljava/lang/String;",
         )

--- a/tests/Object/test_apkinfo.py
+++ b/tests/Object/test_apkinfo.py
@@ -254,3 +254,11 @@ class TestApkinfo:
         upper_methods = apkinfo.lowerfunc(method)
 
         assert (expect_method, expect_offset) in upper_methods
+
+    def test_class_hierarchy_with_expected_class(self, apkinfo):
+        expected_upper_class = {"Lcom/example/google/service/HttpHelper;"}
+        class_name = "Lcom/example/google/service/WebServiceCalling;"
+
+        upper_set = apkinfo.class_hierarchy[class_name]
+
+        assert expected_upper_class == upper_set

--- a/tests/Object/test_apkinfo.py
+++ b/tests/Object/test_apkinfo.py
@@ -209,28 +209,27 @@ class TestApkinfo:
         expected_bytecode_list = [
             BytecodeObject(
                 "iput-object",
-                ["v15", "v14"],
-                (
-                    "Lcom/example/google/service/SMSReceiver;->"
-                    "_Context Landroid/content/Context;"
-                ),
+                ["v5", "v8"],
+                "Landroid/support/v4/app/FragmentManagerImpl;->mTmpActions [Ljava/lang/Runnable;",
             ),
             BytecodeObject(
                 "invoke-direct",
-                ["v14", "v8"],
-                (
-                    "Lcom/example/google/service/SMSReceiver;"
-                    "->isContact(Ljava/lang/String;)Ljava/lang/Boolean;"
-                ),
+                ["v5", "v6"],
+                "Ljava/lang/IllegalStateException;-><init>(Ljava/lang/String;)V",
             ),
-            BytecodeObject("array-length", ["v10", "v6"], None),
-            BytecodeObject("return-void", None, None),
+            BytecodeObject("array-length", ["v5", "v5"], None),
+            BytecodeObject(
+                "invoke-static",
+                [],
+                "Landroid/os/Looper;->myLooper()Landroid/os/Looper;",
+            ),
+            BytecodeObject("return", ["v0"], None),
         ]
 
         method = apkinfo.find_method(
-            class_name="Lcom/example/google/service/SMSReceiver;",
-            method_name="onReceive",
-            descriptor="(Landroid/content/Context; Landroid/content/Intent;)V",
+            class_name="Landroid/support/v4/app/FragmentManagerImpl;",
+            method_name="execPendingActions",
+            descriptor="()Z",
         )
 
         bytecodes = list(apkinfo.get_method_bytecode(method))

--- a/tests/Object/test_apkinfo.py
+++ b/tests/Object/test_apkinfo.py
@@ -210,12 +210,18 @@ class TestApkinfo:
             BytecodeObject(
                 "iput-object",
                 ["v5", "v8"],
-                "Landroid/support/v4/app/FragmentManagerImpl;->mTmpActions [Ljava/lang/Runnable;",
+                (
+                    "Landroid/support/v4/app/FragmentManagerImpl;"
+                    "->mTmpActions [Ljava/lang/Runnable;"
+                ),
             ),
             BytecodeObject(
                 "invoke-direct",
                 ["v5", "v6"],
-                "Ljava/lang/IllegalStateException;-><init>(Ljava/lang/String;)V",
+                (
+                    "Ljava/lang/IllegalStateException;"
+                    "-><init>(Ljava/lang/String;)V"
+                ),
             ),
             BytecodeObject("array-length", ["v5", "v5"], None),
             BytecodeObject(


### PR DESCRIPTION
**Description**

This PR aims to improve the simulation accuracy of invoke-kind instructions.

It enables the bytecode loader to track the data type of registers.

With the help of types, the tainted analysis can infer the called methods more accurately.

**How does it work**

The RP achieves it by making the following changes.

1. Modify the bytecode loader to record the data type of each register.
2. Add a method to get the class inheritance relation from an APK.

With that information, the Dalvik Bytecode loader can operate the following instructions like a real Dalvik virtual machine.

1. invoke-virtual
2. invoke-interface
3. invoke-super

It performs a lookup procedure defined by the Dalvik doc to find the correct method to call.

**Code Changes**

1. **quark/Objects/struct/registerobject.py**
   + Add properties to store data types.
2. **quark/Evaluator/pyeval.py**
   + Update instructions to track the data type of registers.
   + Add invoke-super and the missing instructions, aget, aput, and new-array.
   + Add a method to perform the lookup procedure.
3. **quark/Object/interface/baseapkinfo.py**
   + Add a method to get the inheritance relation of all classes in an APK.
4. **quark/Object/apkinfo.py** and  **rzapkinfo.py**
   + Update get_method_bytecode to parse more instructions.
   + Implement the above method in baseapkinfo.py

**Test Plans**

1. Update tests for those mentioned features.
2. Ensure the PR passes all the tests.