### PR TITLE
Ensure Quark runs with a compatible Rizin

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -31,8 +31,8 @@ Once you see the following msg, then you're all set::
       -o, --output FILE               Output report in JSON
       -a, --apk FILE                  APK file  [required]
       -r, --rule PATH                 Rules directory  [default:
-                                      /Users/$USER/.quark-engine/quark-rules]
-      -g, --graph                     Create call graph to call_graph_image
+                                      /home/haeter/.quark-engine/quark-rules]
+      -g, --graph [png|json]          Create call graph to call_graph_image
                                       directory
       -c, --classification            Show rules classification
       -t, --threshold [100|80|60|40|20]
@@ -46,9 +46,14 @@ Once you see the following msg, then you're all set::
       --core-library [androguard|rizin]
                                       Specify the core library used to analyze an
                                       APK
-      --multi-process INTEGER RANGE   Allow analyzing APK with N processes, 
-                                      where N doesn't exceeds the number of usable CPUs - 1 
-                                      to avoid memory exhaustion.
+      --multi-process INTEGER RANGE   Allow analyzing APK with N processes, where
+                                      N doesn't exceeds the number of usable CPUs
+                                      - 1 to avoid memory exhaustion.  [x>=1]
+      --rizin-path FILE               Specify a Rizin executable for Quark to
+                                      perform analyses.
+      --disable-rizin-installation    Don't install Rizin automatically when no
+                                      Rizin instance with a compatible version is
+                                      found.
       --version                       Show the version and exit.
       --help                          Show this message and exit.
 

