### PR TITLE
Add Quark Script APIs to detect CWE-312

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,12 +23,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pipenv rzpipe meson==0.62.0 ninja coverage
+        python -m pip install pytest rzpipe meson==0.62.0 ninja coverage ciphey frida objection
         sudo apt-get install -y ninja-build
         
         # Install graphviz
         sudo apt-get -y install graphviz
-        
         
         # Install Rizin
         sudo git clone --branch v0.3.4 https://github.com/rizinorg/rizin /opt/rizin/
@@ -39,12 +38,19 @@ jobs:
         sudo ldconfig -v
         cd -
         
-        
+        # Install click >= 8.0.0 for CLI supports
+        python -m pip install click==8.0.3
+
+    - name: Install Quark-Engine
+      run: |
+        python setup.py build
+        python setup.py install
+
     - name: Test with pytest
       run: |
-          pipenv install --dev
-          pipenv install coveralls codecov pytest-cov --skip-lock
-          pipenv run pytest --cov=./
+        python -m pip install black pytest sphinx sphinx-rtd-theme
+        python -m pip install coveralls codecov pytest-cov
+        pytest --cov=./
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -27,17 +27,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
 
-    # Runs a single command using the runners shell
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pipenv
-        pipenv install --skip-lock --dev
+        python -m pip install ciphey frida objection
+        python -m pip install black pytest sphinx sphinx-rtd-theme
+
+        # Install click >= 8.0.0 for CLI supports
+        python -m pip install click==8.0.3
 
     - run: sudo apt-get -y install graphviz
       if: matrix.os == 'ubuntu-latest'
@@ -45,28 +48,33 @@ jobs:
       if: matrix.os == 'macOS-latest'
     - run: choco install graphviz
       if: matrix.os == 'windows-latest'
+
+    - name: Install Quark-Engine
+      run: |
+        python setup.py build
+        python setup.py install
+
     # Download the latest rule set
     - name: Download rule from https://github.com/quark-engine/quark-rules
-      run: |
-        pipenv run freshquark
+      run: freshquark
 
     # Runs a set of commands using the quark-engine
     - name: Run a multi-line script
       run: |
-        pipenv run quark --help
+        quark --help
         git clone https://github.com/quark-engine/apk-malware-samples
-        pipenv run quark -a apk-malware-samples/14d9f1a92dd984d6040cc41ed06e273e.apk -s
-        pipenv run quark -a apk-malware-samples/14d9f1a92dd984d6040cc41ed06e273e.apk -d
-        pipenv run quark -a apk-malware-samples/14d9f1a92dd984d6040cc41ed06e273e.apk -s -g
-        pipenv run quark -a apk-malware-samples/14d9f1a92dd984d6040cc41ed06e273e.apk -d -g
-        pipenv run quark -a apk-malware-samples/14d9f1a92dd984d6040cc41ed06e273e.apk -s -c
+        quark -a apk-malware-samples/14d9f1a92dd984d6040cc41ed06e273e.apk -s
+        quark -a apk-malware-samples/14d9f1a92dd984d6040cc41ed06e273e.apk -d
+        quark -a apk-malware-samples/14d9f1a92dd984d6040cc41ed06e273e.apk -s -g
+        quark -a apk-malware-samples/14d9f1a92dd984d6040cc41ed06e273e.apk -d -g
+        quark -a apk-malware-samples/14d9f1a92dd984d6040cc41ed06e273e.apk -s -c
 
     - name: Check Accuracy
       shell: bash
       run: |
