### PR TITLE
Add Quark Script APIs to detect hard-coded credentials

### DIFF
--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -132,7 +132,7 @@ class Behavior:
     def getParamValues(self) -> List[str]:
         """Get parameter values from behavior.
 
-        :return: python containing parameter values
+        :return: python list containing parameter values
         """
         allResult = self.hasString(".*", True)
 

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -151,7 +151,7 @@ class Behavior:
                 if len(params) >= 2:
                     secondParam = params[1]
 
-                return firstParam, secondParam
+        return firstParam, secondParam
 
 
 class QuarkResult:

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -138,15 +138,15 @@ class Behavior:
 
         for result in allResult:
             if result[0] == "(" and result[-1] == ")" and \
-                self.firstAPI.innerObj.class_name in result and \
-                self.secondAPI.innerObj.class_name in result:
+                    self.firstAPI.innerObj.class_name in result and \
+                    self.secondAPI.innerObj.class_name in result:
 
                 params = result[1:-1].split(",")[1:]
-                    
+
                 if len(params) < 2:
-                    secondParam = None    
+                    secondParam = None
                 firstParam = params[0]
-                
+
                 return firstParam, secondParam
 
 

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -129,6 +129,26 @@ class Behavior:
         """
         return self.hasString(URL_REGEX, True)
 
+    def getParamValues(self) -> Any:
+        """Get first and second parameter values from behavior.
+
+        :return: strings of first and second parameter values
+        """
+        allResult = self.hasString(".*", True)
+
+        for result in allResult:
+            if result[0] == "(" and result[-1] == ")" and \
+                self.firstAPI.innerObj.class_name in result and \
+                self.secondAPI.innerObj.class_name in result:
+
+                params = result[1:-1].split(",")[1:]
+                    
+                if len(params) < 2:
+                    secondParam = None    
+                firstParam = params[0]
+                
+                return firstParam, secondParam
+
 
 class QuarkResult:
     def __init__(self, quark: Quark, ruleInstance: Rule) -> None:
@@ -191,6 +211,15 @@ class QuarkResult:
             return Method(self, methodObj)
         else:
             return None
+
+    def getAllStrings(self):
+        """
+        List all strings inside the target APK.
+
+        :return: python list containing all defined strings.
+        """
+        apkinfo = self.quark.apkinfo
+        return apkinfo.get_strings()
 
 
 def runQuarkAnalysis(samplePath: PathLike, ruleInstance: Rule) -> QuarkResult:

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -129,23 +129,27 @@ class Behavior:
         """
         return self.hasString(URL_REGEX, True)
 
-    def getParamValues(self) -> Any:
+    def getParamValues(self) -> Tuple[str, str]:
         """Get first and second parameter values from behavior.
 
         :return: strings of first and second parameter values
         """
         allResult = self.hasString(".*", True)
 
+        secondParam = None
+        firstParam = None
         for result in allResult:
             if result[0] == "(" and result[-1] == ")" and \
                     self.firstAPI.innerObj.class_name in result and \
                     self.secondAPI.innerObj.class_name in result:
 
                 params = result[1:-1].split(",")[1:]
+                secondParam = None
 
-                if len(params) < 2:
-                    secondParam = None
-                firstParam = params[0]
+                if len(params) >= 1:
+                    firstParam = params[0]
+                if len(params) >= 2:
+                    secondParam = params[1]
 
                 return firstParam, secondParam
 
@@ -212,7 +216,7 @@ class QuarkResult:
         else:
             return None
 
-    def getAllStrings(self):
+    def getAllStrings(self) -> List[str]:
         """
         List all strings inside the target APK.
 

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -129,29 +129,22 @@ class Behavior:
         """
         return self.hasString(URL_REGEX, True)
 
-    def getParamValues(self) -> Tuple[str, str]:
-        """Get first and second parameter values from behavior.
+    def getParamValues(self) -> List[str]:
+        """Get parameter values from behavior.
 