--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -15,6 +15,29 @@ Then we could test one of the apk in `apk-malware-samples` by the rules `quark-r
 
     $ quark -a Ahmyth.apk -s
 
+Running analyses based on Rizin
+==================
+
+Now Quark also supports `Rizin`_ as one of our Android analysis frameworks. You can use option ``--core-library`` with ``rizin`` to enable the Rizin-based analysis library.
+
+.. _`Rizin`: https://github.com/rizinorg/rizin
+
+.. code-block:: bash
+
+    quark -a Ahmyth.apk -s --core-library rizin
+
+
+For now, Quark is compatible with Rizin v0.4.0. But, users don't have to installed a Rizin with that version. Quark provides a feature to automatically setup a independent Rizin. In this way, the dependency will not conflict with your environment. Type in the above command and let Quark handle everything else for you.
+
+If there is a working installation of Rizin installed in the system, Quark will check its version to determine if it is compatible. If true, Quark automatically uses it for the analysis. Otherwise, Quark uses the independent Rizin installed in the Quark directory (``~/.quark-engine``).
+
+You can use option ``--rizin-path`` to specify the path of the Rizin executable.
+
+.. code-block:: bash
+
+    quark -a Ahmyth.apk -s --core-library rizin --rizin-path path_to_a_rizin_executable
+
+Moreover, if you don't want Quark to install an independent Rizin, you can use the flag ``--disable-rizin-installation`` to disable this feature.
 
 Running in Docker
 =================

--- a/quark/config.py
+++ b/quark/config.py
@@ -9,5 +9,9 @@ SOURCE = "https://github.com/quark-engine/quark-rules"
 DIR_PATH = f"{HOME_DIR}quark-rules"
 
 DEBUG = False
+COMPATIBLE_RAZIN_VERSIONS = ["0.4.0"]
+
+RIZIN_DIR = f"{HOME_DIR}rizin/"
+RIZIN_COMMIT = "de8a5cac5532845643a52d1231b17a7b34feb50a"
 
 Path(HOME_DIR).mkdir(parents=True, exist_ok=True)

--- a/quark/core/axmlreader/__init__.py
+++ b/quark/core/axmlreader/__init__.py
@@ -1,8 +1,8 @@
 import enum
 import functools
 import os.path
-import pkg_resources
 
+import pkg_resources
 import rzpipe
 
 # Resource Types Definition
@@ -71,7 +71,19 @@ class AxmlReader(object):
     A Class that parses the Android XML file
     """
 
-    def __init__(self, file_path, structure_path=None):
+    def __init__(self, file_path, structure_path=None, rizin_path=None):
+        """
+        Create an AxmlReader object to parse the given Android XML file like
+        AndroidManifest.xml.
+
+        :param file_path: a file in the Android XML format
+        :param structure_path: a plain text file defining the structures of
+        the Android XML format. Defaults to None
+        :param rizin_path: a PathLike object to specify a Rizin executable to
+        use. Defaults to None
+        :raises AxmlException: if the given file is an invalid Android XML
+        file
+        """
         if structure_path is None:
             structure_path = pkg_resources.resource_filename(
                 "quark.core.axmlreader", "axml_definition"
@@ -83,7 +95,7 @@ class AxmlReader(object):
                 f" of Rizin in {structure_path}"
             )
 
-        self._rz = rzpipe.open(file_path)
+        self._rz = rzpipe.open(file_path, rizin_home=rizin_path)
         self._rz.cmd(f"pfo {structure_path}")
 
         self._file_size = int(self._rz.cmd("i~size[1]"), 16)

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -38,14 +38,18 @@ MAX_SEARCH_LAYER = 3
 class Quark:
     """Quark module is used to check quark's five-stage theory"""
 
-    def __init__(self, apk, core_library="androguard"):
+    def __init__(self, apk, core_library="androguard", rizin_path=None):
         """
+        Create a Quark object.
 
-        :param apk: the filename of the apk.
+        :param apk: an APK for Quark to analyze
+        :param core_library: a string indicating which analysis library Quark should use. Defaults to "androguard"
+        :param rizin_path: a PathLike object to specify a Rizin executable for the Rizin-based analysis library. Defaults to None
+        :raises ValueError: if an unknown core library is specified
         """
         core_library = core_library.lower()
         if core_library == "rizin":
-            self.apkinfo = RizinImp(apk)
+            self.apkinfo = RizinImp(apk, rizin_path=rizin_path)
         elif core_library == "androguard":
             self.apkinfo = AndroguardImp(apk)
         else:

--- a/quark/report.py
+++ b/quark/report.py
@@ -6,6 +6,7 @@ import os
 
 from quark.core.quark import Quark
 from quark.core.struct.ruleobject import RuleObject
+from quark.utils.tools import find_rizin_instance
 
 
 class Report:
@@ -13,20 +14,46 @@ class Report:
     This module is for users who want to use quark as a Python module.
     """
 
-    def __init__(self):
-        self.quark = None
-
-    def analysis(self, apk, rule, core_library="androguard"):
+    def __init__(self, rizin_path=None, disable_rizin_installation=False):
         """
-        The main function of Quark-Engine analysis, the analysis is based on the provided APK file.
+        Create a Report object.
 
-        :param core_library: the library to analysis binary
-        :param apk: the APK file
-        :param rule: the rule to be checked, it could be a directory or a single json rule
+        :param rizin_path: a PathLike object to specify a Rizin executable for
+        the Rizin-based analysis library. Defaults to None
+        :param disable_rizin_installation: a flag to disable the automatic
+        installation of Rizin. Defaults to False. Defaults to False
+        """
+        self.quark = None
+        self.rizin_path = rizin_path
+        self.disable_rizin_installation = disable_rizin_installation
+
+    def analysis(self, apk, rule, core_library="androguard", rizin_path=None):
+        """
+        The main function of Quark-Engine analysis, the analysis is based on
+        the provided APK file.
+
+        :param apk: an APK for Quark to analyze
+        :param rule: a Quark rule that will be used in the analysis. It could
+        be a directory or a Quark rule
+        :param core_library: a string indicating which analysis library Quark
+        should use. Defaults to "androguard"
+        :param rizin_path: a PathLike object to specify a Rizin executable for
+        the Rizin-based analysis library. Defaults to None
         :return: None
         """
 
-        self.quark = Quark(apk, core_library)
+        if core_library.lower() == "rizin":
+            if rizin_path:
+                self.rizin_path = rizin_path
+            elif not self.rizin_path:
+                self.rizin_path = find_rizin_instance(
+                    disable_rizin_installation=self.disable_rizin_installation
+                )
+
+                if not self.rizin_path:
+                    raise ValueError("Cannot found a valid Rizin executable.")
+
+        self.quark = Quark(apk, core_library, self.rizin_path)
 
         if os.path.isdir(rule):
 

--- a/quark/utils/pprint.py
+++ b/quark/utils/pprint.py
@@ -3,8 +3,14 @@
 # See the file 'LICENSE' for copying permission.
 
 from prettytable import PrettyTable
+from quark.utils.colors import bold, cyan, green, red, yellow
 
-from quark.utils.colors import bold, cyan, yellow, red, green
+
+def clear_the_last_line():
+    """
+    Clear the last line of the terminal.
+    """
+    print("\033[A\033[A")
 
 
 def print_info(message):

--- a/quark/utils/tools.py
+++ b/quark/utils/tools.py
@@ -4,6 +4,19 @@
 
 import copy
 import re
+import shutil
+import subprocess
+from ast import Str
+from os import F_OK, PathLike, access, mkdir
+from xmlrpc.client import Boolean
+
+from quark.config import COMPATIBLE_RAZIN_VERSIONS, RIZIN_COMMIT, RIZIN_DIR
+from quark.utils.pprint import (
+    clear_the_last_line,
+    print_error,
+    print_info,
+    print_success,
+)
 
 
 def remove_dup_list(element):
@@ -55,3 +68,253 @@ def descriptor_to_androguard_format(descriptor):
     new_descriptor = re.sub(r"\[ ", "[", new_descriptor)
 
     return new_descriptor
+
+
+def execute_command(command, stderr=subprocess.PIPE, cwd=None):
+    """
+    Execute a given command and yield the messages from the standard output.
+
+    :param command: a list of strings which is the command to execute
+    :param cwd: a PathLike object which is the working directory. Defaults to
+    None
+    :raises subprocess.CalledProcessError: if the process terminates with a
+    non-zero return code
+    :yield: a string holding a line of message in the standard output
+    """
+    process = subprocess.Popen(
+        command,
+        bufsize=1,
+        stdout=subprocess.PIPE,
+        stderr=stderr,
+        universal_newlines=True,
+        cwd=cwd,
+    )
+
+    line = ""
+    while True:
+        char = process.stdout.read(1)
+        if char == "\n" or char == "\r":
+            clear_the_last_line()
+            yield line
+            line = ""
+            continue
+
+        elif char == "":
+            break
+
+        line = line + char
+
+    process.stdout.close()
+    return_code = process.wait()
+
+    if return_code:
+        error_messages = ""
+        if stderr == subprocess.PIPE:
+            for message in process.stderr.readlines():
+                error_messages = error_messages + message
+
+        raise subprocess.CalledProcessError(
+            return_code, command, stderr=error_messages
+        )
+
+    if stderr == subprocess.PIPE:
+        process.stderr.close()
+
+
+def get_rizin_version(rizin_path) -> Str:
+    """
+    Get the version number of the Rizin instance in the path.
+
+    :param rizin_path: a path to the Rizin executable
+    :return: the version number of the Rizin instance
+    """
+    try:
+        process = subprocess.run(
+            [rizin_path, "-v"], timeout=5, check=True, stdout=subprocess.PIPE
+        )
+        result = str(process.stdout)
+
+        matched_versions = re.finditer(
+            r"[0-9]+\.[0-9]+\.[0-9]+", result[: result.index("@")]
+        )
+        first_matched = next(matched_versions, None)
+
+        if first_matched:
+            return first_matched.group(0)
+        else:
+            return None
+
+    except BaseException:
+        return None
+
+
+def download_rizin(target_path) -> Boolean:
+    """
+    Download the source code of Rizin into the specified path. If a file or
+    folder already exists, this function will remove them.
+
+    :param target_path: a PathLike object specifying the location to save the
+    downloaded files
+    :return: a boolean indicating if the operation finishes without errors
+    """
+    if access(target_path, F_OK):
+        shutil.rmtree(target_path)
+        mkdir(target_path)
+
+    try:
+        print()
+
+        for line in execute_command(
+            [
+                "git",
+                "clone",
+                "--progress",
+                "https://github.com/rizinorg/rizin",
+                target_path,
+            ],
+            stderr=subprocess.STDOUT,
+        ):
+            print_info(line)
+
+        return True
+
+    except subprocess.CalledProcessError as error:
+        print_error("An error occurred when downloading Rizin.\n")
+
+    return False
+
+
+def update_rizin(source_path, target_commit) -> Boolean:
+    """
+    Checkout the specified commit in the Rizin repository. Then, compile the
+    source code to build a Rizin executable.
+
+    :param source_path: a PathLike object specifying the location to the
+    source code
+    :param target_commit: a hash value representing a valid commit in the
+    repository
+    :return: a boolean indicating the operation is success or not
+    """
+
+    try:
+        print()
+
+        # Checkout to target commit
+        for line in execute_command(
+            ["git", "checkout", target_commit], cwd=source_path
+        ):
+            print_info(line)
+
+        # Remove the last build
+        for line in execute_command(["rm", "-rf", "build"], cwd=source_path):
+            print_info(line)
+
+        # Clean out old subproject
+        for line in execute_command(
+            ["git", "clean", "-dxff", "subprojects/"], cwd=source_path
+        ):
+            print_info(line)
+
+    except subprocess.CalledProcessError as error:
+        print_error("An error occurred when updating Rizin.\n")
+
+        for line in error.stderr.decode().splitlines():
+            print_error(line)
+
+        return False
+
+    # Compile Rizin
+    try:
+        print()
+
+        # Configure
+        for line in execute_command(
+            ["meson", "--buildtype=release", "build"], cwd=source_path
+        ):
+            print_info(line)
+
+        # Compile the source code
+        for line in execute_command(
+            ["meson", "compile", "-C", "build"], cwd=source_path
+        ):
+            print_info(line)
+
+        return True
+
+    except subprocess.CalledProcessError as error:
+        print_error("An error occurred when updating Rizin.\n")
+
+        for line in error.stderr.decode().splitlines():
+            print_error(line)
+
+        return False
+
+
+def find_rizin_instance(
+    rizin_source_path: PathLike = RIZIN_DIR,
+    target_commit: Str = RIZIN_COMMIT,
+    disable_rizin_installation: Boolean = False,
+) -> Str:
+    """
+    Search the system PATH and the Quark directory (~/.quark-engine)
+    respectively to find an appropriate Rizin executable. If none of them are
+    usable and the user doesn't disable the automatic installation feature,
+    this method will download the source code and compile a Rizin executable
+    for Quark.
+
+    :param rizin_source_path: a path to the source code of Rizin. Defaults to
+    RIZIN_DIR
+    :param target_commit: a commmit specifying the Rizin version to compile.
+    Defaults to RIZIN_COMMIT
+    :param disable_rizin_installation: a flag to disable the automatic
+    installation of Rizin. Defaults to False
+    :return: a path if an appropriate Rizin executable is found, otherwise
+    None
+    """
+
+    # Search Rizin in PATH
+    which_result = shutil.which("rizin")
+    if which_result:
+        version = get_rizin_version(which_result)
+        if version in COMPATIBLE_RAZIN_VERSIONS:
+            return which_result
+
+    # Otherwise, search the home path
+    rizin_executable_path = rizin_source_path + "build/binrz/rizin/rizin"
+    current_version = get_rizin_version(rizin_executable_path)
+
+    if not current_version and not disable_rizin_installation:
+        print_info("Cannot find a compatible Rizin instance.")
+        print_info("Automatically install Rizin into the Quark directory.")
+        for _ in range(3):
+            result = download_rizin(rizin_source_path)
+            if result:
+                break
+
+        result = update_rizin(rizin_source_path, target_commit)
+        if result:
+            print_success("Successfully install Rizin.")
+            return rizin_executable_path
+        else:
+            return None
+
+    if not current_version:
+        return None
+
+    if current_version in COMPATIBLE_RAZIN_VERSIONS:
+        return rizin_executable_path
+
+    # The current version is not compatible
+    print_info(
+        "Find an outdated Rizin executable in the Quark directory. Try to update it."
+    )
+
+    if disable_rizin_installation:
+        return rizin_executable_path
+    else:
+        # Update and compile the source code
+        result = update_rizin(rizin_source_path, target_commit)
+        if result:
+            return rizin_executable_path
+        else:
+            return None

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,11 +1,11 @@
 import os
 import os.path
+import shutil
 import zipfile
 from unittest.mock import patch
 
 import pytest
 import requests
-
 from quark.report import Report
 
 
@@ -19,7 +19,8 @@ def invalid_file(tempfile):
 @pytest.fixture(scope="module")
 def sample_apk_file():
     APK_SOURCE = (
-        "https://github.com/quark-engine/" "apk-malware-samples/raw/master/Ahmyth.apk"
+        "https://github.com/quark-engine/"
+        "apk-malware-samples/raw/master/Ahmyth.apk"
     )
     APK_NAME = "Ahmyth.apk"
 
@@ -129,6 +130,67 @@ class TestReport:
 
                 assert mock_run.call_count == num_of_rules
                 assert mock_generate_report.call_count == num_of_rules
+
+    def test_analysis_without_specified_rizin_path(
+        self, sample_apk_file, sample_rule_directory
+    ):
+        expected_path = shutil.which("rizin")
+
+        with patch("quark.core.quark.Quark.run") as mock_run:
+            with patch(
+                "quark.core.quark.Quark.generate_json_report"
+            ) as mock_generate_report:
+                sample_report = Report()
+                sample_report.analysis(
+                    sample_apk_file,
+                    sample_rule_directory,
+                    core_library="rizin",
+                )
+
+                assert sample_report.rizin_path == expected_path
+
+                mock_run.assert_called_once()
+                mock_generate_report.assert_called_once()
+
+    def test_analysis_with_specified_rizin_path(
+        self, sample_apk_file, sample_rule_directory
+    ):
+        rizin_path = shutil.which("rizin")
+
+        with patch("quark.core.quark.Quark.run") as mock_run:
+            with patch(
+                "quark.core.quark.Quark.generate_json_report"
+            ) as mock_generate_report:
+                with patch(
+                    "quark.utils.tools.find_rizin_instance"
+                ) as mock_find_rizin:
+
+                    sample_report = Report()
+                    sample_report.analysis(
+                        sample_apk_file,
+                        sample_rule_directory,
+                        core_library="rizin",
+                        rizin_path=rizin_path,
+                    )
+
+                    assert sample_report.rizin_path == rizin_path
+
+                    mock_find_rizin.assert_not_called()
+                    mock_run.assert_called_once()
+                    mock_generate_report.assert_called_once()
+
+    def test_analysis_with_invalid_rizin_path(
+        self, sample_report, sample_apk_file, sample_rule_directory
+    ):
+        invalid_path = "INVALID_PATH"
+
+        with pytest.raises(ValueError):
+            sample_report.analysis(
+                sample_apk_file,
+                sample_rule_directory,
+                core_library="rizin",
+                rizin_path=invalid_path,
+            )
 
     def test_get_report_with_invalid_type(self, sample_report):
         with pytest.raises(ValueError):


### PR DESCRIPTION
**Description**
Fix #332.
This PR aims to -
+ determine which Rizin executable Quark should use for the Rizin-based analysis.
+ compile and install an independent Rizin if necessary.

It consists of three steps to find a Rizin executable.
1. Check if the user specifies a path for Rizin (by option --rizin-path).
2. Check if a compatible Rizin executable exists in the system PATH.
3. Otherwise, install an independent Rizin in the Quark directory (~/.quark-engine) and use it for the analysis.

Note that a user can use the flag `--disable-rizin-installation` to disable the installation of the independent Rizin.
In this way, Quark will terminate the execution if no compatible Rizin exists.

**Test Plans**
- [x] Add seventeen tests for this logic.
- [ ] Ensure all tests pass.