### PR TITLE
Update analysis library for Rizin v0.5.x

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,8 +32,9 @@ jobs:
         sudo apt-get -y install graphviz ninja-build
  
         # Install Rizin
-        sudo git clone --branch v0.3.4 https://github.com/rizinorg/rizin /opt/rizin/
+        sudo git clone https://github.com/rizinorg/rizin /opt/rizin/
         cd /opt/rizin/
+        sudo git checkout de8a5cac5532845643a52d1231b17a7b34feb50a
         meson build
         ninja -C build
         sudo ninja -C build install

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -252,24 +252,22 @@ class RizinImp(BaseApkinfo):
         return method
 
     @functools.lru_cache
-    def _get_methods_classified(self, dexindex):
+    def _get_methods_classified(
+        self, dex_index: int
+    ) -> Dict[str, List[MethodObject]]:
         """
-        Parse all methods in the specified Dex and convert them into a
-        dictionary. The dictionary takes their belonging classes as the keys.
-        Then, it categorizes them into lists.
+        Use command isj to get all the methods and categorize them into
+        a dictionary.
 
-        :param dexindex: an index indicating which Dex file should this method
-        parse
-        :return: a dictionary taking a class name as the key and a list of
-        MethodObject as the corresponding value.
+        :param dex_index: an index to the Dex file that need to be parsed.
+        :return: a dict that holds methods categorized by their class name
         """
-        rz = self._get_rz(dexindex)
+        rz = self._get_rz(dex_index)
 
         method_json_list = rz.cmdj("isj")
         method_dict = defaultdict(list)
         for json_obj in method_json_list:
             method = self._parse_method_from_isj_obj(json_obj, dexindex)
-
             if method:
                 method_dict[method.class_name].append(method)
 

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -267,7 +267,7 @@ class RizinImp(BaseApkinfo):
         method_json_list = rz.cmdj("isj")
         method_dict = defaultdict(list)
         for json_obj in method_json_list:
-            method = self._parse_method_from_isj_obj(json_obj, dexindex)
+            method = self._parse_method_from_isj_obj(json_obj, dex_index)
             if method:
                 method_dict[method.class_name].append(method)
 

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -10,7 +10,7 @@ import tempfile
 import zipfile
 from collections import defaultdict, namedtuple
 from os import PathLike
-from typing import Dict, Generator, List, Optional, Set, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Set, Tuple, Union
 
 import rzpipe
 

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -539,6 +539,9 @@ class RizinImp(BaseApkinfo):
 
             if instruct_flow:
                 for ins in instruct_flow:
+                    if "disasm" not in ins:
+                        continue
+
                     yield self._parse_smali(ins["disasm"])
 
     def get_strings(self) -> Set[str]:
@@ -611,6 +614,10 @@ class RizinImp(BaseApkinfo):
 
         if instruction_flow:
             for ins in instruction_flow:
+                # Skip the instruction without disam  field.
+                if "disam" not in ins:
+                    continue
+
                 if ins["disasm"].startswith("invoke"):
                     if ";" in ins["disasm"]:
                         index = ins["disasm"].rindex(";")

--- a/quark/utils/tools.py
+++ b/quark/utils/tools.py
@@ -44,6 +44,16 @@ def contains(subset_to_check, target_list):
 
 
 def descriptor_to_androguard_format(descriptor):
+    """
+    Insert a space between the arguments of the given descriptor.
+
+    :param descriptor: a descriptor whose arguments may or may not be
+    separated by spaces
+    :raises ValueError: if the descriptor is not surrounded by
+    parentheses
+    :return: a descriptor with arguments separated by spaces
+    """
+
     if "(" not in descriptor or ")" not in descriptor:
         raise ValueError(f"Invalid descriptor. {descriptor}")
 

--- a/quark/utils/tools.py
+++ b/quark/utils/tools.py
@@ -49,7 +49,7 @@ def descriptor_to_androguard_format(descriptor):
 
     delimiter = descriptor.index(")")
 
-    arg_str = descriptor[:delimiter]
+    arg_str = descriptor[1:delimiter]
     args = re.findall(r"L.+?;|[ZBCSIJFD]|\[", arg_str)
 
     new_descriptor = "(" + " ".join(args) + descriptor[delimiter:]

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -291,51 +291,70 @@ class TestApkinfo:
         assert expect_method in result
 
     def test_find_method_in_regular_class(self, apkinfo):
