### PR TITLE
Fix json report format

### DIFF
--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -520,13 +520,10 @@ class Quark:
                     }
                 )
 
-        # Assign level 3 - list methods calling to the APIs
+        # Assign level 3 examine result
         combination = []
         if rule_obj.check_item[2]:
-            for method_list in self.quark_analysis.level_3_result:
-                combination.append(
-                    [method.full_name for method in method_list]
-                )
+            combination = rule_obj.api
 
         # Assign level 4 - 5 examine result if exist
         sequnce_show_up = []

--- a/tests/core/json_report_sample.json
+++ b/tests/core/json_report_sample.json
@@ -1,0 +1,156 @@
+{
+    "md5": "14d9f1a92dd984d6040cc41ed06e273e",
+    "apk_filename": "14d9f1a92dd984d6040cc41ed06e273e.apk",
+    "size_bytes": 166917,
+    "threat_level": "High Risk",
+    "total_score": 4,
+    "crimes": [
+        {
+            "crime": "Send Location via SMS",
+            "score": 4,
+            "weight": 4.0,
+            "confidence": "100%",
+            "permissions": [
+                "android.permission.SEND_SMS",
+                "android.permission.ACCESS_COARSE_LOCATION",
+                "android.permission.ACCESS_FINE_LOCATION"
+            ],
+            "native_api": [
+                {
+                    "class": "Landroid/telephony/TelephonyManager;",
+                    "method": "getCellLocation",
+                    "descriptor": "()Landroid/telephony/CellLocation;"
+                },
+                {
+                    "class": "Landroid/telephony/SmsManager;",
+                    "method": "sendTextMessage",
+                    "descriptor": "(Ljava/lang/String; Ljava/lang/String; Ljava/lang/String; Landroid/app/PendingIntent; Landroid/app/PendingIntent;)V"
+                }
+            ],
+            "combination": [
+                {
+                    "class": "Landroid/telephony/TelephonyManager",
+                    "method": "getCellLocation",
+                    "descriptor": "()Landroid/telephony/CellLocation;"
+                },
+                {
+                    "class": "Landroid/telephony/SmsManager",
+                    "method": "sendTextMessage",
+                    "descriptor": "(Ljava/lang/String; Ljava/lang/String; Ljava/lang/String; Landroid/app/PendingIntent; Landroid/app/PendingIntent;)V"
+                }
+            ],
+            "sequence": [
+                {
+                    "'Lcom/google/progress/AndroidClientService$2; run ()V'": {
+                        "first": [
+                            "invoke-virtual",
+                            "v5",
+                            "Lcom/google/progress/Locate;->getLocation()Ljava/lang/String;"
+                        ],
+                        "first_hex": "6e 10 2f 02 05 00",
+                        "second": [
+                            "invoke-virtual",
+                            "v3",
+                            "v0",
+                            "v4",
+                            "Lcom/google/progress/SMSHelper;->sendSms(Ljava/lang/String; Ljava/lang/String;)I"
+                        ],
+                        "second_hex": "6e 30 3e 02 03 04"
+                    }
+                },
+                {
+                    "'Lcom/google/progress/AndroidClientService; sendMessage ()V'": {
+                        "first": [
+                            "invoke-virtual",
+                            "v6",
+                            "Lcom/google/progress/Locate;->getLocation()Ljava/lang/String;"
+                        ],
+                        "first_hex": "6e 10 2f 02 06 00",
+                        "second": [
+                            "invoke-virtual",
+                            "v4",
+                            "v6",
+                            "v7",
+                            "Lcom/google/progress/SMSHelper;->sendSms(Ljava/lang/String; Ljava/lang/String;)I"
+                        ],
+                        "second_hex": "6e 30 3e 02 64 07"
+                    }
+                },
+                {
+                    "'Lcom/google/progress/AndroidClientService; doByte ([B)V'": {
+                        "first": [
+                            "invoke-virtual/range",
+                            "v35",
+                            "Lcom/google/progress/Locate;->getLocation()Ljava/lang/String;"
+                        ],
+                        "first_hex": "74 01 2f 02 23 00",
+                        "second": [
+                            "invoke-virtual",
+                            "v0",
+                            "v1",
+                            "v2",
+                            "Lcom/google/progress/SMSHelper;->sendSms(Ljava/lang/String; Ljava/lang/String;)I"
+                        ],
+                        "second_hex": "6e 30 3e 02 10 02"
+                    }
+                }
+            ],
+            "register": [
+                {
+                    "'Lcom/google/progress/AndroidClientService$2; run ()V'": {
+                        "first": [
+                            "invoke-virtual",
+                            "v5",
+                            "Lcom/google/progress/Locate;->getLocation()Ljava/lang/String;"
+                        ],
+                        "first_hex": "6e 10 2f 02 05 00",
+                        "second": [
+                            "invoke-virtual",
+                            "v3",
+                            "v0",
+                            "v4",
+                            "Lcom/google/progress/SMSHelper;->sendSms(Ljava/lang/String; Ljava/lang/String;)I"
+                        ],
+                        "second_hex": "6e 30 3e 02 03 04"
+                    }
+                },
+                {
+                    "'Lcom/google/progress/AndroidClientService; sendMessage ()V'": {
+                        "first": [
+                            "invoke-virtual",
+                            "v6",
+                            "Lcom/google/progress/Locate;->getLocation()Ljava/lang/String;"
+                        ],
+                        "first_hex": "6e 10 2f 02 06 00",
+                        "second": [
+                            "invoke-virtual",
+                            "v4",
+                            "v6",
+                            "v7",
+                            "Lcom/google/progress/SMSHelper;->sendSms(Ljava/lang/String; Ljava/lang/String;)I"
+                        ],
+                        "second_hex": "6e 30 3e 02 64 07"
+                    }
+                },
+                {
+                    "'Lcom/google/progress/AndroidClientService; doByte ([B)V'": {
+                        "first": [
+                            "invoke-virtual/range",
+                            "v35",
+                            "Lcom/google/progress/Locate;->getLocation()Ljava/lang/String;"
+                        ],
+                        "first_hex": "74 01 2f 02 23 00",
+                        "second": [
+                            "invoke-virtual",
+                            "v0",
+                            "v1",
+                            "v2",
+                            "Lcom/google/progress/SMSHelper;->sendSms(Ljava/lang/String; Ljava/lang/String;)I"
+                        ],
+                        "second_hex": "6e 30 3e 02 10 02"
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/core/test_quark.py
+++ b/tests/core/test_quark.py
@@ -1,4 +1,5 @@
 import base64
+import json
 import os
 from unittest.mock import patch
 
@@ -432,3 +433,20 @@ class TestQuark:
         # Check if proper dict object
         assert isinstance(json_report, dict)
         assert json_report.get("md5") == "14d9f1a92dd984d6040cc41ed06e273e"
+
+    def test_json_report_format(self, quark_obj):
+        # Inner function for comparing two json objects
+        def sorting(item):
+            if isinstance(item, dict):
+                return sorted((key, sorting(values)) for key, values in item.items())
+            if isinstance(item, list):
+                return sorted(sorting(x) for x in item)
+            else:
+                return item
+
+        json_report = quark_obj.get_json_report()
+
+        with open("tests/core/json_report_sample.json") as json_file:
+            sample_json = json.loads(json_file.read())
+
+            assert sorting(sample_json) == sorting(json_report)


### PR DESCRIPTION
Description
In the feature request in issue #117, there are two PRs (#254, #247) related to it and modified the original report format, including the detail report and JSON report, which caused Jadx and APKLab to fail to read different JSON formats.

Code change

1. quark/core/quark.py

Test plan
Adding a new test in `tests/core/test_quark.py` to ensure that the format must match the sample JSON file `tests/core/json_report_sample.json`.