### PR TITLE
Specify the minimal supported version of prettytable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as fh:
     long_description = fh.read()
 
 required_requirements = [
-    "prettytable",
+    "prettytable>=1.0.0",
     "androguard==3.4.0a1",
     "tqdm",
     "colorama",


### PR DESCRIPTION
**Description**

Please refer to #304.
This PR specifies the minimal supported version of [prettytable](https://github.com/jazzband/prettytable) to `1.0.0`.

**Code Changes**
+ `setup.py`