### PR TITLE
Use field `lib` to get a method's class name from Rizin

### DIFF
--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -163,7 +163,7 @@ class TestApkinfo:
 
         assert test_custom_method.issubset(apkinfo.all_methods)
 
-    def test_find_method(self, apkinfo):
+    def test_find_method_in_regular_class(self, apkinfo):
         result = apkinfo.find_method(
             "Ljava/lang/reflect/Field;", "setAccessible", "(Z)V"
         )
@@ -172,6 +172,43 @@ class TestApkinfo:
         assert str(result.class_name) == "Ljava/lang/reflect/Field;"
         assert str(result.name) == "setAccessible"
         assert str(result.descriptor) == "(Z)V"
+
+    def test_find_method_in_inner_class(self, apkinfo):
+        result = apkinfo.find_method(
+            "Landroid/support/v4/accessibilityservice/Accessibility"
+            + "ServiceInfoCompat$AccessibilityServiceInfoVersionImpl;",
+            "getId",
+            "(Landroid/accessibilityservice/AccessibilityServiceInfo;)"
+            + "Ljava/lang/String;",
+        )
+
+        assert isinstance(result, MethodObject)
+        assert (
+            str(result.class_name)
+            == "Landroid/support/v4/accessibilityservice/Accessibility"
+            + "ServiceInfoCompat$AccessibilityServiceInfoVersionImpl;"
+        )
+        assert str(result.name) == "getId"
+        assert (
+            str(result.descriptor)
+            == "(Landroid/accessibilityservice/AccessibilityServiceInfo;)"
+            + "Ljava/lang/String;"
+        )
+
+    def test_find_method_in_anonymous_class(self, apkinfo):
+        result = apkinfo.find_method(
+            "Landroid/support/v4/view/AccessibilityDelegateCompatIcs$1;",
+            "sendAccessibilityEvent",
+            "(Landroid/view/View; I)V",
+        )
+
+        assert isinstance(result, MethodObject)
+        assert (
+            str(result.class_name)
+            == "Landroid/support/v4/view/AccessibilityDelegateCompatIcs$1;"
+        )
+        assert str(result.name) == "sendAccessibilityEvent"
+        assert str(result.descriptor) == "(Landroid/view/View; I)V"
 
     def test_upperfunc(self, apkinfo):
         api = apkinfo.find_method(


### PR DESCRIPTION
**Description**
Close #331.
Use another field called `lib` to bypass the length limitation since Rizin recently added it to the `isj` command.
Thank the Rizin community for this handy feature. :D

**Test plan**
Add two tests for methods in inner classes and anonymous classes.