### PR TITLE
Fix Quark rules not matching when no spaces between arguments.

### DIFF
--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -18,6 +18,7 @@ from quark.core.axmlreader import AxmlReader
 from quark.core.interface.baseapkinfo import BaseApkinfo
 from quark.core.struct.bytecodeobject import BytecodeObject
 from quark.core.struct.methodobject import MethodObject
+from quark.utils.tools import descriptor_to_androguard_format
 
 RizinCache = namedtuple("rizin_cache", "address dexindex is_imported")
 
@@ -78,20 +79,10 @@ class RizinImp(BaseApkinfo):
             class_name, method_descriptor = full_name.split(".method.", maxsplit=1)
             class_name = class_name + ";"
 
-            l_index = method_descriptor.index("(")
-            r_index = method_descriptor.index(")")
-            methodname = method_descriptor[:l_index]
-            argument_string = method_descriptor[l_index:r_index]
-            argument_string = (
-                "("
-                + " ".join(re.findall(r"L.+?;|[ZBCSIJFD]|\[", argument_string))
-                + ")"
-            )
-
-            argument_string = re.sub(r"\[ ", "[", argument_string)
-
-            return_value = method_descriptor[method_descriptor.index(")") + 1 :]
-            descriptor = argument_string + return_value
+            delimiter = method_descriptor.index('(')
+            methodname = method_descriptor[:delimiter]
+            descriptor = method_descriptor[delimiter:]
+            descriptor = descriptor_to_androguard_format(descriptor)
 
             is_imported = json_obj["is_imported"]
 

--- a/quark/core/struct/ruleobject.py
+++ b/quark/core/struct/ruleobject.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+from quark.utils.tools import descriptor_to_androguard_format
 
 
 class RuleObject:
@@ -37,7 +38,15 @@ class RuleObject:
 
         self._crime = self._json_obj["crime"]
         self._permission = self._json_obj["permission"]
+
         self._api = self._json_obj["api"]
+        for index in range(len(self._api)):
+            descriptor = self._api[index]["descriptor"]
+            if " " not in descriptor:
+                self._api[index][
+                    "descriptor"
+                ] = descriptor_to_androguard_format(descriptor)
+
         self._score = self._json_obj["score"]
         self.rule_filename = os.path.basename(json_filename)
         self._label = self._json_obj["label"]

--- a/quark/utils/tools.py
+++ b/quark/utils/tools.py
@@ -3,6 +3,7 @@
 # See the file 'LICENSE' for copying permission.
 
 import copy
+import re
 
 
 def remove_dup_list(element):
@@ -39,3 +40,18 @@ def contains(subset_to_check, target_list):
         else:
             return True
     return False
+
+
+def descriptor_to_androguard_format(descriptor):
+    if "(" not in descriptor or ")" not in descriptor:
+        raise ValueError(f"Invalid descriptor. {descriptor}")
+
+    delimiter = descriptor.index(")")
+
+    arg_str = descriptor[:delimiter]
+    args = re.findall(r"L.+?;|[ZBCSIJFD]|\[", arg_str)
+
+    new_descriptor = "(" + " ".join(args) + descriptor[delimiter:]
+    new_descriptor = re.sub(r"\[ ", "[", new_descriptor)
+
+    return new_descriptor

--- a/tests/core/struct/test_ruleobject.py
+++ b/tests/core/struct/test_ruleobject.py
@@ -122,8 +122,10 @@ class TestRuleObject:
         for idx, value in enumerate(expected_value):
             assert rule_obj.get_score(confidence[idx]) == value
 
-    def test_androguard_format_api(self, rule_obj):
+    @staticmethod
+    def test_androguard_format_api(rule_obj):
         assert rule_obj.api[0]["descriptor"] == "(I Ljava/lang/String; [B J)V"
 
-    def test_java_format_api(self, rule_obj):
+    @staticmethod
+    def test_java_format_api(rule_obj):
         assert rule_obj.api[1]["descriptor"] == "(I Ljava/lang/String; [B J)V"

--- a/tests/core/struct/test_ruleobject.py
+++ b/tests/core/struct/test_ruleobject.py
@@ -18,11 +18,13 @@ def rule_obj(scope="function"):
         "api": [
             {
                 "class": "Landroid/telephony/TelephonyManager",
-                "method": "getCellLocation"
+                "method": "getCellLocation",
+                "descriptor": "(I Ljava/lang/String; [B J)V"
             },
             {
                 "class": "Landroid/telephony/SmsManager",
-                "method": "sendTextMessage"
+                "method": "sendTextMessage",
+                "descriptor": "(ILjava/lang/String;[BJ)V"
             }
         ],
         "score": 4,
@@ -119,3 +121,9 @@ class TestRuleObject:
         expected_value = [0.25, 0.5, 1.0, 2.0, 4.0]
         for idx, value in enumerate(expected_value):
             assert rule_obj.get_score(confidence[idx]) == value
+
+    def test_androguard_format_api(self, rule_obj):
+        assert rule_obj.api[0]["descriptor"] == "(I Ljava/lang/String; [B J)V"
+
+    def test_java_format_api(self, rule_obj):
+        assert rule_obj.api[1]["descriptor"] == "(I Ljava/lang/String; [B J)V"

--- a/tests/utils/test_tools.py
+++ b/tests/utils/test_tools.py
@@ -1,6 +1,10 @@
 import pytest
 
-from quark.utils.tools import contains, remove_dup_list
+from quark.utils.tools import (
+    contains,
+    descriptor_to_androguard_format,
+    remove_dup_list,
+)
 
 
 def test_remove_dup_list_with_invalid_arg():
@@ -61,3 +65,50 @@ def test_contains_with_correct_sequence():
     result = contains(subset, target)
 
     assert result is True
+
+
+def test_descriptor_to_androguard_format_with_invalid_str():
+    descriptor = "Z"
+
+    with pytest.raises(ValueError):
+        _ = descriptor_to_androguard_format(descriptor)
+
+
+def test_descriptor_to_androguard_format_with_formatted_str():
+    descriptor = "(I Ljava/lang/String; [B J)"
+
+    result = descriptor_to_androguard_format(descriptor)
+
+    assert result == descriptor
+
+
+def test_descriptor_to_androguard_format_with_primitive():
+    descriptor = "(ZBCSIJFD)"
+
+    result = descriptor_to_androguard_format(descriptor)
+
+    assert result == "(Z B C S I J F D)"
+
+
+def test_descriptor_to_androguard_format_with_class():
+    descriptor = "(Ljava/lang/String;)"
+
+    result = descriptor_to_androguard_format(descriptor)
+
+    assert result == "(Ljava/lang/String;)"
+
+
+def test_descriptor_to_androguard_format_with_array():
+    descriptor = "([Ljava/lang/String;)"
+
+    result = descriptor_to_androguard_format(descriptor)
+
+    assert result == "([Ljava/lang/String;)"
+
+
+def test_descriptor_to_androguard_format_with_combination():
+    descriptor = "(ILjava/lang/String;[BJ)"
+
+    result = descriptor_to_androguard_format(descriptor)
+
+    assert result == "(I Ljava/lang/String; [B J)"


### PR DESCRIPTION
**Description**
Refer to  #138 
This PR inserts additional spaces into those APIs that don't have spaces in the arguments. The adjustment happens when Quark loading a JSON rule.

**Code changes**
1. quark/utils/tools.py
   - add a function to add spaces to the API.
2. quark/core/struct/ruleobject.py
   - support API without spaces.
3. quark/core/rzapkinfo.py
   - remove the repeated code.
   
**Test plan**
- [x]  All tests passed.