-        echo "Ahmyth_RESULT=$(pipenv run quark -a apk-malware-samples/Ahmyth.apk -s -t 100 | grep 100% | wc -l | awk '{print $1}')" >> $GITHUB_ENV
-        echo "a4db_RESULT=$(pipenv run quark -a apk-malware-samples/13667fe3b0ad496a0cd157f34b7e0c991d72a4db.apk -s -t 100 | grep 100% | wc -l | awk '{print $1}')" >> $GITHUB_ENV
-        echo "e273e_RESULT=$(pipenv run quark -a apk-malware-samples/14d9f1a92dd984d6040cc41ed06e273e.apk -s -t 100 | grep 100% | wc -l | awk '{print $1}')" >> $GITHUB_ENV
+        echo "Ahmyth_RESULT=$(quark -a apk-malware-samples/Ahmyth.apk -s -t 100 | grep 100% | wc -l | awk '{print $1}')" >> $GITHUB_ENV
+        echo "a4db_RESULT=$(quark -a apk-malware-samples/13667fe3b0ad496a0cd157f34b7e0c991d72a4db.apk -s -t 100 | grep 100% | wc -l | awk '{print $1}')" >> $GITHUB_ENV
+        echo "e273e_RESULT=$(quark -a apk-malware-samples/14d9f1a92dd984d6040cc41ed06e273e.apk -s -t 100 | grep 100% | wc -l | awk '{print $1}')" >> $GITHUB_ENV
 
     - name: Check Ahmyt Result
       shell: bash

--- a/Pipfile
+++ b/Pipfile
@@ -23,6 +23,8 @@ plotly = "<=5.4.0"
 prompt-toolkit = "==3.0.19"
 rzpipe = "<=0.1.2"
 objection = "<=1.11.0"
+frida = "<=15.2.2"
+ciphey = ">=5.0.0,<=5.14.0"
 
 [requires]
 python_version = "3.8"

--- a/quark/script/ciphey.py
+++ b/quark/script/ciphey.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
+# See the file 'LICENSE' for copying permission.
+
+from ciphey import decrypt
+from ciphey.iface import Config
+
+
+def checkClearText(inputString: str) -> str:
+    """Check the decrypted value of the input string.
+
+    :param inputString: string to be checked.
+    :return: the decrypted value
+    """
+    return decrypt(Config().library_default().complete_config(), inputString)

--- a/quark/script/frida/__init__.py
+++ b/quark/script/frida/__init__.py
@@ -11,7 +11,6 @@ from time import sleep
 from typing import Any, Dict, List, Tuple
 
 import pkg_resources
-from quark.script import Behavior
 from quark.utils.regex import URL_REGEX
 
 import frida
@@ -38,9 +37,9 @@ class MethodCallEventDispatcher:
         :return: python list that holds calls to the target method
         """
         messageBuffer = []
-        id = self._getMethodIdentifier(targetMethod, methodParamTypes)
+        methodId = self._getMethodIdentifier(targetMethod, methodParamTypes)
 
-        self.watchedMethods[id] = messageBuffer
+        self.watchedMethods[methodId] = messageBuffer
         self.script.exports.watch_method_call(targetMethod, methodParamTypes)
 
         return messageBuffer
@@ -53,10 +52,10 @@ class MethodCallEventDispatcher:
         :param targetMethod: the target API
         :param methodParamTypes: the parameter types of the target API
         """
-        id = self._getMethodIdentifier(targetMethod, methodParamTypes)
+        methodId = self._getMethodIdentifier(targetMethod, methodParamTypes)
 
-        if id in self.watchedMethods:
-            del self.watchedMethods[id]
+        if methodId in self.watchedMethods:
+            del self.watchedMethods[methodId]
 
     def receiveMessage(self, messageFromFridaAgent: dict, _) -> None:
         if messageFromFridaAgent["type"] == "error":
@@ -69,15 +68,15 @@ class MethodCallEventDispatcher:
         eventType = receivedEvent.get("type", None)
 
         if eventType == "CallCaptured":
-            id = tuple(receivedEvent["identifier"][0:2])
+            methodId = tuple(receivedEvent["identifier"][0:2])
 
-            if id in self.watchedMethods:
-                messageBuffer = self.watchedMethods[id]
+            if methodId in self.watchedMethods:
+                messageBuffer = self.watchedMethods[methodId]
                 messageBuffer.append(receivedEvent)
 
         elif eventType == "FailedToWatch":
-            id = tuple(receivedEvent["identifier"])
-            self.watchedMethods.pop(id)
+            methodId = tuple(receivedEvent["identifier"])
+            self.watchedMethods.pop(methodId)
 
 
 @functools.lru_cache

