### PR TITLE
Fix pytest.xml

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,7 +31,7 @@ jobs:
         
         
         # Install Rizin
-        sudo git clone https://github.com/rizinorg/rizin /opt/rizin/
+        sudo git clone --branch v0.2.1 https://github.com/rizinorg/rizin /opt/rizin/
         cd /opt/rizin/
         meson build
         ninja -C build

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -36,6 +36,7 @@ jobs:
         meson build
         ninja -C build
         sudo ninja -C build install
+        sudo ldconfig -v
         cd -
         
         


### PR DESCRIPTION
**Description**
1. Specify the Rizin version to the latest release, v0.2.1.
2. Cache the generated libraries after building Rizin.

**Code changes**
+ pytest.xml