### PR TITLE
fix: add missing comma between two depends in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Build-Depends: debhelper-compat (= 12),
                python3-colorama,
                python3-click,
                python3-graphviz,
-               python3-pandas
+               python3-pandas,
                python3-prompt-toolkit
 
 Standards-Version: 21.4.3
@@ -32,7 +32,7 @@ Depends: ${misc:Depends},
          python3-colorama,
          python3-click,
          python3-graphviz,
-         python3-pandas
+         python3-pandas,
          python3-prompt-toolkit
 Description: Android Malware (Analysis | Scoring System)
  Quark-Engine is a full-featured Android analysis framework written in


### PR DESCRIPTION
fix #285 