### PR TITLE
Parallelize the analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ quark -a first.apk -a second.apk -C
 
 <img src="https://i.imgur.com/ClRWOei.png"/>
 
-### Parallelize the analysis
-Add the option `-j` and set the number of processes. You can now utilize every CPU by the Quark asynchronous analysis.
+### Parallelizing Quark
+Now Quark supports multiprocessing for analyzing APKs parallelly, by adding the option `--multi-process` and set the number of processes. (the default is the number of CPUs in your computer.)
 ```bash
-quark -a Ahmyth.apk -s -j 4
+quark -a Ahmyth.apk -s --multi-process 4
 ```
 
 ### Upcoming unstable feature

--- a/README.md
+++ b/README.md
@@ -139,6 +139,12 @@ quark -a first.apk -a second.apk -C
 
 <img src="https://i.imgur.com/ClRWOei.png"/>
 
+### Parallelize the analysis
+Add the option `-j` and set the number of processes. You can now utilize every CPU by the Quark asynchronous analysis.
+```bash
+quark -a Ahmyth.apk -s -j 4
+```
+
 ### Upcoming unstable feature
 Now Quark also supports [Rizin](https://github.com/rizinorg/rizin) as one of our Android analysis frameworks. You can use option `--core-library` with `rizin` to enable the Rizin-based analysis library.
 ```bash

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -194,12 +194,7 @@ def entry_point(
             rule_checker_list = [
                 rule_checker
                 for rule_checker in rule_checker_list
-                if len(
-                    np.intersect1d(
-                        np.array(rule_checker.label), selected_label
-                    )
-                )
-                != 0
+                if len(np.intersect1d(rule_checker.label, selected_label)) != 0
             ]
 
             if num_of_process > 1:

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -120,13 +120,12 @@ logo()
     default="androguard",
 )
 @click.option(
-    "-j",
-    "--num-of-process",
+    "--multi-process",
     "num_of_process",
     type=click.IntRange(min=1),
     help="Allow analyzing APK with N processes",
     required=False,
-    default=1,
+    default=os.cpu_count(),
 )
 def entry_point(
     summary,

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -347,11 +347,11 @@ def entry_point(
         ):
             # Run the checker
             data.run(rule_checker)
-            
+
             confidence = rule_checker.check_item.count(True) * 20
 
             if confidence >= threshold_number:
-                print(f"Rulepath: {rulepath}")
+                print(f"Rulepath: {rule_path}")
                 print(f"Rule crime: {rule_checker.crime}")
                 data.show_detail_report(rule_checker)
                 print_success("OK")

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -125,7 +125,7 @@ logo()
     type=click.IntRange(min=1),
     help="Allow analyzing APK with N processes",
     required=False,
-    default=os.cpu_count(),
+    default=1,
 )
 def entry_point(
     summary,

--- a/quark/core/parallelquark.py
+++ b/quark/core/parallelquark.py
@@ -1,0 +1,128 @@
+from multiprocessing.pool import Pool
+
+from quark.core.analysis import QuarkAnalysis
+from quark.core.quark import Quark
+
+_quark = None
+
+
+class ParallelQuark(Quark):
+    @staticmethod
+    def _worker_initializer(apk, core_library):
+        global _quark
+        _quark = Quark(apk, core_library)
+
+    @staticmethod
+    def _worker_analysis(rule_obj):
+        _quark.quark_analysis = QuarkAnalysis()
+        _quark.run(rule_obj)
+
+        # Pack analysis result
+        def to_raw_method(methodobject):
+            return (
+                methodobject.class_name,
+                methodobject.name,
+                methodobject.descriptor,
+            )
+
+        reached_stage = rule_obj.check_item.count(True)
+        level_4_result = tuple(
+            to_raw_method(method) for method in _quark.quark_analysis.level_4_result
+        )
+        behavior_list = [
+            (
+                to_raw_method(item["parent"]),
+                to_raw_method(item["first_call"]),
+                to_raw_method(item["second_call"]),
+            )
+            for item in _quark.quark_analysis.call_graph_analysis_list
+        ]
+
+        return (
+            reached_stage,
+            level_4_result,
+            behavior_list,
+            _quark.quark_analysis.parent_wrapper_mapping,
+        )
+
+    def _apply_analysis_result(self, rule_obj):
+        async_result = self._result_map[id(rule_obj)]
+        result = async_result.get()
+
+        # Overwrite rule_obj
+        for i in range(result[0]):
+            rule_obj.check_item[i] = True
+
+        # Overwrite quark analysis
+        analysis = self.quark_analysis
+        analysis.crime_description = rule_obj.crime
+
+        apis = [
+            self.apkinfo.find_method(
+                rule_obj.api[i]["class"],
+                rule_obj.api[i]["method"],
+                rule_obj.api[i]["descriptor"],
+            )
+            for i in range(2)
+        ]
+
+        analysis.first_api, analysis.second_api = apis
+
+        # analysis.level_1_result
+        if result[0] >= 2:
+            analysis.level_2_result = [api for api in apis if api]
+        # analysis.level_3_result
+
+        if result[0] >= 4:
+            analysis.level_4_result = [
+                self.apkinfo.find_method(method[0], method[1], method[2])
+                for method in result[1]
+            ]
+            analysis.parent_wrapper_mapping = result[3]
+
+        if result[0] >= 5:
+            behavior_list = [
+                tuple(
+                    self.apkinfo.find_method(method[0], method[1], method[2])
+                    for method in behavior
+                )
+                for behavior in result[2]
+            ]
+
+            analysis.level_5_result = [behavior[0] for behavior in behavior_list]
+
+            analysis.call_graph_analysis_list.extend(
+                [
+                    {
+                        "parent": behavior[0],
+                        "first_call": behavior[1],
+                        "second_call": behavior[2],
+                        "apkinfo": self.apkinfo,
+                        "first_api": analysis.first_api,
+                        "second_api": analysis.second_api,
+                        "crime": analysis.crime_description,
+                    }
+                    for behavior in behavior_list
+                ]
+            )
+
+    def __init__(self, apk, core_library, num_of_process=1):
+        self._result_map = {}
+        self._pool = Pool(
+            num_of_process - 1, self._worker_initializer, (apk, core_library)
+        )
+
+        super().__init__(apk, core_library)
+
+    def apply_rules(self, rule_obj_list):
+        for rule_obj in rule_obj_list:
+            result = self._pool.apply_async(self._worker_analysis, (rule_obj,))
+            self._result_map[id(rule_obj)] = result
+        self._pool.close()
+
+    def run(self, rule_obj):
+        self._apply_analysis_result(rule_obj)
+
+    def close(self):
+        self._pool.close()
+        self._pool.join()

--- a/quark/core/parallelquark.py
+++ b/quark/core/parallelquark.py
@@ -119,9 +119,6 @@ class ParallelQuark(Quark):
             result = self._pool.apply_async(self._worker_analysis, (rule_obj,))
             self._result_map[id(rule_obj)] = result
 
-    def close(self):
-        self._pool.close()
-
     def run(self, rule_obj):
         self._apply_analysis_result(rule_obj)
 

--- a/quark/core/parallelquark.py
+++ b/quark/core/parallelquark.py
@@ -118,6 +118,8 @@ class ParallelQuark(Quark):
         for rule_obj in rule_obj_list:
             result = self._pool.apply_async(self._worker_analysis, (rule_obj,))
             self._result_map[id(rule_obj)] = result
+
+    def close(self):
         self._pool.close()
 
     def run(self, rule_obj):


### PR DESCRIPTION
**Description**

This PR adds a rule-based parallelization feature to Quark analysis. It allows Quark to scan multiple rules at a time.

**Usage**

Add the option `-j` to set the number of processes that Quark can use for analysis.
(Default is 1, to disable this feature.)

```
quark -a PATH_TO_APK -s -j NUMBER_OF_RULES
```

**Code changes**

+ `quark/cli.py`
  + Add the option `-j` as mentioned above.
  + Parallelly start the analysis of each rule before Quark askes the results.
+ `quark/parallelquark.py`
  + A subclass of Quark that handles the parallelization work.