### PR TITLE
Add JSON output option to graph

### DIFF
--- a/quark/cli.py
+++ b/quark/cli.py
@@ -65,8 +65,10 @@ logo()
 @click.option(
     "-g",
     "--graph",
-    is_flag=True,
+    is_flag=False,
     help="Create call graph to call_graph_image directory",
+    flag_value="png",
+    type=click.Choice(["png", "json"]),
     required=False,
 )
 @click.option(
@@ -311,7 +313,7 @@ def entry_point(
         if classification:
             data.show_rule_classification()
         if graph:
-            data.show_call_graph()
+            data.show_call_graph(graph)
 
     # Show detail report
     if detail:

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -635,7 +635,7 @@ class Quark:
             for seq_operation in self.quark_analysis.level_5_result:
                 print(f"\t\t {seq_operation.full_name}")
 
-    def show_call_graph(self, output_format):
+    def show_call_graph(self, output_format=None):
         print_info("Creating Call Graph...")
         for call_graph_analysis in self.quark_analysis.call_graph_analysis_list:
             call_graph(call_graph_analysis, output_format)

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -635,10 +635,10 @@ class Quark:
             for seq_operation in self.quark_analysis.level_5_result:
                 print(f"\t\t {seq_operation.full_name}")
 
-    def show_call_graph(self):
+    def show_call_graph(self, output_format):
         print_info("Creating Call Graph...")
         for call_graph_analysis in self.quark_analysis.call_graph_analysis_list:
-            call_graph(call_graph_analysis)
+            call_graph(call_graph_analysis, output_format)
         print_success("Call Graph Completed")
 
     def show_rule_classification(self):

--- a/quark/utils/graph.py
+++ b/quark/utils/graph.py
@@ -30,7 +30,7 @@ def wrapper_lookup(apkinfo, method, native_api):
     return []
 
 
-def call_graph(call_graph_analysis):
+def call_graph(call_graph_analysis, output_format="png"):
     """
     Generating a call graph based on two native Android APIs.
     """
@@ -53,7 +53,7 @@ def call_graph(call_graph_analysis):
         filename=f"{parent_function.name}_{first_call.name}_{second_call.name}",
         node_attr={"fontname": "Courier New Bold"},
         comment="Quark-Engine Call Graph Result",
-        format="png",
+        format=output_format,
         graph_attr={
             "label": f"Potential Malicious Activity: {crime}",
             "labelloc": "top",


### PR DESCRIPTION
**Descrption:**
- Add output format option to `graph`, the default value is `png`. Users can choose `JSON` as the output format. The `JSON` format is one of the formats provided by Graphviz.
- Related to #134 
- e.g. : `quark -a sample.apk -s -g json` will dump in json format

**Code changed:**
- cli.py
- quark.py
- graph.py