--- a/quark/script/frida/__init__.py
+++ b/quark/script/frida/__init__.py
@@ -174,7 +174,7 @@ def runFridaHook(
     apkPackageName: str,
     targetMethod: str,
     methodParamTypes: str,
-    secondToWait: int,
+    secondToWait: int = 10,
 ) -> FridaResult:
     """Track calls to the specified method for given seconds.
 

--- a/quark/script/frida/__init__.py
+++ b/quark/script/frida/__init__.py
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+# This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
+# See the file 'LICENSE' for copying permission.
+
+import functools
+import json
+import re
+import sys
+from dataclasses import dataclass
+from time import sleep
+from typing import Any, Dict, List, Tuple
+
+import pkg_resources
+from quark.script import Behavior
+from quark.utils.regex import URL_REGEX
+
+import frida
+from frida.core import Device
+from frida.core import Session as FridaSession
+
+
+class MethodCallEventDispatcher:
+    def __init__(self, frida: FridaSession) -> None:
+        self.frida = frida
+        self.watchedMethods = {}
+
+    @staticmethod
+    def _getMethodIdentifier(targetMethod: str, paramType: str):
+        return (targetMethod, paramType)
+
+    def startWatchingMethodCall(
+        self, targetMethod: str, methodParamTypes: str
+    ) -> List["Behavior"]:
+        """Start tracking calls to the target method.
+
+        :param targetMethod: the target API
+        :param methodParamTypes: the parameter types of the target API
+        :return: python list that holds calls to the target method
+        """
+        messageBuffer = []
+        id = self._getMethodIdentifier(targetMethod, methodParamTypes)
+
+        self.watchedMethods[id] = messageBuffer
+        self.script.exports.watch_method_call(targetMethod, methodParamTypes)
+
+        return messageBuffer
+
+    def stopWatchingMethodCall(
+        self, targetMethod: str, methodParamTypes: str
+    ) -> None:
+        """Stop tracking calls to the target method.
+
+        :param targetMethod: the target API
+        :param methodParamTypes: the parameter types of the target API
+        """
+        id = self._getMethodIdentifier(targetMethod, methodParamTypes)
+
+        if id in self.watchedMethods:
+            del self.watchedMethods[id]
+
+    def receiveMessage(self, messageFromFridaAgent: dict, _) -> None:
+        if messageFromFridaAgent["type"] == "error":
+            errorDescription = messageFromFridaAgent["description"]
+            print(errorDescription, file=sys.stderr)
+            return
+
+        receivedEvent = json.loads(messageFromFridaAgent["payload"])
+
+        eventType = receivedEvent.get("type", None)
+
+        if eventType == "CallCaptured":
+            id = tuple(receivedEvent["identifier"][0:2])
+
+            if id in self.watchedMethods:
+                messageBuffer = self.watchedMethods[id]
+                messageBuffer.append(receivedEvent)
+
+        elif eventType == "FailedToWatch":
+            id = tuple(receivedEvent["identifier"])
+            self.watchedMethods.pop(id)
+
+
+@functools.lru_cache
+def _setupFrida(
+    appPackageName: str, protocol="usb", **kwargs: Any
+) -> Tuple[Device, FridaSession, int]:
+    device = None
+    if protocol == "usb":
+        device = frida.get_usb_device(**kwargs)
+    elif protocol == "local":
+        device = frida.get_local_device(**kwargs)
+    elif protocol == "remote":
+        device = frida.get_remote_device(**kwargs)
+
+    processId = device.spawn([appPackageName])
+    session = device.attach(processId)
+
+    return device, session, processId
+
+
+@functools.lru_cache
+def _injectAgent(frida: FridaSession) -> MethodCallEventDispatcher:
+    dispatcher = MethodCallEventDispatcher(frida)
+
+    pathToFridaAgentSource = pkg_resources.resource_filename(
+        "quark.script.frida", "agent.js"
+    )
+
+    with open(pathToFridaAgentSource, "r") as fridaAgentSource:
+        fridaAgent = dispatcher.frida.create_script(fridaAgentSource.read())
+        fridaAgent.on("message", dispatcher.receiveMessage)
+        fridaAgent.load()
+        dispatcher.script = fridaAgent
+
+    return dispatcher
+
+
+@dataclass
+class Behavior:
+    _message: Dict[str, str]
+
+    def hasString(self, pattern: str, regex: bool = False) -> List[str]:
+        """Check if the behavior contains strings
+
+        :param pattern: string to be checked
+        :param regex: True if the string is a regular expression, defaults to
+         False
+        :return: python list containing all matched strings
+        """
+        arguments = self.getParamValues()
+
+        allMatchedStrings = set()
+        for argument in arguments:
+            if regex:
+                matchedStrings = [
+                    match.group(0) for match in re.finditer(pattern, argument)
+                ]
+                allMatchedStrings.update(matchedStrings)
+            else:
+                if pattern in argument:
+                    return [pattern]
+
+        return list(allMatchedStrings)
+
+    def hasUrl(self) -> List[str]:
+        """Check if the behavior contains urls.
+
+        :return: python list containing all detected urls
+        """
+        return self.hasString(URL_REGEX, True)
+
+    def getParamValues(self) -> List[str]:
+        """Get parameter values from behavior.
+
+        :return: python list containing parameter values
+        """
+        return self._message["paramValues"]
+
+
+@dataclass
+class FridaResult:
+    _messageBuffer: List[str]
+
+    @property
+    def behaviorOccurList(self) -> List[Behavior]:
+        """List that stores instances of detected behavior in different part of
+         the target file.
+
+        :return: detected behavior instance
+        """
+        return [Behavior(message) for message in self._messageBuffer]
+
+
+def runFridaHook(
+    apkPackageName: str,
+    targetMethod: str,
+    methodParamTypes: str,
+    secondToWait: int,
+) -> FridaResult:
+    """Track calls to the specified method for given seconds.
+
+    :param apkPackageName: the target APK
+    :param targetMethod: the target API
+    :param methodParamTypes: string that holds the parameters used by the
+     target API
+    :param secondToWait: seconds to wait for method calls
+    :return: FridaResult instance
+    """
+    device, frida, appProcess = _setupFrida(apkPackageName)
+    dispatcher = _injectAgent(frida)
+
+    buffer = dispatcher.startWatchingMethodCall(targetMethod, methodParamTypes)
+    device.resume(appProcess)
+
+    sleep(secondToWait)
+    dispatcher.stopWatchingMethodCall(targetMethod, methodParamTypes)
+
+    return FridaResult(buffer)

--- a/quark/script/frida/__init__.py
+++ b/quark/script/frida/__init__.py
@@ -2,14 +2,13 @@
 # This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
 # See the file 'LICENSE' for copying permission.
 
-from ctypes import Union
 import functools
 import json
 import re
 import sys
 from dataclasses import dataclass
 from time import sleep
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Union
 
 import pkg_resources
 from quark.utils.regex import URL_REGEX

--- a/quark/script/frida/__init__.py
+++ b/quark/script/frida/__init__.py
@@ -62,6 +62,11 @@ class MethodCallEventDispatcher:
     def receiveMessage(self, messageFromFridaAgent: dict, _) -> None:
         if messageFromFridaAgent["type"] == "error":
             errorDescription = messageFromFridaAgent["description"]
+        """Send the event captured by Frida to the corresponding
+         buffers.
+
+        :param eventWrapperFromFrida: python dict containing captured events
+        """
             print(errorDescription, file=sys.stderr)
             return
 

--- a/quark/script/frida/agent.js
+++ b/quark/script/frida/agent.js
@@ -47,8 +47,8 @@ function watchMethodCall(classAndMethodName, methodParamTypes) {
             const paramTypesOfPossibleMethod = possibleMethod.argumentTypes.map((argument) => argument.className);
             return paramTypesOfPossibleMethod.join(",") === methodParamTypes;
         }).forEach((matchedMethod) => {
-            const retType = matchedMethod.returnType.name
-            replaceMethodImplementation(matchedMethod, classAndMethodName, methodParamTypes, retType)
+            const retType = matchedMethod.returnType.name;
+            replaceMethodImplementation(matchedMethod, classAndMethodName, methodParamTypes, retType);
         }
         );
 

--- a/quark/script/frida/agent.js
+++ b/quark/script/frida/agent.js
@@ -1,0 +1,58 @@
+// -*- coding: utf-8 -*-
+// This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
+// See the file 'LICENSE' for copying permission.
+
+/*global Java, send, rpc*/
+function replaceMethodImplementation(targetMethod, classAndMethodName, methodParamTypes, returnType) {
+    targetMethod.implementation = function () {
+        let callEvent = {
+            "type": "CallCaptured",
+            "identifier": [classAndMethodName, methodParamTypes, returnType],
+            "paramValues": []
+        };
+
+        for (const arg of arguments) {
+            callEvent["paramValues"].push((arg || "(none)").toString());
+        }
+
+        send(JSON.stringify(callEvent));
+        return targetMethod.apply(this, arguments);
+    };
+}
+
+function watchMethodCall(classAndMethodName, methodParamTypes) {
+    if (classAndMethodName == null || methodParamTypes == null) {
+        return;
+    }
+
+    const indexOfLastSeparator = classAndMethodName.lastIndexOf(".");
+    const classNamePattern = classAndMethodName.substring(0, indexOfLastSeparator);
+    const methodNamePattern = classAndMethodName.substring(indexOfLastSeparator + 1);
+
+    Java.perform(() => {
+        const classOfTargetMethod = Java.use(classNamePattern);
+        const possibleMethods = classOfTargetMethod[`${methodNamePattern}`];
+
+        if (typeof possibleMethods === "undefined") {
+            const failedToWatchEvent = {
+                "type": "FailedToWatch",
+                "identifier": [classAndMethodName, methodParamTypes]
+            };
+
+            send(JSON.stringify(failedToWatchEvent));
+            return;
+        }
+
+        possibleMethods.overloads.filter((possibleMethod) => {
+            const paramTypesOfPossibleMethod = possibleMethod.argumentTypes.map((argument) => argument.className);
+            return paramTypesOfPossibleMethod.join(",") === methodParamTypes;
+        }).forEach((matchedMethod) => {
+            const retType = matchedMethod.returnType.name
+            replaceMethodImplementation(matchedMethod, classAndMethodName, methodParamTypes, retType)
+        }
+        );
+
+    });
+}
+
+rpc.exports["watchMethodCall"] = (classAndMethodName, methodParamTypes) => watchMethodCall(classAndMethodName, methodParamTypes);

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,9 @@ setuptools.setup(
         "quark.webreport": [
             "analysis_report_layout.html",
             "genrule_report_layout.html"
+        ],
+        "quark.script.frida": [
+            "agent.js"
         ]
     },
     entry_points={

--- a/tests/script/test_ciphey.py
+++ b/tests/script/test_ciphey.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
+# See the file 'LICENSE' for copying permission.
+
+from quark.script.ciphey import checkClearText
+
+
+def testCheckClearTextWithClearText():
+    assert checkClearText("Clear Text") == "Clear Text"
+
+
+def testCheckClearTextWithCipherText():
+    assert (
+        checkClearText("NB2HI4DTHIXS6Z3PN5TWYZJOMNXW2===")
+        == "https://google.com"
+    )

--- a/tests/script/test_frida.py
+++ b/tests/script/test_frida.py
@@ -87,7 +87,7 @@ class TestMethodCallEventDispatcher:
             ),
         }
 
-        dispatcher.receiveMessage(failedToWatchMessage, None)
+        dispatcher.handleCapturedEvent(failedToWatchMessage, None)
 
         assert (
             dispatcher._getMethodIdentifier(targetMethod, methodParamTypes)
@@ -147,7 +147,7 @@ class TestMethodCallEventDispatcher:
             "payload": json.dumps(expectedEvent),
         }
 
-        dispatcher.receiveMessage(callMessage, None)
+        dispatcher.handleCapturedEvent(callMessage, None)
 
         assert expectedEvent in buffer
 
@@ -157,7 +157,7 @@ class TestMethodCallEventDispatcher:
 
         errorMessage = {"type": "error", "description": "Any description."}
 
-        dispatcher.receiveMessage(errorMessage, None)
+        dispatcher.handleCapturedEvent(errorMessage, None)
 
         captured = capsys.readouterr()
 

--- a/tests/script/test_frida.py
+++ b/tests/script/test_frida.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+# This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
+# See the file 'LICENSE' for copying permission.
+import json
+from unittest.mock import Mock, patch
+
+from pytest import fixture
+from quark.script.frida import (
+    Behavior,
+    FridaResult,
+    MethodCallEventDispatcher,
+    runFridaHook,
+)
+
+
+@fixture(scope="function")
+def dispatcherThatHooksOneMethod():
+    dispatcher = MethodCallEventDispatcher(None)
+    dispatcher.script = Mock()
+
+    targetMethod = (
+        "com.google.progress.WifiCheckTask.checkWifiCanOrNotConnectServer"
+    )
+    methodParamTypes = "java.lang.String"
+
+    buffer = dispatcher.startWatchingMethodCall(targetMethod, methodParamTypes)
+
+    return dispatcher, targetMethod, methodParamTypes, buffer
+
+
+@fixture(scope="function")
+def methodCallMessages():
+    return [
+        {
+            "type": "CallCaptured",
+            "identifier": [
+                (
+                    "com.google.progress.WifiCheckTask"
+                    ".checkWifiCanOrNotConnectServer"
+                ),
+                "java.lang.String",
+                "V",
+            ],
+            "paramValues": [
+                "SimpleString",
+                "https://github.com/quark-engine/",
+            ],
+        }
+    ]
+
+
+class TestMethodCallEventDispatcher:
+    @staticmethod
+    def testStartWatchingMethodCallSuccess(dispatcherThatHooksOneMethod):
+        (
+            dispatcher,
+            targetMethod,
+            methodParamTypes,
+            _,
+        ) = dispatcherThatHooksOneMethod
+        mockedFridaAgentAPI = dispatcher.script.exports.watch_method_call
+
+        assert (
+            dispatcher._getMethodIdentifier(targetMethod, methodParamTypes)
+            in dispatcher.watchedMethods
+        )
+        mockedFridaAgentAPI.assert_called_once_with(
+            targetMethod, methodParamTypes
+        )
+
+    @staticmethod
+    def testStartWatchingMethodFailed(dispatcherThatHooksOneMethod):
+        (
+            dispatcher,
+            targetMethod,
+            methodParamTypes,
+            _,
+        ) = dispatcherThatHooksOneMethod
+
+        failedToWatchMessage = {
+            "type": "send",
+            "payload": json.dumps(
+                {
+                    "type": "FailedToWatch",
+                    "identifier": [targetMethod, methodParamTypes],
+                }
+            ),
+        }
+
+        dispatcher.receiveMessage(failedToWatchMessage, None)
+
+        assert (
+            dispatcher._getMethodIdentifier(targetMethod, methodParamTypes)
+            not in dispatcher.watchedMethods
+        )
+
+    @staticmethod
+    def testStopWatchingMethodCallSuccess(dispatcherThatHooksOneMethod):
+        (
+            dispatcher,
+            targetMethod,
+            methodParamTypes,
+            _,
+        ) = dispatcherThatHooksOneMethod
+
+        dispatcher.stopWatchingMethodCall(targetMethod, methodParamTypes)
+
+        assert (
+            dispatcher._getMethodIdentifier(targetMethod, methodParamTypes)
+            not in dispatcher.watchedMethods
+        )
+
+    @staticmethod
+    def testStopWatchingMethodCallFailed(dispatcherThatHooksOneMethod):
+        (
+            dispatcher,
+            targetMethod,
+            methodParamTypes,
+            _,
+        ) = dispatcherThatHooksOneMethod
+
+        dispatcher.stopWatchingMethodCall(targetMethod, methodParamTypes)
+        dispatcher.stopWatchingMethodCall(targetMethod, methodParamTypes)
+
+        assert (
+            dispatcher._getMethodIdentifier(targetMethod, methodParamTypes)
+            not in dispatcher.watchedMethods
+        )
+
+    @staticmethod
+    def testDispatchCallMessage(dispatcherThatHooksOneMethod):
+        (
+            dispatcher,
+            targetMethod,
+            paramTypes,
+            buffer,
+        ) = dispatcherThatHooksOneMethod
+
+        expectedEvent = {
+            "type": "CallCaptured",
+            "identifier": [targetMethod, paramTypes, "V"],
+            "paramValues": ["param1", "param2"],
+        }
+
+        callMessage = {
+            "type": "send",
+            "payload": json.dumps(expectedEvent),
+        }
+
+        dispatcher.receiveMessage(callMessage, None)
+
+        assert expectedEvent in buffer
+
+    @staticmethod
+    def testDispatchErrorMessage(dispatcherThatHooksOneMethod, capsys):
+        dispatcher = dispatcherThatHooksOneMethod[0]
+
+        errorMessage = {"type": "error", "description": "Any description."}
+
+        dispatcher.receiveMessage(errorMessage, None)
+
+        captured = capsys.readouterr()
+
+        assert errorMessage["description"] in captured.err
+
+
+class TestBehavior:
+    @staticmethod
+    def testHasString(methodCallMessages):
+        behavior = Behavior(methodCallMessages[0])
+        capturedStrings = behavior.hasString("SimpleString")
+        assert capturedStrings == ["SimpleString"]
+
+    @staticmethod
+    def testHasUrl(methodCallMessages):
+        behavior = Behavior(methodCallMessages[0])
+        capturedUrls = behavior.hasUrl()
+        assert capturedUrls == ["https://github.com/quark-engine/"]
+
+    @staticmethod
+    def testGetParamValues(methodCallMessages):
+        behavior = Behavior(methodCallMessages[0])
+        capturedArguments = behavior.getParamValues()
+        assert capturedArguments == [
+            "SimpleString",
+            "https://github.com/quark-engine/",
+        ]
+
+
+class TestFridaResult:
+    @staticmethod
+    def testGetBehaviorOccurList(methodCallMessages):
+        fridaResult = FridaResult(methodCallMessages)
+        behaviorOccurList = fridaResult.behaviorOccurList
+        assert len(behaviorOccurList) == 1
+
+
+def testFridaHook(methodCallMessages):
+    mockedSession = Mock()
+    mockedSession.create_script.return_value = Mock()
+
+    mockedDevice = Mock()
+    mockedDevice.spawn.return_value = 1
+    mockedDevice.attach.return_value = mockedSession
+
+    appPackageName = "appName"
+    targetMethod = "targetMethod"
+    paramTypes = "paramType1,paramType2"
+
+    with patch("frida.get_usb_device", return_value=mockedDevice) as _:
+        with patch(
+            (
+                "quark.script.frida.MethodCallEventDispatcher"
+                ".startWatchingMethodCall"
+            ),
+            return_value=methodCallMessages,
+        ) as _:
+            fridaResult = runFridaHook(
+                appPackageName, targetMethod, paramTypes, 10
+            )
+
+            assert len(fridaResult.behaviorOccurList) == 1

--- a/tests/script/test_frida.py
+++ b/tests/script/test_frida.py
@@ -167,7 +167,7 @@ class TestMethodCallEventDispatcher:
 class TestBehavior:
     @staticmethod
     def testHasString(methodCallMessages):
-        behavior = Behavior(methodCallMessages[0])
+        behavior = Behavior(methodCallMessages[0])  # nosec E1120
         capturedStrings = behavior.hasString("SimpleString")
         assert capturedStrings == ["SimpleString"]
 


### PR DESCRIPTION
#### Description
Please refer to #324.

This PR adds the following two Quark script APIs to detect cleartext storage of sensitive information ([CWE-312](https://cwe.mitre.org/data/definitions/312.html)).

1. `hookMethod(fridaSession, method, overloadFilter, callback, watchArgs)`
2. `checkClearText(inputString)`

**Test Plans**

- [x] All tests passed