### PR TITLE
Add Quark Script APIs for staged result analysis and objection integration

### DIFF
--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -228,12 +228,12 @@ class Quark:
 
         :param usage_table: the usage of the involved registers
         :param first_method: the first API or the method calling the first APIs
-        :param second_method: the second API or the method calling the second 
-        APIs
-        :param keyword_item_list: keywords required to be present in the usage 
-        , defaults to None
-        :param regex: treat the keywords as regular expressions, defaults to 
-        False
+        :param second_method: the second API or the method calling the second
+         APIs
+        :param keyword_item_list: keywords required to be present in the usage
+         , defaults to None
+        :param regex: treat the keywords as regular expressions, defaults to
+         False
         :yield: _description_
         """
         first_method_pattern = (
@@ -359,9 +359,6 @@ class Quark:
                     )
 
                     state = True
-
-                # if "onCallStateChanged" in parent_function.full_name and "getMaxSystemAudio" in first_call_method.full_name and "setSystemAudioMax" in second_call_method.full_name:
-                #     print("Hit")
 
         return state
 

--- a/quark/core/struct/ruleobject.py
+++ b/quark/core/struct/ruleobject.py
@@ -4,6 +4,7 @@
 
 import json
 import os
+
 from quark.utils.tools import descriptor_to_androguard_format
 
 
@@ -21,19 +22,20 @@ class RuleObject:
         "_label",
     ]
 
-    def __init__(self, json_filename, json_data=None):
-        """
-        According to customized JSON rules, calculate the weighted score and assessing the stages of the crime.
+    def __init__(self, ruleJson: os.PathLike, jsonData: dict = None) -> None:
+        """Making detection rule a rule instance
 
-        :param json_filename:
+        :param ruleJson: Path of a single Quark rule
+        :param jsonData: Dictionary to directly assign to the content of this
+         Quark rule, defaults to None
         """
         # the state of five stages
         self.check_item = [False, False, False, False, False]
 
-        if json_data is not None:
-            self._json_obj = json_data
+        if jsonData is not None:
+            self._json_obj = jsonData
         else:
-            with open(json_filename) as json_file:
+            with open(ruleJson) as json_file:
                 self._json_obj = json.loads(json_file.read())
 
         self._crime = self._json_obj["crime"]
@@ -48,7 +50,7 @@ class RuleObject:
                 ] = descriptor_to_androguard_format(descriptor)
 
         self._score = self._json_obj["score"]
-        self.rule_filename = os.path.basename(json_filename)
+        self.rule_filename = os.path.basename(ruleJson)
         self._label = self._json_obj["label"]
 
     def __repr__(self):