-        result = apkinfo.find_method(
+        expected = [
             "Ljava/lang/reflect/Field;", "setAccessible", "(Z)V"
+        ]
+        expect_method = MethodObject(
+            expected[0],
+            expected[1],
+            expected[2],
         )
 
-        assert isinstance(result, MethodObject)
-        assert str(result.class_name) == "Ljava/lang/reflect/Field;"
-        assert str(result.name) == "setAccessible"
-        assert str(result.descriptor) == "(Z)V"
+        result = apkinfo.find_method(
+            expected[0],
+            expected[1],
+            expected[2],
+        )
+
+        assert isinstance(result, list)
+        assert len(result) > 0
+        assert expect_method in result
 
     def test_find_method_in_inner_class(self, apkinfo):
-        result = apkinfo.find_method(
+        expected = [
             "Landroid/support/v4/accessibilityservice/Accessibility"
             + "ServiceInfoCompat$AccessibilityServiceInfoVersionImpl;",
             "getId",
             "(Landroid/accessibilityservice/AccessibilityServiceInfo;)"
             + "Ljava/lang/String;",
+        ]
+        expect_method = MethodObject(
+            expected[0],
+            expected[1],
+            expected[2],
         )
 
-        assert isinstance(result, MethodObject)
-        assert (
-            str(result.class_name)
-            == "Landroid/support/v4/accessibilityservice/Accessibility"
-            + "ServiceInfoCompat$AccessibilityServiceInfoVersionImpl;"
+        result = apkinfo.find_method(
+            expected[0],
+            expected[1],
+            expected[2],
         )
-        assert str(result.name) == "getId"
-        assert (
-            str(result.descriptor)
-            == "(Landroid/accessibilityservice/AccessibilityServiceInfo;)"
-            + "Ljava/lang/String;"
-        )
+
+        assert isinstance(result, list)
+        assert len(result) > 0
+        assert expect_method in result
 
     def test_find_method_in_anonymous_class(self, apkinfo):
-        result = apkinfo.find_method(
+        expected = [
             "Landroid/support/v4/view/AccessibilityDelegateCompatIcs$1;",
             "sendAccessibilityEvent",
             "(Landroid/view/View; I)V",
+        ]
+        expect_method = MethodObject(
+            expected[0],
+            expected[1],
+            expected[2],
         )
 
-        assert isinstance(result, MethodObject)
-        assert (
-            str(result.class_name)
-            == "Landroid/support/v4/view/AccessibilityDelegateCompatIcs$1;"
+        result = apkinfo.find_method(
+            expected[0],
+            expected[1],
+            expected[2],
         )
-        assert str(result.name) == "sendAccessibilityEvent"
-        assert str(result.descriptor) == "(Landroid/view/View; I)V"
+
+        assert isinstance(result, list)
+        assert len(result) > 0
+        assert expect_method in result
 
     def test_upperfunc(self, apkinfo):
         api = apkinfo.find_method(

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -290,6 +290,53 @@ class TestApkinfo:
         assert isinstance(result, list)
         assert expect_method in result
 
+    def test_find_method_in_regular_class(self, apkinfo):
+        result = apkinfo.find_method(
+            "Ljava/lang/reflect/Field;", "setAccessible", "(Z)V"
+        )
+
+        assert isinstance(result, MethodObject)
+        assert str(result.class_name) == "Ljava/lang/reflect/Field;"
+        assert str(result.name) == "setAccessible"
+        assert str(result.descriptor) == "(Z)V"
+
+    def test_find_method_in_inner_class(self, apkinfo):
+        result = apkinfo.find_method(
+            "Landroid/support/v4/accessibilityservice/Accessibility"
+            + "ServiceInfoCompat$AccessibilityServiceInfoVersionImpl;",
+            "getId",
+            "(Landroid/accessibilityservice/AccessibilityServiceInfo;)"
+            + "Ljava/lang/String;",
+        )
+
+        assert isinstance(result, MethodObject)
+        assert (
+            str(result.class_name)
+            == "Landroid/support/v4/accessibilityservice/Accessibility"
+            + "ServiceInfoCompat$AccessibilityServiceInfoVersionImpl;"
+        )
+        assert str(result.name) == "getId"
+        assert (
+            str(result.descriptor)
+            == "(Landroid/accessibilityservice/AccessibilityServiceInfo;)"
+            + "Ljava/lang/String;"
+        )
+
+    def test_find_method_in_anonymous_class(self, apkinfo):
+        result = apkinfo.find_method(
+            "Landroid/support/v4/view/AccessibilityDelegateCompatIcs$1;",
+            "sendAccessibilityEvent",
+            "(Landroid/view/View; I)V",
+        )
+
+        assert isinstance(result, MethodObject)
+        assert (
+            str(result.class_name)
+            == "Landroid/support/v4/view/AccessibilityDelegateCompatIcs$1;"
+        )
+        assert str(result.name) == "sendAccessibilityEvent"
+        assert str(result.descriptor) == "(Landroid/view/View; I)V"
+
     def test_upperfunc(self, apkinfo):
         api = apkinfo.find_method(
             "Lcom/example/google/service/ContactsHelper;",

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -170,7 +170,7 @@ class TestApkinfo:
         if apkinfo.core_library == "androguard":
             assert len(apkinfo.android_apis) == 1270
         elif apkinfo.core_library == "rizin":
-            assert len(apkinfo.android_apis) == 1269
+            assert len(apkinfo.android_apis) == 1438
         assert api.issubset(apkinfo.android_apis)
 
     def test_custom_methods(self, apkinfo):
@@ -189,7 +189,7 @@ class TestApkinfo:
         if apkinfo.core_library == "androguard":
             assert len(apkinfo.custom_methods) == 3999
         elif apkinfo.core_library == "rizin":
-            assert len(apkinfo.custom_methods) == 3990
+            assert len(apkinfo.custom_methods) == 3999
         assert test_custom_method.issubset(apkinfo.custom_methods)
 
     def test_all_methods(self, apkinfo):
@@ -209,7 +209,7 @@ class TestApkinfo:
         if apkinfo.core_library == "androguard":
             assert len(apkinfo.all_methods) == 5452
         elif apkinfo.core_library == "rizin":
-            assert len(apkinfo.all_methods) == 5260
+            assert len(apkinfo.all_methods) == 5451
 
         assert test_custom_method.issubset(apkinfo.all_methods)
 

--- a/tests/core/test_rzapkinfo.py
+++ b/tests/core/test_rzapkinfo.py
@@ -1,11 +1,4 @@
-import pytest
-import requests
-
-from quark.core.apkinfo import AndroguardImp
-from quark.core.interface.baseapkinfo import BaseApkinfo
 from quark.core.rzapkinfo import RizinImp
-from quark.core.struct.bytecodeobject import BytecodeObject
-from quark.core.struct.methodobject import MethodObject
 
 
 OPS = [

--- a/tests/core/test_rzapkinfo.py
+++ b/tests/core/test_rzapkinfo.py
@@ -1,0 +1,41 @@
+import pytest
+import requests
+
+from quark.core.apkinfo import AndroguardImp
+from quark.core.interface.baseapkinfo import BaseApkinfo
+from quark.core.rzapkinfo import RizinImp
+from quark.core.struct.bytecodeobject import BytecodeObject
+from quark.core.struct.methodobject import MethodObject
+
+
+OPS = [
+    {
+        "mnemonic": "const-class",
+        "parameter": "Landroid/view/KeyEvent;",
+        "expect_type": str,
+    },
+    {
+        "mnemonic": "const-wide/16",
+        "parameter": 0x3e8,
+        "expect_type": float,
+    },
+    {
+        "mnemonic": "invoke-virtual",
+        "parameter": ("Ljava/lang/StringBuilder;->append(Ljava/lang/String;)"
+                      "Ljava/lang/StringBuilder;"),
+        "expect_type": str,
+    },
+    {
+        "mnemonic": "const-string",
+        "parameter": "str.google.c.a.tc",
+        "expect_type": str,
+    },
+]
+
+
+class TestRzApkinfo:
+
+    def test_parse_parameter(self):
+        for op in OPS:
+            parsed_param = RizinImp._parse_parameter(op.get("parameter"))
+            assert isinstance(parsed_param, op.get("expect_type"))


### PR DESCRIPTION
**Description**

Close https://github.com/quark-engine/quark-engine/issues/334.
This PR is based on  #335 .
It aims to updates the Rizin-based analysis library to work with the current Rizin at the dev branch. 
The current release is v0.5.x.
It includes the following changes -

* Update parser for command axtj
* Replace command axffj with pdfj and is.j since Rizin v0.4.x removed it.
* Rewrite _get_method_by_address by using is.j to precisely find the method via a given address.
* Add support to parse methods with variable-length arguments.
* Refactor to use the same code to parse the output of isj and is.j.

**Code Changes**

* quark/core/rzapkinfo.py
* quark/utils/tools.py

**Test Plans**

All tests passed.