### PR TITLE
Fix the missing file in the PyPi package

### DIFF
--- a/quark/core/axmlreader/__init__.py
+++ b/quark/core/axmlreader/__init__.py
@@ -1,6 +1,7 @@
 import enum
 import functools
 import os.path
+import pkg_resources
 
 import rzpipe
 
@@ -72,8 +73,7 @@ class AxmlReader(object):
 
     def __init__(self, file_path, structure_path=None):
         if structure_path is None:
-            directory = os.path.dirname(__file__)
-            structure_path = os.path.join(directory, "axml_definition")
+            structure_path = pkg_resources.resource_filename("quark.core.axmlreader", "axml_definition")
 
         if not os.path.isfile(structure_path):
             raise AxmlException(

--- a/quark/core/axmlreader/__init__.py
+++ b/quark/core/axmlreader/__init__.py
@@ -73,7 +73,9 @@ class AxmlReader(object):
 
     def __init__(self, file_path, structure_path=None):
         if structure_path is None:
-            structure_path = pkg_resources.resource_filename("quark.core.axmlreader", "axml_definition")
+            structure_path = pkg_resources.resource_filename(
+                "quark.core.axmlreader", "axml_definition"
+            )
 
         if not os.path.isfile(structure_path):
             raise AxmlException(

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,9 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/quark-engine/quark-engine",
     packages=setuptools.find_packages(),
+    package_data={
+        "quark.core.axmlreader":["axml_definition"]
+    },
     entry_points={
         "console_scripts": [
             "quark=quark.cli:entry_point",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     url="https://github.com/quark-engine/quark-engine",
     packages=setuptools.find_packages(),
     package_data={
-        "quark.core.axmlreader":["axml_definition"]
+        "quark.core.axmlreader": ["axml_definition"]
     },
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
**Description**

Fix #295.

This PR aims to

1. modify `setup.py` to include the missing file, `quark/core/axmlreader/axml_definition`.
2. use [the recommended API](https://setuptools.pypa.io/en/latest/userguide/datafiles.html?highlight=INclude#accessing-data-files-at-runtime)  to access it in the Rizin-based analysis library.