### PR TITLE
Add link to MD5 hash to directly go to VT report

### DIFF
--- a/quark/webreport/analysis_report_layout.html
+++ b/quark/webreport/analysis_report_layout.html
@@ -406,7 +406,9 @@
                                 <dt class="col-sm-3 sample-info-lable">File name</dt>
                                 <dd class="col-sm-9 sample-info-lable">$filename$</dd>
                                 <dt class="col-sm-3 sample-info-lable">MD5</dt>
-                                <dd class="col-sm-9 sample-info-lable">$md5$</dd>
+                                <dd class="col-sm-9 sample-info-lable">
+                                    <a href="https://www.virustotal.com/gui/file/$md5$" title="Go to Virus Total Report" target="_blank">$md5$</a>
+                                </dd>
                                 <dt class="col-sm-3 sample-info-lable">File size</dt>
                                 <dd class="col-sm-9 sample-info-lable">$filesize$ Mb</dd>
                                 <dt class="col-sm-3 sample-info-lable">Labels</dt>


### PR DESCRIPTION
# LINK FOR VIRUS TOTAL REPORT
The following PR aims to close issue #393 

I added to the MD5 hash a link to go directly to Virus Total with the corresponding hash.

![image](https://user-images.githubusercontent.com/61980210/194541289-ad0586ee-cf3e-487a-9a09-623f3c505131.png)

The browser will open a new tab to Virus Total when the user clicks on the link related to the hash.

![image](https://user-images.githubusercontent.com/61980210/194541594-15a530cf-3fe6-4cf8-96fe-86fce0a271b5.png)
