### PR TITLE
Fix web report typo and darken radar chart grid lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ See our demo [here](https://pulorsok.github.io/ruleviewer/web-report-demo).
 quark -a sample.apk -s -w quark_report.html
 ```
 
-![](https://i.imgur.com/uizHQan.jpg)
+![](https://i.imgur.com/fNc3mC0.jpg)
 
 ## Navigate the Rules
 

--- a/quark/webreport/analysis_report_layout.html
+++ b/quark/webreport/analysis_report_layout.html
@@ -500,7 +500,7 @@ $report_data$
     const ctx = document.getElementById('myChart').getContext('2d');
     Chart.defaults.font.size = 24;
 
-    const radareChart = new Chart(ctx, {
+    const radarChart = new Chart(ctx, {
         type: 'radar',
         backgroundColor: "rgba(0, 0, 0, 0.2)",
         data: {
@@ -576,8 +576,8 @@ $report_data$
                 borderWidth: 2
             }]
         }
-        radareChart.data = data
-        radareChart.update('active');
+        radarChart.data = data
+        radarChart.update('active');
 
     })
 </script>
@@ -598,8 +598,8 @@ $report_data$
                 borderWidth: 1
             }]
         }
-        radareChart.data = data
-        radareChart.update('active');
+        radarChart.data = data
+        radarChart.update('active');
 
     }
     function search() {

--- a/quark/webreport/analysis_report_layout.html
+++ b/quark/webreport/analysis_report_layout.html
@@ -423,7 +423,7 @@
             <div class="row radar-chart">
                 <div class="col-md-6"><canvas id="myChart" width="400" height="400"></canvas></div>
                 <div class="col-md-6">
-                    <h3>Select labels to see max confidence in radare chart</h3>
+                    <h3>Select labels to see max confidence in radar chart</h3>
                     <div class="label-group">
                         $all_labels_html$
                     </div>

--- a/quark/webreport/analysis_report_layout.html
+++ b/quark/webreport/analysis_report_layout.html
@@ -511,7 +511,7 @@ $report_data$
                 data: [],
                 backgroundColor: 'rgba(0, 99, 132, 0.2)',
                 borderColor: 'rgba(0, 0, 0, 1)',
-                borderWidth: 1
+                borderWidth: 2,
             }]
         },
         options: {
@@ -528,6 +528,12 @@ $report_data$
                     ticks: {
                         stepSize: 20
                     },
+                    angleLines: {
+                        color: 'rgba(0, 0, 0, 0.4)'
+                    },
+                    grid: {
+                        color: "rgba(0, 0, 0, 0.4)"
+                    }
                 }
             }
         },
@@ -567,7 +573,7 @@ $report_data$
                 data: maxConfidence,
                 backgroundColor: 'rgba(0, 99, 132, 0.2)',
                 borderColor: 'rgba(0, 0, 0, 1)',
-                borderWidth: 1
+                borderWidth: 2
             }]
         }
         radareChart.data = data

--- a/quark/webreport/generate.py
+++ b/quark/webreport/generate.py
@@ -80,7 +80,7 @@ class ReportGenerator:
 
         self.insert_sample_information_html(
             rule_number_set, filename, md5, filesize, five_stages_labels)
-        self.insert_radarechart_html(five_stages_labels, all_labels)
+        self.insert_radarchart_html(five_stages_labels, all_labels)
         self.insert_report_html(analysis_result)
 
         self.analysis_result_layout = get_json_report_html(
@@ -88,9 +88,9 @@ class ReportGenerator:
 
         return self.analysis_result_layout
 
-    def insert_radarechart_html(self, five_stages_labels, all_labels):
+    def insert_radarchart_html(self, five_stages_labels, all_labels):
         """
-        Generate the HTML of radare chart secton in Quark web report.
+        Generate the HTML of radar chart secton in Quark web report.
 
         :param five_stages_labels: the set of lebels
         with 100% confidence crimes


### PR DESCRIPTION
#### Description
This PR aims to close Issue #405.

Two modifications did.

1.Fix the typo in the radar chart section in Web Report. Change "radare chart" to "radar chart."

##### Before
![](https://i.imgur.com/2kT6LIa.png)

##### After
![](https://i.imgur.com/1uVBLFY.png)


2.Darken the grid lines of the radar chart in the Web Report. 
##### Before
![](https://i.imgur.com/wj6EZYQ.png)


##### After
![](https://i.imgur.com/L6BshK6.png)
