### PR TITLE
Update the analysis library for Rizin v0.3.x

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,7 +31,7 @@ jobs:
         
         
         # Install Rizin
-        sudo git clone --branch v0.2.1 https://github.com/rizinorg/rizin /opt/rizin/
+        sudo git clone --branch v0.3.4 https://github.com/rizinorg/rizin /opt/rizin/
         cd /opt/rizin/
         meson build
         ninja -C build

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ quark -a Ahmyth.apk -s --multi-process 4
 ```
 
 ### Upcoming unstable feature
-Now Quark also supports [Rizin](https://github.com/rizinorg/rizin) (v0.2.0 or v0.2.1, please see [#305](https://github.com/quark-engine/quark-engine/issues/305) for more detail) as one of our Android analysis frameworks. You can use option `--core-library` with `rizin` to enable the Rizin-based analysis library.
+Now Quark also supports [Rizin](https://github.com/rizinorg/rizin) as one of our Android analysis frameworks. You can use option `--core-library` with `rizin` to enable the Rizin-based analysis library.
 ```bash
 quark -a Ahmyth.apk -s --core-library rizin
 ```

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -29,7 +29,7 @@ from quark.utils.output import (
     output_parent_function_json,
     output_parent_function_table,
 )
-from quark.utils.pprint import print_info, print_success
+from quark.utils.pprint import print_info, print_success, print_warning
 from quark.utils.weight import Weight
 
 MAX_SEARCH_LAYER = 3
@@ -422,6 +422,17 @@ class Quark:
                 self.quark_analysis.level_3_result[1].update(
                     second_api_xref_from
                 )
+
+                if not first_api_xref_from:
+                    print_warning(
+                        f"Unable to find the upperfunc of {first_api}"
+                    )
+                    continue
+                if not second_api_xref_from:
+                    print_warning(
+                        f"Unable to find the upperfunc of{second_api}"
+                    )
+                    continue
 
                 mutual_parent_function_list = self.find_intersection(
                     first_api_xref_from, second_api_xref_from

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -334,7 +334,7 @@ class Quark:
         for method in potential_method_list:
             current_class_set = {method.class_name}
 
-            while not current_class_set.intersection(
+            while current_class_set and not current_class_set.intersection(
                 {class_name, "Ljava/lang/Object;"}
             ):
                 next_class_set = set()

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -24,6 +24,20 @@ from quark.utils.tools import descriptor_to_androguard_format, remove_dup_list
 
 RizinCache = namedtuple("rizin_cache", "address dexindex is_imported")
 
+PRIMITIVE_TYPE_MAPPING = {
+    "void":"V",
+    "boolean":"Z",
+    "byte":"B",
+    "char":"C",
+    "short":"S",
+    "int":"I",
+    "long":"J",
+    "float":"F",
+    "double":"D",
+    "String":"Ljava/lang/String;"
+}
+
+RIZIN_ESCAPE_CHAR_LIST = ['<', '>', '$']
 
 class RizinImp(BaseApkinfo):
     def __init__(
@@ -68,20 +82,6 @@ class RizinImp(BaseApkinfo):
         return rz
 
     def _convert_type_to_type_signature(self, raw_type: str):
-        # TODO - Initialize the dict only once
-        mapping_dict = {
-            "void":"V",
-            "boolean":"Z",
-            "byte":"B",
-            "char":"C",
-            "short":"S",
-            "int":"I",
-            "long":"J",
-            "float":"F",
-            "double":"D",
-            "String":"Ljava/lang/String;"
-        }
-
         if raw_type.endswith('[]'):
             return '[' + self._convert_type_to_type_signature(raw_type[:-2])
 
@@ -99,8 +99,7 @@ class RizinImp(BaseApkinfo):
         return raw_type
             
     def _escape_str_in_rizin_manner(self, raw_str: str):
-        char_list = ['<', '>', '$']
-        for c in char_list:
+        for c in RIZIN_ESCAPE_CHAR_LIST:
             raw_str = raw_str.replace(c, '_')
         return raw_str
 

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -105,7 +105,8 @@ class RizinImp(BaseApkinfo):
 
         return raw_type
 
-    def _escape_str_in_rizin_manner(self, raw_str: str):
+    @staticmethod
+    def _escape_str_in_rizin_manner(raw_str: str):
         for c in RIZIN_ESCAPE_CHAR_LIST:
             raw_str = raw_str.replace(c, "_")
         return raw_str
@@ -164,6 +165,9 @@ class RizinImp(BaseApkinfo):
             # -- Method name --
             method_name = json_obj["realname"]
 
+            # -- Is imported --
+            is_imported = json_obj["is_imported"]
+
             # -- Class name --
             # Test if the class name is truncated
             escaped_method_name = self._escape_str_in_rizin_manner(method_name)
@@ -205,9 +209,6 @@ class RizinImp(BaseApkinfo):
                 flag_name = flag_name[4:]
 
             class_name = self._convert_type_to_type_signature(flag_name)
-
-            # -- Is imported --
-            is_imported = json_obj["is_imported"]
 
             # Append the method
             method = MethodObject(

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -9,7 +9,6 @@ import re
 import tempfile
 import zipfile
 from collections import defaultdict, namedtuple
-from curses import raw
 from os import PathLike
 from typing import Dict, Generator, List, Optional, Set, Union
 

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -25,19 +25,28 @@ from quark.utils.tools import descriptor_to_androguard_format, remove_dup_list
 RizinCache = namedtuple("rizin_cache", "address dexindex is_imported")
 
 PRIMITIVE_TYPE_MAPPING = {
-    "void":"V",
-    "boolean":"Z",
-    "byte":"B",
-    "char":"C",
-    "short":"S",
-    "int":"I",
-    "long":"J",
-    "float":"F",
-    "double":"D",
-    "String":"Ljava/lang/String;"
+    "void": "V",
+    "boolean": "Z",
+    "byte": "B",
+    "char": "C",
+    "short": "S",
+    "int": "I",
+    "long": "J",
+    "float": "F",
+    "double": "D",
+    "Boolean": "Ljava/lang/Boolean;",
+    "Byte": "Ljava/lang/Byte;",
+    "Character": "Ljava/lang/Character;",
+    "Short": "Ljava/lang/Short;",
+    "Integer": "Ljava/lang/Integer;",
+    "Long": "Ljava/lang/Long;",
+    "Float": "Ljava/lang/Float;",
+    "Double": "Ljava/lang/Double;",
+    "String": "Ljava/lang/String;",
 }
 
-RIZIN_ESCAPE_CHAR_LIST = ['<', '>', '$']
+RIZIN_ESCAPE_CHAR_LIST = ["<", ">", "$"]
+
 
 class RizinImp(BaseApkinfo):
     def __init__(

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -117,7 +117,10 @@ class TestApkinfo:
             ),
         }
 
-        assert len(apkinfo.android_apis) == 1270
+        if apkinfo.core_library == "androguard":
+            assert len(apkinfo.android_apis) == 1270
+        elif apkinfo.core_library == "rizin":
+            assert len(apkinfo.android_apis) == 1269
         assert api.issubset(apkinfo.android_apis)
 
     def test_custom_methods(self, apkinfo):
@@ -133,7 +136,10 @@ class TestApkinfo:
                 "()V",
             ),
         }
-        assert len(apkinfo.custom_methods) == 3999
+        if apkinfo.core_library == "androguard":
+            assert len(apkinfo.custom_methods) == 3999
+        elif apkinfo.core_library == "rizin":
+            assert len(apkinfo.custom_methods) == 3990
         assert test_custom_method.issubset(apkinfo.custom_methods)
 
     def test_all_methods(self, apkinfo):
@@ -153,7 +159,7 @@ class TestApkinfo:
         if apkinfo.core_library == "androguard":
             assert len(apkinfo.all_methods) == 5452
         elif apkinfo.core_library == "rizin":
-            assert len(apkinfo.all_methods) == 5273
+            assert len(apkinfo.all_methods) == 5260
 
         assert test_custom_method.issubset(apkinfo.all_methods)
 
@@ -168,20 +174,21 @@ class TestApkinfo:
         assert str(result.descriptor) == "(Z)V"
 
     def test_upperfunc(self, apkinfo):
-        api = apkinfo.find_method("Ljava/lang/reflect/Field;", "setAccessible", "(Z)V")
-
-        expect_function = MethodObject(
-            (
-                "Landroid/support/v4/widget/SlidingPaneLayout$"
-                "SlidingPanelLayoutImplJB;"
-            ),
+        api = apkinfo.find_method(
+            "Lcom/example/google/service/ContactsHelper;",
             "<init>",
-            "()V",
+            "(Landroid/content/Context;)V",
         )
 
-        upper = list(apkinfo.upperfunc(api))[0]
+        expect_function = apkinfo.find_method(
+            "Lcom/example/google/service/SMSReceiver;",
+            "isContact",
+            "(Ljava/lang/String;)Ljava/lang/Boolean;",
+        )
 
-        assert upper == expect_function
+        upper_methods = list(apkinfo.upperfunc(api))
+
+        assert expect_function in upper_methods
 
     def test_lowerfunc(self, apkinfo):
         method = apkinfo.find_method(
@@ -238,17 +245,17 @@ class TestApkinfo:
 
     def test_lowerfunc(self, apkinfo):
         method = apkinfo.find_method(
-            "Lcom/example/google/service/WebServiceCalling;",
-            "Send",
-            "(Landroid/os/Handler; Ljava/lang/String;)V",
+            "Lcom/example/google/service/SMSReceiver;",
+            "isContact",
+            "(Ljava/lang/String;)Ljava/lang/Boolean;",
         )
 
         expect_method = apkinfo.find_method(
-            "Ljava/lang/StringBuilder;",
-            "append",
-            "(Ljava/lang/String;)Ljava/lang/StringBuilder;",
+            "Lcom/example/google/service/ContactsHelper;",
+            "<init>",
+            "(Landroid/content/Context;)V",
         )
-        expect_offset = 42
+        expect_offset = 10
 
         upper_methods = apkinfo.lowerfunc(method)
 


### PR DESCRIPTION
**Description**

Close #314.
This PR updates the Rizin-based analysis library to work with Rizin v0.3.x. It includes the following changes:
1. Update parsers for Rizin command `isj` and `pdfj`.
2. Replace command `icg` with `icj` since Rizin v0.3.0 removed it.
3. Add more checks to prevent [upstream issues](https://github.com/rizinorg/rizin/issues/2416) crashing Quark.

**Code Changes**

+ quark/core/quark.py
+ quark/core/rzapkinfo.py

**Test Plans**

All tests passed on Rizin v0.3.x (v0.3.0, v0.3.1, v0.3.2, v0.3.3, and v0.3.4).