### PR TITLE
Add Quark Script APIs to detect CWE-94

### DIFF
--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -85,6 +85,30 @@ class Method:
         """
         return self.innerObj.full_name
 
+    @property
+    def className(self) -> str:
+        """Show the class name of the method.
+
+        :return: the string of the method class name
+        """
+        return self.innerObj.class_name
+
+    @property
+    def methodName(self) -> str:
+        """Show the method name of the method.
+
+        :return: the string of the method name
+        """
+        return self.innerObj.name
+
+    @property
+    def descriptor(self) -> str:
+        """Show the descriptor of the method.
+
+        :return: the string of the method descriptor
+        """
+        return self.innerObj.descriptor
+
 
 class Behavior:
     def __init__(
@@ -218,6 +242,43 @@ class QuarkResult:
         apkinfo = self.quark.apkinfo
         return apkinfo.get_strings()
 
+    def findMethodInCaller(
+        self,
+        callerMethod: List[str],
+        targetMethod: List[str]
+    ) -> bool:
+        """
+        Check if target method in caller method.
+
+        :params callerMethod: python list contains class name, method name and
+        descriptor of caller method.
+
+        :params targetMethod: python list contains class name, method name and
+        descriptor of target method.
+
+        :return: True/False
+        """
+
+        apkinfo = self.quark.apkinfo
+
+        callerMethodObj = apkinfo.find_method(
+            class_name=callerMethod[0],
+            method_name=callerMethod[1],
+            descriptor=callerMethod[2])
+
+        if not callerMethodObj:
+            print("Caller method not Found!")
+            raise ValueError
+
+        callerMethodInstance = Method(self, callerMethodObj)
+
+        for calleeMethod, _ in callerMethodInstance.getXrefTo():
+            if calleeMethod.innerObj.class_name == targetMethod[0] and \
+                    calleeMethod.innerObj.name == targetMethod[1] and \
+                    calleeMethod.innerObj.descriptor == targetMethod[2]:
+                return True
+        return False
+
 
 def runQuarkAnalysis(samplePath: PathLike, ruleInstance: Rule) -> QuarkResult:
     """Given detection rule and target sample, this instance runs the basic
@@ -231,3 +292,17 @@ def runQuarkAnalysis(samplePath: PathLike, ruleInstance: Rule) -> QuarkResult:
     analysis = QuarkResult(quark, ruleInstance)
 
     return analysis
+
+
+def strToMethodObj(method: str) -> MethodObject:
+    result = method.replace(" ", "").split("->")
+    className = result[0]
+    methodName = result[1].split("(")[0]
+    descriptor = f"({result[1].split('(')[1]}"
+
+    methodObj = MethodObject(class_name=className,
+                             name=methodName, descriptor=descriptor)
+    print(methodObj)
+    # methodInstance = Method(methodObj=methodObj)
+
+    return methodObj

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -248,14 +248,12 @@ class QuarkResult:
         targetMethod: List[str]
     ) -> bool:
         """
-        Check if target method in caller method.
+        Check if target method is in caller method.
 
-        :params callerMethod: python list contains class name, method name and
+        :params callerMethod: python list contains class name, method name and 
         descriptor of caller method.
-
-        :params targetMethod: python list contains class name, method name and
+        :params targetMethod: python list contains class name, method name and 
         descriptor of target method.
-
         :return: True/False
         """
 
@@ -292,17 +290,3 @@ def runQuarkAnalysis(samplePath: PathLike, ruleInstance: Rule) -> QuarkResult:
     analysis = QuarkResult(quark, ruleInstance)
 
     return analysis
-
-
-def strToMethodObj(method: str) -> MethodObject:
-    result = method.replace(" ", "").split("->")
-    className = result[0]
-    methodName = result[1].split("(")[0]
-    descriptor = f"({result[1].split('(')[1]}"
-
-    methodObj = MethodObject(class_name=className,
-                             name=methodName, descriptor=descriptor)
-    print(methodObj)
-    # methodInstance = Method(methodObj=methodObj)
-
-    return methodObj

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -250,10 +250,10 @@ class QuarkResult:
         """
         Check if target method is in caller method.
 
-        :params callerMethod: python list contains class name, method name and 
-        descriptor of caller method.
-        :params targetMethod: python list contains class name, method name and 
-        descriptor of target method.
+        :params callerMethod: python list contains class name,
+        method name and descriptor of caller method.
+        :params targetMethod: python list contains class name,
+        method name and descriptor of target method.
         :return: True/False
         """
 

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -230,6 +230,22 @@ class TestQuarkReuslt:
     def testgetAllStrings(QUARK_ANALYSIS_RESULT):
         assert len(QUARK_ANALYSIS_RESULT.getAllStrings()) == 1005
 
+    @staticmethod
+    def testfindMethodInCaller(QUARK_ANALYSIS_RESULT):
+        callerMethod = [
+            "Lcom/google/progress/WifiCheckTask;",
+            "checkWifiCanOrNotConnectServer",
+            "([Ljava/lang/String;)Z",
+        ]
+        targetMethod = [
+            "Landroid/util/Log;",
+            "e",
+            "(Ljava/lang/String; Ljava/lang/String;)I",
+        ]
+
+        assert QUARK_ANALYSIS_RESULT.findMethodInCaller(
+            callerMethod, targetMethod)
+
 
 def testRunQuarkAnalysis(SAMPLE_PATH):
     ruleset = Ruleset(RULE_FOLDER_PATH)


### PR DESCRIPTION
#### Description
Please refer to #324 

This PR adds the following a Quark script APIs to detect hard-coded credentials.

1. `quarkResultInstance.findMethodInCaller(callerMethod, targetMethod)`

I also add three properties in Method class, avoiding using innerObj to obtain the info of the method:
1. className
2. methodName
3. descriptor

**Test Plans**

- [x] All tests passed