-        :return: strings of first and second parameter values
+        :return: python containing parameter values
         """
         allResult = self.hasString(".*", True)
 
-        secondParam = None
-        firstParam = None
+        paramValues = []
         for result in allResult:
             if result[0] == "(" and result[-1] == ")" and \
                     self.firstAPI.innerObj.class_name in result and \
                     self.secondAPI.innerObj.class_name in result:
 
-                params = result[1:-1].split(",")[1:]
-                secondParam = None
+                paramValues = result[1:-1].split(",")[1:]
 
-                if len(params) >= 1:
-                    firstParam = params[0]
-                if len(params) >= 2:
-                    secondParam = params[1]
-
-        return firstParam, secondParam
+        return paramValues
 
 
 class QuarkResult:

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -3,7 +3,6 @@
 # See the file 'LICENSE' for copying permission.
 
 import os
-import statistics
 
 import pytest
 import requests

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -170,9 +170,9 @@ class TestBehavior:
         result = behavior.hasUrl()
 
         assert "www.baidu.com" in result
-        
+
     @staticmethod
-    def testGetParamValueWithAES(QUARK_ANALYSIS_RESULT):
+    def testGetParamValues(QUARK_ANALYSIS_RESULT):
         behaviorOccurList = QUARK_ANALYSIS_RESULT.behaviorOccurList
         behavior = next(
             filter(
@@ -181,10 +181,11 @@ class TestBehavior:
                 behaviorOccurList,
             )
         )
-        
+
         first_api, second_api = behavior.getParamValues()
-        
+
         assert first_api == "ping www.baidu.com" and second_api == None
+
 
 class TestQuarkReuslt:
     @staticmethod
@@ -227,7 +228,7 @@ class TestQuarkReuslt:
         caller_list = QUARK_ANALYSIS_RESULT.getMethodXrefFrom(method)
 
         assert expectedMethod in caller_list
-        
+
     @staticmethod
     def testgetAllStrings(QUARK_ANALYSIS_RESULT):
         assert len(QUARK_ANALYSIS_RESULT.getAllStrings()) == 1005

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -184,7 +184,7 @@ class TestBehavior:
 
         first_api, second_api = behavior.getParamValues()
 
-        assert first_api == "ping www.baidu.com" and second_api == None
+        assert first_api == "ping www.baidu.com" and second_api is None
 
 
 class TestQuarkReuslt:

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -181,9 +181,7 @@ class TestBehavior:
             )
         )
 
-        first_api, second_api = behavior.getParamValues()
-
-        assert first_api == "ping www.baidu.com" and second_api is None
+        assert behavior.getParamValues()[0] == "ping www.baidu.com"
 
 
 class TestQuarkReuslt:

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -3,6 +3,7 @@
 # See the file 'LICENSE' for copying permission.
 
 import os
+import statistics
 
 import pytest
 import requests
@@ -169,7 +170,21 @@ class TestBehavior:
         result = behavior.hasUrl()
 
         assert "www.baidu.com" in result
-
+        
+    @staticmethod
+    def testGetParamValueWithAES(QUARK_ANALYSIS_RESULT):
+        behaviorOccurList = QUARK_ANALYSIS_RESULT.behaviorOccurList
+        behavior = next(
+            filter(
+                lambda b: "checkWifiCanOrNotConnectServer"
+                in b.methodCaller.fullName,
+                behaviorOccurList,
+            )
+        )
+        
+        first_api, second_api = behavior.getParamValues()
+        
+        assert first_api == "ping www.baidu.com" and second_api == None
 
 class TestQuarkReuslt:
     @staticmethod
@@ -212,6 +227,10 @@ class TestQuarkReuslt:
         caller_list = QUARK_ANALYSIS_RESULT.getMethodXrefFrom(method)
 
         assert expectedMethod in caller_list
+        
+    @staticmethod
+    def testgetAllStrings(QUARK_ANALYSIS_RESULT):
+        assert len(QUARK_ANALYSIS_RESULT.getAllStrings()) == 1005
 
 
 def testRunQuarkAnalysis(SAMPLE_PATH):


### PR DESCRIPTION
#### Description
Please refer to #324 

This PR adds the following 2 Quark script APIs to detect hard-coded credentials.

1. `behaviorInstance.getParamValues(None)`
2. `quarkResultInstance.getAllStrings(None)`

**Test Plans**

- [x] All tests passed