### PR TITLE
Add Quark Script for CWE-780 to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Quark Script is now in a beta version. We'll keep releasing practical APIs and a
 *   [CWE-926](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-926-in-android-application-dvba-apk)
 *   [CWE-749](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-749-in-android-application-mstg-android-java-apk)
 *   [CWE-532](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-532-in-android-application-dvba-apk)
+*   [CWE-780](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-780-in-android-application-mstg-android-java-apk)
 
 ## Quark Web Report
 


### PR DESCRIPTION
Please refer to #399.

The PR adds the link to the Quark Script case for CWE-780 to README.
+ [CWE-780](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-780-in-android-application-mstg-android-java-apk)