### PR TITLE
Fix missing words/lines in the Quark Script document

### DIFF
--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -748,6 +748,7 @@ configureJsExecution.json
 =========================
 
 .. code-block:: json
+
     {
         "crime": "Configure JavaScript execution on websites",
         "permission": [],

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -744,7 +744,7 @@ Quark Script CWE-749.py
         if enableJS and exposeAPI:
             print(f"CWE-749 is detected in method, {caller.fullName}"
 
-configureJsExecution.json
+Quark Rule: configureJsExecution.json
 =========================
 
 .. code-block:: json


### PR DESCRIPTION
**Description**

This PR aims to fix the following two errors in the Quark Script document for CWE-749 -

+ missing content of Quark rule `configureJsExecution.json`
+ missing words `Quark Rule:` in the title

**Before**

![](https://i.imgur.com/RP2clkn.png)

**After**

![](https://i.imgur.com/NcpzgYh.png)