### PR TITLE
Simplify the generator value check in the Androguard core library

### DIFF
--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -83,17 +83,11 @@ class AndroguardImp(BaseApkinfo):
             methodname=regex_method_name,
             descriptor=regex_descriptor,
         )
-        if list(method_result):
-            (result,) = list(
-                self.analysis.find_methods(
-                    classname=regex_class_name,
-                    methodname=regex_method_name,
-                    descriptor=regex_descriptor,
-                )
-            )
-
+        
+        try:
+            result = next(method_result)
             return self._convert_to_method_object(result)
-        else:
+        except StopIteration:
             return None
 
     @functools.lru_cache()

--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -84,11 +84,8 @@ class AndroguardImp(BaseApkinfo):
             descriptor=regex_descriptor,
         )
         
-        try:
-            result = next(method_result)
-            return self._convert_to_method_object(result)
-        except StopIteration:
-            return None
+        result = next(method_result, None)
+        return self._convert_to_method_object(result) if result else None
 
     @functools.lru_cache()
     def upperfunc(self, method_object: MethodObject) -> Set[MethodObject]:

--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -83,7 +83,7 @@ class AndroguardImp(BaseApkinfo):
             methodname=regex_method_name,
             descriptor=regex_descriptor,
         )
-        
+
         result = next(method_result, None)
         return self._convert_to_method_object(result) if result else None
 


### PR DESCRIPTION
**Description**

This PR uses the built-in function to check the generator value.
The new check can eliminate the repetitive calls in the Androguard core library.

**Code changes**
+ quark/core/apkinfo.py
  + Apply the built-in function, [next()](https://docs.python.org/3/library/functions.html#next), to the return value of Androguard API, `AnalyzeAPK.find_methods`.
  + Remove the repetitive calls to Androguard API, `AnalyzeAPK.find_methods`.