### PR TITLE
Avoid logging messages in the Dalvik Bytecode Loader

### DIFF
--- a/quark/config.py
+++ b/quark/config.py
@@ -8,4 +8,6 @@ HOME_DIR = f"{Path.home()}/.quark-engine/"
 SOURCE = "https://github.com/quark-engine/quark-rules"
 DIR_PATH = f"{HOME_DIR}quark-rules"
 
+DEBUG = False
+
 Path(HOME_DIR).mkdir(parents=True, exist_ok=True)

--- a/quark/evaluator/pyeval.py
+++ b/quark/evaluator/pyeval.py
@@ -9,18 +9,22 @@
 import logging
 from datetime import datetime
 
+from quark import config
 from quark.core.struct.registerobject import RegisterObject
 from quark.core.struct.tableobject import TableObject
 
 MAX_REG_COUNT = 40
-TIMESTAMPS = datetime.now().strftime("%Y-%m-%d")
-LOG_FILENAME = f"{TIMESTAMPS}.quark.log"
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
-handler = logging.FileHandler(LOG_FILENAME, mode="w")
-format_str = "%(asctime)s %(levelname)s [%(lineno)d]: %(message)s"
-handler.setFormatter(logging.Formatter(format_str))
-log.addHandler(handler)
+if config.DEBUG:
+    TIMESTAMPS = datetime.now().strftime("%Y-%m-%d")
+    LOG_FILENAME = f"{TIMESTAMPS}.quark.log"
+    handler = logging.FileHandler(LOG_FILENAME, mode="w")
+    format_str = "%(asctime)s %(levelname)s [%(lineno)d]: %(message)s"
+    handler.setFormatter(logging.Formatter(format_str))
+    log.addHandler(handler)
+else:
+    log.disabled = True
 
 
 def logger(func):


### PR DESCRIPTION
**Description**
Refer to #225 . 
The logging behavior in pyeval.py is now disabled by default. Developers can set a variable in config.py to bring it back.

**Code changes**
+ pyeval.py
  + Apply an if-statement to the logger.
+ config.py
  + Add a variable named DEBUG to indicate whether the logger should run.