@@ -111,7 +113,7 @@ class RuleObject:
         """
         if confidence == 0:
             return 0
-        return (2 ** (confidence - 1) * self._score) / 2 ** 4
+        return (2 ** (confidence - 1) * self._score) / 2**4
 
 
 if __name__ == "__main__":

--- a/quark/radiocontrast.py
+++ b/quark/radiocontrast.py
@@ -118,7 +118,7 @@ class RadioContrast:
                     "score": 1,
                     "label": [],
                 }
-                comb = RuleObject("test", json_data=generated_rule)
+                comb = RuleObject("test", jsonData=generated_rule)
 
                 try:
                     self.quark.run(comb)

--- a/quark/rulegeneration.py
+++ b/quark/rulegeneration.py
@@ -89,7 +89,7 @@ class RuleGeneration:
                     "score": 1,
                     "label": [],
                 }
-                comb = RuleObject("test", json_data=generated_rule)
+                comb = RuleObject("test", jsonData=generated_rule)
 
                 try:
                     self.quark.run(comb)

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -136,8 +136,7 @@ class QuarkResult:
         self.quark.run(ruleInstance)
         self.rule = ruleInstance
 
-        # * 將 quark.quark_analysis 替換成新的 analysi
-        # TODO - 令 Quark 每次分析使用新的 QarkAnalysis 物件
+        # Reset the Quark object
         self.innerObj = self.quark.quark_analysis
         self.quark.quark_analysis = QuarkAnalysis()
 

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+# This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
+# See the file 'LICENSE' for copying permission.
+
+import functools
+from os import PathLike
+from os.path import abspath, isfile, join
+from typing import Any, List, Tuple, Union
+
+from quark.config import DIR_PATH as QUARK_RULE_PATH
+from quark.core.analysis import QuarkAnalysis
+from quark.core.quark import Quark
+from quark.core.struct.methodobject import MethodObject
+from quark.core.struct.ruleobject import RuleObject as Rule
+from quark.utils.regex import URL_REGEX
+
+
+@functools.lru_cache
+def _getQuark(apk: PathLike) -> Quark:
+    return Quark(apk)
+
+
+class Ruleset:
+    def __init__(self, ruleFolder: PathLike) -> None:
+        self.ruleFolder = ruleFolder
+
+        # Apply cache
+        self._loadRule = functools.lru_cache()(self._loadRuleWithoutCache)
+
+    def __getitem__(self, key: str) -> Rule:
+        return self._loadRule(key)
+
+    def _loadRuleWithoutCache(self, key: str):
+        absoluteRulePath = abspath(join(self.ruleFolder, key))
+
+        if isfile(absoluteRulePath) and absoluteRulePath.endswith(".json"):
+            return Rule(absoluteRulePath)
+        else:
+            raise KeyError(f"Unable to find file {absoluteRulePath}")
+
+
+class DefaultRuleset(Ruleset):
+    def __getitem__(self, key: Union[str, int]) -> Rule:
+        return super().__getitem__(f"{key:05}.json")
+
+
+DEFAULT_RULESET = DefaultRuleset(join(QUARK_RULE_PATH, "rules"))
+
+
+class Method:
+    def __init__(
+        self, quarkResultInstance: "QuarkResult", methodObj: MethodObject
+    ) -> None:
+        self.quarkResult = quarkResultInstance
+        self.innerObj = methodObj
+
+    def __getattr__(self, name) -> Any:
+        return getattr(self.innerObj, name)
+
+    def __eq__(self, __o: object) -> bool:
+        if isinstance(__o, Method):
+            return __o.innerObj == self.innerObj
+
+        return False
+
+    def getXrefTo(self) -> List[Tuple["Method", int]]:
+        """Find out who this method called.
+
+        :return: python list containing tuples (callee methods, index)
+        """
+        return self.quarkResult.getMethodXrefTo(self)
+
+    def getXrefFrom(self) -> List["Method"]:
+        """Find out who call this method.
+
+        :return: python list containing caller methods
+        """
+        return self.quarkResult.getMethodXrefFrom(self)
+
+    @property
+    def fullName(self) -> str:
+        """Show the name of the method.
+
+        :return: the name of the method
+        """
+        return self.innerObj.full_name
+
+
+class Behavior:
+    def __init__(
+        self,
+        quarkResultInstance: "QuarkResult",
+        methodCaller: Method,
+        firstAPI: Method,
+        secondAPI: Method,
+    ) -> None:
+        self.quarkResult = quarkResultInstance
+        self.methodCaller = methodCaller
+        self.firstAPI = firstAPI
+        self.secondAPI = secondAPI
+
+    def hasString(self, pattern: str, regex=False) -> List[str]:
+        usageTable = self.quarkResult.quark._evaluate_method(
+            self.methodCaller.innerObj
+        )
+
+        result_generator = (
+            self.quarkResult.quark.check_parameter_on_single_method(
+                usage_table=usageTable,
+                first_method=self.firstAPI.innerObj,
+                second_method=self.secondAPI.innerObj,
+                keyword_item_list=[(pattern,), (pattern,)],
+                regex=regex,
+            )
+        )
+
+        found_keywords = {
+            keyword
+            for _, keyword_list in result_generator
+            for keyword in keyword_list
+        }
+
+        return list(found_keywords)
+
+    def hasUrl(self) -> List[str]:
+        """Check if the behavior contains urls.
+
+        :return: python list containing all detected urls
+        """
+        return self.hasString(URL_REGEX, True)
+
+
+class QuarkResult:
+    def __init__(self, quark: Quark, ruleInstance: Rule) -> None:
+        self.quark = quark
+        self.quark.run(ruleInstance)
+        self.rule = ruleInstance
+
+        # * 將 quark.quark_analysis 替換成新的 analysi
+        # TODO - 令 Quark 每次分析使用新的 QarkAnalysis 物件
+        self.innerObj = self.quark.quark_analysis
+        self.quark.quark_analysis = QuarkAnalysis()
+
+        # Apply cache
+        self._wrapMethodObject = functools.lru_cache()(
+            self._wrapMethodObjectWithoutCache
+        )
+
+    @functools.cached_property
+    def behaviorOccurList(self):
+        """List that stores instances of detected behavior in different part of
+         the target file.
+
+        :return: detected behavior instance
+        """
+        occurList = [
+            Behavior(
+                quarkResultInstance=self,
+                methodCaller=self._wrapMethodObject(
+                    call_graph_analysis["parent"]
+                ),
+                firstAPI=self._wrapMethodObject(
+                    call_graph_analysis["first_call"]
+                ),
+                secondAPI=self._wrapMethodObject(
+                    call_graph_analysis["second_call"]
+                ),
+            )
+            for call_graph_analysis in self.innerObj.call_graph_analysis_list
+        ]
+        return occurList
+
+    def getMethodXrefTo(self, method: Method) -> List[Tuple[Method, int]]:
+        apkinfo = self.quark.apkinfo
+        methodObj = method.innerObj
+
+        callee_info = [
+            (self._wrapMethodObject(callee), offset)
+            for callee, offset in list(apkinfo.lowerfunc(methodObj))
+        ]
+        return callee_info
+
+    def getMethodXrefFrom(self, method: Method) -> List[Method]:
+        apkinfo = self.quark.apkinfo
+        methodObj = method.innerObj
+
+        caller_set = apkinfo.upperfunc(methodObj)
+        return [self._wrapMethodObject(caller) for caller in list(caller_set)]
+
+    def _wrapMethodObjectWithoutCache(self, methodObj: MethodObject) -> Method:
+        if methodObj:
+            return Method(self, methodObj)
+        else:
+            return None
+
+
+def runQuarkAnalysis(samplePath: PathLike, ruleInstance: Rule) -> QuarkResult:
+    """Given detection rule and target sample, this instance runs the basic
+     Quark.
+
+    :param samplePath: Target file
+    :param ruleInstance: Quark rule object
+    :return: QuarkResult instance
+    """
+    quark = _getQuark(samplePath)
+    analysis = QuarkResult(quark, ruleInstance)
+
+    return analysis

--- a/quark/script/objection.py
+++ b/quark/script/objection.py
@@ -89,18 +89,3 @@ class Objection:
         }
 
         self._sendRequest(ENDPOINT, data)
-
-    # def get_jobs(self) -> dict:
-    #     ENDPOINT = "jobsGet"
-    #     response = self._sendRequest(ENDPOINT)
-
-    #     return None if response[0] != requests.codes.ok else response[1]
-
-    # def kill_job(self, ident: Union[str, int]) -> bool:
-    #     if isinstance(ident, int):
-    #         ident = f"{ident:06}"
-
-    #     ENDPOINT = "jobsKill"
-    #     data = {"ident": ident}
-
-    #     return self._sendRequest(ENDPOINT, data)[0] == requests.codes.ok

--- a/quark/script/objection.py
+++ b/quark/script/objection.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+# This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
+# See the file 'LICENSE' for copying permission.
+
+import re
+from typing import Tuple, Union
+
+import requests
+from quark.script import Method
+
+
+def convertMethodToString(method: Method):
+    def converArgumentsToObjectionFormat(arguments: str):
+        argList = arguments.split()
+        argList = map(
+            lambda a: a.replace("/", ".")
+            if a.startswith("[L")
+            else re.sub("(^L)|;", "", a).replace("/", "."),
+            argList,
+        )
+
+        return ",".join(argList)
+
+    str_mapping = {
+        "class_name": method.class_name[1:-1].replace("/", "."),
+        "method_name": method.name,
+        "arguments": converArgumentsToObjectionFormat(
+            method.descriptor[1: method.descriptor.index(")")]
+        ),
+    }
+    return (
+        "{class_name}.{method_name}".format_map(str_mapping),
+        str_mapping["arguments"],
+    )
+
+
+class Objection:
+    def __init__(self, host: str) -> None:
+        """Create an instance for Objection (dynamic analysis tool).
+
+        :param host: Monitoring IP:port
+        """
+        self.host = host
+
+    def _sendRequest(
+        self, rpcEndpoint: str, data: dict = None
+    ) -> Tuple[int, dict]:
+        url = f"http://{self.host}/rpc/invoke/{rpcEndpoint}"
+
+        if data:
+            response = requests.post(
+                url, json=data, headers={"Content-type": "application/json"}
+            )
+        else:
+            response = requests.get(url)
+
+        return (response.status_code, response.json())
+
+    def hookMethod(
+        self,
+        method: Union[Method, str],
+        overloadFilter: str = "",
+        watchArgs: bool = False,
+        watchBacktrace: bool = False,
+        watchRet: bool = False,
+    ):
+        """Hook the target method with Objection.
+
+        :param method: the tagrget API
+        :param overloadFilter: _description_, defaults to ""
+        :param watchArgs: Return Args information if True, defaults to False
+        :param watchBacktrace: Return backtrace information if True, defaults
+         to False
+        :param watchRet: Return the return information of the target API if
+         True, defaults to False
+        """
+
+        # Convert Method object to a string
+        if isinstance(method, Method):
+            method, overloadFilter = convertMethodToString(method)
+
+        ENDPOINT = "androidHookingWatchMethod"
+        data = {
+            "pattern": method,
+            "overloadFilter": overloadFilter,
+            "watchArgs": watchArgs,
+            "watchBacktrace": watchBacktrace,
+            "watchRet": watchRet,
+        }
+
+        self._sendRequest(ENDPOINT, data)
+
+    # def get_jobs(self) -> dict:
+    #     ENDPOINT = "jobsGet"
+    #     response = self._sendRequest(ENDPOINT)
+
+    #     return None if response[0] != requests.codes.ok else response[1]
+
+    # def kill_job(self, ident: Union[str, int]) -> bool:
+    #     if isinstance(ident, int):
+    #         ident = f"{ident:06}"
+
+    #     ENDPOINT = "jobsKill"
+    #     data = {"ident": ident}
+
+    #     return self._sendRequest(ENDPOINT, data)[0] == requests.codes.ok

--- a/tests/core/test_quark.py
+++ b/tests/core/test_quark.py
@@ -401,7 +401,7 @@ class TestQuark:
             source_str, pattern_list, keyword_item_list
         )
 
-        assert result is False
+        assert bool(result) is False
 
     def test_check_parameter_values_with_matched_str(self, simple_quark_obj):
         source_str = (
@@ -420,13 +420,13 @@ class TestQuark:
             " [Ljava/lang/String; Ljava/lang/String; [Ljava/lang/String;"
             " Ljava/lang/String;)Landroid/database/Cursor;",
         )
-        keyword_item_list = [("content://call_log/calls")]
+        keyword_item_list = [("content://call_log/calls",)]
 
         result = simple_quark_obj.check_parameter_values(
             source_str, pattern_list, keyword_item_list
         )
 
-        assert result is True
+        assert bool(result) is True
 
     def test_get_json_report(self, quark_obj):
         json_report = quark_obj.get_json_report()

--- a/tests/script/rules/00068.json
+++ b/tests/script/rules/00068.json
@@ -1,0 +1,20 @@
+{
+    "crime": "Executes the specified string Linux command",
+    "permission": [],
+    "api": [
+        {
+            "class": "Ljava/lang/Runtime;",
+            "method": "getRuntime",
+            "descriptor": "()Ljava/lang/Runtime;"
+        },
+        {
+            "class": "Ljava/lang/Runtime;",
+            "method": "exec",
+            "descriptor": "(Ljava/lang/String;)Ljava/lang/Process;"
+        }
+    ],
+    "score": 1,
+    "label": [
+        "control"
+    ]
+}

--- a/tests/script/test_objection.py
+++ b/tests/script/test_objection.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+# This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
+# See the file 'LICENSE' for copying permission.
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from quark.core.struct.methodobject import MethodObject
+from quark.script import Method
+from quark.script.objection import Objection, convertMethodToString
+
+
+def testCovertMethodToStringWithClasses():
+    method = Method(
+        quarkResultInstance=None,
+        methodObj=MethodObject(
+            "Lcustom/class/name$subclass;",
+            "method_name",
+            "(Ljava/lang/String; Ljava/lang/Object;)V",
+        ),
+    )
+
+    result = convertMethodToString(method)
+
+    assert result == (
+        "custom.class.name$subclass.method_name",
+        "java.lang.String,java.lang.Object",
+    )
+
+
+def testCovertMethodToStringWithPrimitives():
+    method = Method(
+        quarkResultInstance=None,
+        methodObj=MethodObject(
+            "Lcustom/class/name;", "method_name", "(I [B J)V"
+        ),
+    )
+
+    result = convertMethodToString(method)
+
+    assert result == ("custom.class.name.method_name", "I,[B,J")
+
+
+def testCovertMethodToStringWithArrays():
+    method = Method(
+        quarkResultInstance=None,
+        methodObj=MethodObject(
+            "Lcustom/class/name;",
+            "method_name",
+            "([Ljava/lang/String; [Ljava/lang/Object;)V",
+        ),
+    )
+
+    result = convertMethodToString(method)
+
+    assert result == (
+        "custom.class.name.method_name",
+        "[Ljava.lang.String;,[Ljava.lang.Object;",
+    )
+
+
+def testCovertMethodToStringWithArrayAndClass():
+    method = Method(
+        quarkResultInstance=None,
+        methodObj=MethodObject(
+            "Lcustom/class/name;",
+            "method_name",
+            "([Ljava/lang/String; Ljava/lang/Object;)V",
+        ),
+    )
+
+    result = convertMethodToString(method)
+
+    assert result == (
+        "custom.class.name.method_name",
+        "[Ljava.lang.String;,java.lang.Object",
+    )
+
+
+class TestObjection:
+    @staticmethod
+    def testHookMethodWithMethodObject():
+        obj = Objection("127.0.0.1:8888")
+        method = Method(
+            None,
+            MethodObject(
+                "Lcom/google/progress/WifiCheckTask;",
+                "checkWifiCanOrNotConnectServer",
+                "([Ljava/lang/String;)Z",
+            ),
+        )
+
+        with patch("requests.post") as mocked_post:
+            obj.hookMethod(
+                method, watchArgs=True, watchBacktrace=True, watchRet=True
+            )
+
+            expectedJson = {
+                "pattern": (
+                    "com.google.progress.WifiCheckTask"
+                    ".checkWifiCanOrNotConnectServer"
+                ),
+                "overloadFilter": "[Ljava.lang.String;",
+                "watchArgs": True,
+                "watchBacktrace": True,
+                "watchRet": True,
+            }
+
+            args, keyworkArgs = mocked_post.call_args_list[0]
+
+            assert (
+                "http://127.0.0.1:8888/rpc/invoke/androidHookingWatchMethod"
+                in args
+            )
+
+            TestCase().assertDictEqual(keyworkArgs["json"], expectedJson)
+            TestCase().assertDictEqual(
+                keyworkArgs["headers"], {"Content-type": "application/json"}
+            )

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+# This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
+# See the file 'LICENSE' for copying permission.
+
+import os
+
+import pytest
+import requests
+from quark.core.struct.methodobject import MethodObject
+from quark.script import DefaultRuleset, Method, Ruleset, runQuarkAnalysis
+
+SAMPLE_SOURCE_URL = (
+    "https://github.com/quark-engine/apk-malware-samples"
+    "/raw/master/14d9f1a92dd984d6040cc41ed06e273e.apk"
+)
+SAMPLE_FILENAME = "14d9f1a92dd984d6040cc41ed06e273e.apk"
+
+RULE_FOLDER_PATH = "tests/script/rules"
+RULE_FILENAME = "00068.json"
+RULE_PATH = os.path.join(RULE_FOLDER_PATH, RULE_FILENAME)
+
+
+@pytest.fixture(scope="session")
+def SAMPLE_PATH(tmp_path_factory: pytest.TempPathFactory) -> str:
+    folder = os.path.splitext(os.path.basename(__file__))[0]
+    folder = tmp_path_factory.mktemp(folder)
+
+    sample_path = folder / SAMPLE_FILENAME
+
+    response = requests.get(SAMPLE_SOURCE_URL, allow_redirects=True)
+    file = open(sample_path, "wb")
+    file.write(response.content)
+    file.close()
+
+    return str(sample_path)
+
+
+@pytest.fixture(scope="class")
+def QUARK_ANALYSIS_RESULT(SAMPLE_PATH):
+    ruleset = Ruleset(RULE_FOLDER_PATH)
+    return runQuarkAnalysis(SAMPLE_PATH, ruleset[RULE_FILENAME])
+
+
+class TestRuleset:
+    @staticmethod
+    def testInitWithFolder():
+        _ = Ruleset(RULE_FOLDER_PATH)
+
+    @staticmethod
+    def testGetExistentRule():
+        ruleset = Ruleset(RULE_FOLDER_PATH)
+
+        rule = ruleset[RULE_FILENAME]
+
+        assert rule.crime == "Executes the specified string Linux command"
+
+    @staticmethod
+    def testGetNonexistentRule():
+        NONEXISTENT_RULE = "NONEXISTENT_RULE.json"
+        ruleset = Ruleset(RULE_FOLDER_PATH)
+
+        with pytest.raises(KeyError):
+            _ = ruleset[NONEXISTENT_RULE]
+
+
+class TestDefaultRuleset:
+    @staticmethod
+    def testGetExistentRuleByNumber():
+        ruleset = DefaultRuleset(RULE_FOLDER_PATH)
+
+        rule = ruleset[68]
+
+        assert rule.crime == "Executes the specified string Linux command"
+
+    @staticmethod
+    def testGetNonexistentRuleByNumber():
+        ruleset = DefaultRuleset(RULE_FOLDER_PATH)
+
+        with pytest.raises(KeyError):
+            _ = ruleset[1]
+
+
+class TestMethod:
+    @staticmethod
+    def testInit(QUARK_ANALYSIS_RESULT):
+        methodObj = MethodObject(
+            class_name="Lcom/google/progress/WifiCheckTask;",
+            name="checkWifiCanOrNotConnectServer",
+            descriptor="()Z",
+        )
+
+        method = Method(QUARK_ANALYSIS_RESULT, methodObj)
+
+        assert (
+            method.fullName
+            == "Lcom/google/progress/WifiCheckTask;"
+            " checkWifiCanOrNotConnectServer ()Z"
+        )
+
+    @staticmethod
+    def testGetXrefTo(QUARK_ANALYSIS_RESULT):
+        methodObj = QUARK_ANALYSIS_RESULT.quark.apkinfo.find_method(
+            "Lcom/google/progress/WifiCheckTask;",
+            "checkWifiCanOrNotConnectServer",
+            "()Z",
+        )
+        method = Method(QUARK_ANALYSIS_RESULT, methodObj)
+
+        expectedMethod = Method(
+            QUARK_ANALYSIS_RESULT,
+            MethodObject(
+                "Landroid/util/Log;",
+                "e",
+                "(Ljava/lang/String; Ljava/lang/String;)I",
+            ),
+        )
+        expectedOffset = 116
+
+        callee_list = method.getXrefTo()
+
+        assert (expectedMethod, expectedOffset) in callee_list
+
+    @staticmethod
+    def testGetXrefFrom(QUARK_ANALYSIS_RESULT):
+        methodObj = QUARK_ANALYSIS_RESULT.quark.apkinfo.find_method(
+            "Lcom/google/progress/WifiCheckTask;",
+            "checkWifiCanOrNotConnectServer",
+            "([Ljava/lang/String;)Z",
+        )
+        method = Method(QUARK_ANALYSIS_RESULT, methodObj)
+
+        expectedMethod = Method(
+            QUARK_ANALYSIS_RESULT,
+            MethodObject("Lcom/google/progress/WifiCheckTask;", "test", "()V"),
+        )
+
+        caller_list = method.getXrefFrom()
+
+        assert expectedMethod in caller_list
+
+
+class TestBehavior:
+    @staticmethod
+    def testHasString(QUARK_ANALYSIS_RESULT):
+        behaviorOccurList = QUARK_ANALYSIS_RESULT.behaviorOccurList
+        behavior = next(
+            filter(
+                lambda b: "checkWifiCanOrNotConnectServer"
+                in b.methodCaller.fullName,
+                behaviorOccurList,
+            )
+        )
+
+        result = behavior.hasString("ping")
+
+        assert result
+
+    @staticmethod
+    def testHasUrl(QUARK_ANALYSIS_RESULT):
+        behaviorOccurList = QUARK_ANALYSIS_RESULT.behaviorOccurList
+        behavior = next(
+            filter(
+                lambda b: "checkWifiCanOrNotConnectServer"
+                in b.methodCaller.fullName,
+                behaviorOccurList,
+            )
+        )
+
+        result = behavior.hasUrl()
+
+        assert "www.baidu.com" in result
+
+
+class TestQuarkReuslt:
+    @staticmethod
+    def testMethodGetXrefTo(QUARK_ANALYSIS_RESULT):
+        methodObj = QUARK_ANALYSIS_RESULT.quark.apkinfo.find_method(
+            "Lcom/google/progress/WifiCheckTask;",
+            "checkWifiCanOrNotConnectServer",
+            "()Z",
+        )
+        method = Method(QUARK_ANALYSIS_RESULT, methodObj)
+
+        expectedMethod = Method(
+            QUARK_ANALYSIS_RESULT,
+            MethodObject(
+                "Landroid/util/Log;",
+                "e",
+                "(Ljava/lang/String; Ljava/lang/String;)I",
+            ),
+        )
+        expectedOffset = 116
+
+        callee_list = QUARK_ANALYSIS_RESULT.getMethodXrefTo(method)
+
+        assert (expectedMethod, expectedOffset) in callee_list
+
+    @staticmethod
+    def testMethodGetXrefFrom(QUARK_ANALYSIS_RESULT):
+        methodObj = QUARK_ANALYSIS_RESULT.quark.apkinfo.find_method(
+            "Lcom/google/progress/WifiCheckTask;",
+            "checkWifiCanOrNotConnectServer",
+            "([Ljava/lang/String;)Z",
+        )
+        method = Method(QUARK_ANALYSIS_RESULT, methodObj)
+
+        expectedMethod = Method(
+            QUARK_ANALYSIS_RESULT,
+            MethodObject("Lcom/google/progress/WifiCheckTask;", "test", "()V"),
+        )
+
+        caller_list = QUARK_ANALYSIS_RESULT.getMethodXrefFrom(method)
+
+        assert expectedMethod in caller_list
+
+
+def testRunQuarkAnalysis(SAMPLE_PATH):
+    ruleset = Ruleset(RULE_FOLDER_PATH)
+    ruleObj = ruleset[RULE_FILENAME]
+
+    analysisResult = runQuarkAnalysis(SAMPLE_PATH, ruleObj)
+
+    assert len(analysisResult.behaviorOccurList) == 1


### PR DESCRIPTION
**Description**
Please refer to #324 

This PR adds the following 7 Quark script APIs for staged result analysis and objection integration.
1. `Rule(ruleJson)`
2. `runQuarkAnalysis(SAMPLE_PATH, ruleInstance)`
3. `behaviorInstance.hasUrl(none)`
4. `methodInstance.getXrefFrom(none)`
5. `methodInstance.getXrefTo(none)`
6. `Objection(Monitoring IP and port)`
7. `objInstance.hookMethod(methodInstance or string)`

**Test Plans**

- [x] All tests passed