### PR TITLE
Fix #380, CLI gives an outdated path to the default ruleset

### DIFF
--- a/quark/cli.py
+++ b/quark/cli.py
@@ -67,7 +67,7 @@ logo()
     "--rule",
     help="Rules directory",
     type=click.Path(exists=True, file_okay=True, dir_okay=True),
-    default=f"{config.HOME_DIR}quark-rules",
+    default=f"{config.DIR_PATH}",
     required=False,
     show_default=True,
 )

--- a/quark/config.py
+++ b/quark/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 HOME_DIR = f"{Path.home()}/.quark-engine/"
 SOURCE = "https://github.com/quark-engine/quark-rules"
-DIR_PATH = f"{HOME_DIR}quark-rules"
+DIR_PATH = f"{HOME_DIR}quark-rules/rules"
 
 DEBUG = False
 

--- a/quark/freshquark.py
+++ b/quark/freshquark.py
@@ -28,7 +28,7 @@ def download():
                     "git",
                     "clone",
                     "https://github.com/quark-engine/quark-rules",
-                    config.DIR_PATH,
+                    f"{config.HOME_DIR}quark-rules",
                 ],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -58,7 +58,7 @@ def download():
                 [
                     "git",
                     "-C",
-                    config.DIR_PATH,
+                    f"{config.HOME_DIR}quark-rules",
                     "pull",
                 ],
                 stdout=subprocess.PIPE,

--- a/tests/test_freshquark.py
+++ b/tests/test_freshquark.py
@@ -6,33 +6,36 @@ from quark.freshquark import download
 def test_download_without_exist_rules(tmp_path):
     non_exist_rule_directory = tmp_path / "quark-rules"
 
-    with patch("quark.config.DIR_PATH", non_exist_rule_directory) as _:
-
-        with patch("subprocess.run") as mock:
-            download()
-
-            mock.assert_called_once()
-            assert set(mock.call_args[0][0]) == {
-                "git",
-                "clone",
-                "https://github.com/quark-engine/quark-rules",
-                non_exist_rule_directory,
-            }
-
-
-def test_download_with_exist_rules(tmp_path):
-    exist_rule_directory = tmp_path / "quark-rules"
-    exist_rule_directory.mkdir()
-
-    with patch("quark.config.DIR_PATH", exist_rule_directory) as _:
+    with patch("quark.freshquark.config") as mock_config:
+        mock_config.HOME_DIR = f"{tmp_path}/"
 
         with patch("subprocess.run") as mock:
             download()
 
             mock.assert_called_once()
             assert mock.call_args[0][0] == [
-                "git",
-                "-C",
-                exist_rule_directory,
-                "pull",
-            ]
+                    "git",
+                    "clone",
+                    "https://github.com/quark-engine/quark-rules",
+                    f"{non_exist_rule_directory}"
+                ]
+
+
+def test_download_with_exist_rules(tmp_path):
+    exist_rule_directory = tmp_path / "quark-rules"
+    exist_rule_directory.mkdir()
+
+    with patch("quark.freshquark.config") as mock_config:
+        mock_config.HOME_DIR = f"{tmp_path}/"
+        mock_config.DIR_PATH = f"{exist_rule_directory}"
+
+        with patch("subprocess.run") as mock:
+            download()
+
+            mock.assert_called_once()
+            assert mock.call_args[0][0] == [
+                    "git",
+                    "-C",
+                    f"{exist_rule_directory}",
+                    "pull",
+                ]


### PR DESCRIPTION
**Description**

Please refer to #380 

This PR includes 3 modified files.

- quark/cli.py
- quark/config.py
- quark/freshquark.py

Test Plans

[ issue comment in #380 ](https://github.com/quark-engine/quark-engine/issues/380#issuecomment-1263815618)