### PR TITLE
Reduce file IO and load rules in array

### DIFF
--- a/quark/cli.py
+++ b/quark/cli.py
@@ -149,15 +149,17 @@ def entry_point(
     rule_path_list = [
         os.path.join(rule, file) for file in os.listdir(rule) if file.endswith("json")
     ]
+    rule_buffer_list = []
+    update_rule_buffer(rule_buffer_list, rule_path_list)
 
     if comparison:
 
         # selection of labels on which it will be done the comparison on radar chart
         # first look for all label found in the rule list
         all_labels = set()
-        for rule_path in tqdm(rule_path_list):
-            rule_checker = RuleObject(rule_path)
-            labels = rule_checker.label  # array type, e.g. ['network', 'collection']
+
+        for rule_data in tqdm(rule_buffer_list):
+            labels = rule_data.label
             for single_label in labels:
                 all_labels.add(single_label)
 
@@ -181,12 +183,10 @@ def entry_point(
             # $ print(all_rules["accessibility service"])
             # > [60, 40, 60, 40, 60, 40]
 
-            rule_checker_list = [RuleObject(rulepath) for rulepath in rule_path_list]
-
             # analyse malware only on rules where appears label selected
             rule_checker_list = [
                 rule_checker
-                for rule_checker in rule_checker_list
+                for rule_checker in rule_buffer_list
                 if len(np.intersect1d(rule_checker.label, selected_label)) != 0
             ]
 
@@ -240,12 +240,10 @@ def entry_point(
         # $ print(all_rules["accessibility service"])
         # > [60, 40, 60, 40, 60, 40]
 
-        rule_checker_list = [RuleObject(rulepath) for rulepath in rule_path_list]
-
         if num_of_process > 1:
-            data.apply_rules(rule_checker_list)
+            data.apply_rules(rule_buffer_list)
 
-        for rule_checker in tqdm(rule_checker_list):
+        for rule_checker in tqdm(rule_buffer_list):
             # Run the checker
             data.run(rule_checker)
             confidence = rule_checker.check_item.count(True) * 20
@@ -285,14 +283,14 @@ def entry_point(
                 return
 
             rule_path_list = [summary]
+            update_rule_buffer(rule_buffer_list, rule_path_list)
             label_flag = False
         else:
             label_flag = True
 
-        rule_checker_list = [RuleObject(rule) for rule in rule_path_list]
         rule_checker_list = [
             rule_checker
-            for rule_checker in rule_checker_list
+            for rule_checker in rule_buffer_list
             if (not label_flag) or (summary in rule_checker.label)
         ]
 
@@ -332,28 +330,28 @@ def entry_point(
                 return
 
             rule_path_list = [detail]
+            update_rule_buffer(rule_buffer_list, rule_path_list)
             label_flag = False
         else:
             label_flag = True
 
-        rule_checker_list = [RuleObject(rule) for rule in rule_path_list]
         rule_checker_list = [
             rule_checker
-            for rule_checker in rule_checker_list
+            for rule_checker in rule_buffer_list
             if (not label_flag) or (detail in rule_checker.label)
         ]
 
         if isinstance(data, ParallelQuark):
             data.apply_rules(rule_checker_list)
 
-        for rule_checker, rule_path in tqdm(zip(rule_checker_list, rule_path_list)):
+        for rule_checker in tqdm(rule_checker_list):
             # Run the checker
             data.run(rule_checker)
 
             confidence = rule_checker.check_item.count(True) * 20
 
             if confidence >= threshold_number:
-                print(f"Rulepath: {rule_path}")
+                print(f"Rulepath: {os.path.join(rule, rule_checker.rule_filename)}")
                 print(f"Rule crime: {rule_checker.crime}")
                 data.show_detail_report(rule_checker)
                 print_success("OK")
@@ -366,12 +364,10 @@ def entry_point(
     # Show JSON report
     if output:
 
-        rule_checker_list = [RuleObject(rule) for rule in rule_path_list]
-
         if isinstance(data, ParallelQuark):
-            data.apply_rules(rule_checker_list)
+            data.apply_rules(rule_buffer_list)
 
-        for rule_checker in tqdm(rule_checker_list):
+        for rule_checker in tqdm(rule_buffer_list):
             # Run the checker
             data.run(rule_checker)
 
@@ -403,6 +399,15 @@ def entry_point(
     if isinstance(data, ParallelQuark):
         data.close()
 
+def update_rule_buffer(rule_buffer_list, rule_path_list):
+    for rule_path in tqdm(rule_path_list):
+        with open(rule_path, "r") as json_file:
+            json_data = json.loads(json_file.read())
+        if isinstance(json_data, list):
+            for rule_data in json_data:
+                rule_buffer_list.append(RuleObject(rule_path, rule_data))
+        else:
+            rule_buffer_list.append(RuleObject(rule_path, json_data))
 
 if __name__ == "__main__":
     entry_point()

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -156,7 +156,7 @@ def entry_point(
 
         # selection of labels on which it will be done the comparison on radar chart
         # first look for all label found in the rule list
-        all_labels = set()
+        all_labels = set() # array type, e.g. ['network', 'collection']
 
         for rule_data in tqdm(rule_buffer_list):
             labels = rule_data.label

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -156,7 +156,7 @@ def entry_point(
 
         # selection of labels on which it will be done the comparison on radar chart
         # first look for all label found in the rule list
-        all_labels = set() # array type, e.g. ['network', 'collection']
+        all_labels = set()  # array type, e.g. ['network', 'collection']
 
         for rule_data in tqdm(rule_buffer_list):
             labels = rule_data.label
@@ -351,7 +351,10 @@ def entry_point(
             confidence = rule_checker.check_item.count(True) * 20
 
             if confidence >= threshold_number:
-                print(f"Rulepath: {os.path.join(rule, rule_checker.rule_filename)}")
+                print(
+                    f"Rulepath: "
+                    f"{os.path.join(rule, rule_checker.rule_filename)}"
+                )
                 print(f"Rule crime: {rule_checker.crime}")
                 data.show_detail_report(rule_checker)
                 print_success("OK")
@@ -398,6 +401,7 @@ def entry_point(
 
     if isinstance(data, ParallelQuark):
         data.close()
+
 
 def update_rule_buffer(rule_buffer_list, rule_path_list):
     for rule_path in tqdm(rule_path_list):

--- a/quark/core/struct/ruleobject.py
+++ b/quark/core/struct/ruleobject.py
@@ -29,12 +29,12 @@ class RuleObject:
         # the state of five stages
         self.check_item = [False, False, False, False, False]
 
-        if json_data == None:
+        if json_data is not None:
+            self._json_obj = json_data
+        else:
             with open(json_filename) as json_file:
                 self._json_obj = json.loads(json_file.read())
-        else:
-            self._json_obj = json_data
-        
+
         self._crime = self._json_obj["crime"]
         self._permission = self._json_obj["permission"]
         self._api = self._json_obj["api"]

--- a/quark/core/struct/ruleobject.py
+++ b/quark/core/struct/ruleobject.py
@@ -20,7 +20,7 @@ class RuleObject:
         "_label",
     ]
 
-    def __init__(self, json_filename):
+    def __init__(self, json_filename, json_data=None):
         """
         According to customized JSON rules, calculate the weighted score and assessing the stages of the crime.
 
@@ -29,14 +29,18 @@ class RuleObject:
         # the state of five stages
         self.check_item = [False, False, False, False, False]
 
-        with open(json_filename) as json_file:
-            self._json_obj = json.loads(json_file.read())
-            self._crime = self._json_obj["crime"]
-            self._permission = self._json_obj["permission"]
-            self._api = self._json_obj["api"]
-            self._score = self._json_obj["score"]
-            self.rule_filename = os.path.basename(json_filename)
-            self._label = self._json_obj["label"]
+        if json_data == None:
+            with open(json_filename) as json_file:
+                self._json_obj = json.loads(json_file.read())
+        else:
+            self._json_obj = json_data
+        
+        self._crime = self._json_obj["crime"]
+        self._permission = self._json_obj["permission"]
+        self._api = self._json_obj["api"]
+        self._score = self._json_obj["score"]
+        self.rule_filename = os.path.basename(json_filename)
+        self._label = self._json_obj["label"]
 
     def __repr__(self):
         return f"<RuleObject-{self.rule_filename}>"


### PR DESCRIPTION
**Description:**
- Solve #129 
- Prevent Quark from keeping reloading rule files in `cli.py`. Rules now only reload when necessary.
- Multiple rules can save into a single file now by using the `[]` format (JSON array). Of course, Quark can read those rules too.
- `RuleObject` can be created with loaded JSON data now.

**Code changed:**
- cli.py
- ruleobject.py