### PR TITLE
Add quark script to detect cwe 489

### DIFF
--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1447,6 +1447,8 @@ First, we use Quark API ``getApplication`` to get the application element in the
 Quark Script CWE-489.py
 ===========================
 
+The Quark Script below uses allsafe.apk to demonstrate. You can change the ``SAMPLE_PATH`` to the sample you want to detect. For example, ``SAMPLE_PATH = AndroGoat.apk`` or ``SAMPLE_PATH = pivaa.apk``.
+
 .. code-block:: python
 
     from quark.script import getApplication

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1463,18 +1463,18 @@ Quark Script Result
 .. code-block:: TEXT
     
     $ python3 CWE-489.py
-    CWE-489 is detected in the allsafe.apk
+    CWE-489 is detected in allsafe.apk
 
 - **AndroGoat.apk**
 
 .. code-block:: TEXT
     
     $ python3 CWE-489.py
-    CWE-489 is detected in the AndroGoat.apk
+    CWE-489 is detected in AndroGoat.apk
 
 - **pivaa.apk**
 
 .. code-block:: TEXT
     
     $ python3 CWE-489.py
-    CWE-489 is detected in the pivaa.apk
+    CWE-489 is detected in pivaa.apk

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -276,7 +276,7 @@ getApplication(samplePath)
 - **Description**: Get the application element from the manifest file of the target sample.
 - **params**: 
     1. samplePath: the file path of the target sample
-- **return**: the application elememt of the target sample
+- **return**: the application element of the target sample
 
 applicationInstance.isDebuggable(none)
 ======================================

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -276,10 +276,10 @@ getApplication(samplePath)
 - **Description**: Get the application from the manifest of the target sample.
 - **params**: 
     1. ``samplePath`` : the file path of the target sample
-- **return**: Application instance of the sample
+- **return**: the Application instance of the sample
 
 applicationInstance.isDebuggable(none)
-==========================
+======================================
 - **Description**: Check if the application sets ``android:debuggable=true``.
 - **params**: none
 - **return**:  True/False
@@ -1440,7 +1440,7 @@ Detect CWE-489 in Android Application (allsafe.apk, AndroGoat.apk, pivaa.apk)
 
 This scenario seeks to find **active debug code** in the APK file. See `CWE-489 <https://cwe.mitre.org/data/definitions/489.html>`_ for more details.
 
-Let's use `allsafe.apk <https://github.com/t0thkr1s/allsafe>`_, `AndroGoat.apk <https://github.com/satishpatnayak/AndroGoat>`_, `pivaa.apk <https://github.com/HTBridge/pivaa>`_ and the above APIs to show how Quark script find this vulnerability.
+Let's use `allsafe.apk <https://github.com/t0thkr1s/allsafe>`_, `AndroGoat.apk <https://github.com/satishpatnayak/AndroGoat>`_, `pivaa.apk <https://github.com/HTBridge/pivaa>`_, and the above APIs to show how the Quark script finds this vulnerability.
 
 First, we use Quark API ``getApplication`` to get the application data in the manifest. Then we use ``applicationInstance.isDebuggable`` to check if the application sets the attribute ``android:debuggable=true``. If **Yes**, that causes CWE-489 vulnerabilities.
 
@@ -1454,7 +1454,7 @@ Quark Script CWE-489.py
     SAMPLE_PATH = "allsafe.apk"
 
     if getApplication(SAMPLE_PATH).isDebuggable():
-        print(f"CWE-489 is detected in the {SAMPLE_PATH}")    
+        print(f"CWE-489 is detected in {SAMPLE_PATH}.")    
 
 Quark Script Result
 ======================

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1442,7 +1442,7 @@ This scenario seeks to find **active debug code** in the APK file. See `CWE-489 
 
 Let's use `allsafe.apk <https://github.com/t0thkr1s/allsafe>`_, `AndroGoat.apk <https://github.com/satishpatnayak/AndroGoat>`_, `pivaa.apk <https://github.com/HTBridge/pivaa>`_, and the above APIs to show how the Quark script finds this vulnerability.
 
-First, we use Quark API ``getApplication`` to get the application data in the manifest. Then we use ``applicationInstance.isDebuggable`` to check if the application sets the attribute ``android:debuggable=true``. If **Yes**, that causes CWE-489 vulnerabilities.
+First, we use Quark API ``getApplication`` to get the application data in the manifest. Then we use ``applicationInstance.isDebuggable`` to check if the application sets the attribute ``android:debuggable`` to true. If **Yes**, that causes CWE-489 vulnerabilities.
 
 Quark Script CWE-489.py
 ===========================

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -273,14 +273,14 @@ activityInstance.isExported(none)
 
 getApplication(samplePath)
 ==========================
-- **Description**: Get the application from the manifest of the target sample.
+- **Description**: Get the application element from the manifest file of the target sample.
 - **params**: 
-    1. ``samplePath`` : the file path of the target sample
-- **return**: the Application instance of the sample
+    1. samplePath: the file path of the target sample
+- **return**: the application elememt of the target sample
 
 applicationInstance.isDebuggable(none)
 ======================================
-- **Description**: Check if the application sets ``android:debuggable=true``.
+- **Description**: Check if the application element sets ``android:debuggable=true``.
 - **params**: none
 - **return**:  True/False
 
@@ -1442,7 +1442,7 @@ This scenario seeks to find **active debug code** in the APK file. See `CWE-489 
 
 Let's use `allsafe.apk <https://github.com/t0thkr1s/allsafe>`_, `AndroGoat.apk <https://github.com/satishpatnayak/AndroGoat>`_, `pivaa.apk <https://github.com/HTBridge/pivaa>`_, and the above APIs to show how the Quark script finds this vulnerability.
 
-First, we use Quark API ``getApplication`` to get the application data in the manifest. Then we use ``applicationInstance.isDebuggable`` to check if the application sets the attribute ``android:debuggable`` to true. If **Yes**, that causes CWE-489 vulnerabilities.
+First, we use Quark API ``getApplication`` to get the application element in the manifest file. Then we use ``applicationInstance.isDebuggable`` to check if the application element sets the attribute ``android:debuggable`` to true. If **Yes**, that causes CWE-489 vulnerabilities.
 
 Quark Script CWE-489.py
 ===========================

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -271,6 +271,18 @@ activityInstance.isExported(none)
 - **params**: none
 - **return**: True/False
 
+getApplication(samplePath)
+==========================
+- **Description**: Get the application from the manifest of the target sample.
+- **params**: 
+    1. ``samplePath`` : the file path of the target sample
+- **return**: Application instance of the sample
+
+applicationInstance.isDebuggable(none)
+==========================
+- **Description**: Check if the application sets ``android:debuggable=true``.
+- **params**: none
+- **return**:  True/False
 
 Analyzing real case (InstaStealer) using Quark Script
 ------------------------------------------------------
@@ -1421,3 +1433,48 @@ Quark Script Result
    $　python3 CWE-295.py
    Requested API level 29 is larger than maximum we have, returning API level 28 instead.
    CWE-295 is detected in method, Lcom/insecureshop/util/CustomWebViewClient; onReceivedSslError (Landroid/webkit/WebView; Landroid/webkit/SslErrorHandler; Landroid/net/http/SslError;)V
+
+
+Detect CWE-489 in Android Application (allsafe.apk, AndroGoat.apk, pivaa.apk)
+-------------------------------------------------------------------------------
+
+This scenario seeks to find **active debug code** in the APK file. See `CWE-489 <https://cwe.mitre.org/data/definitions/489.html>`_ for more details.
+
+Let's use `allsafe.apk <https://github.com/t0thkr1s/allsafe>`_, `AndroGoat.apk <https://github.com/satishpatnayak/AndroGoat>`_, `pivaa.apk <https://github.com/HTBridge/pivaa>`_ and the above APIs to show how Quark script find this vulnerability.
+
+First, we use Quark API ``getApplication`` to get the application data in the manifest. Then we use ``applicationInstance.isDebuggable`` to check if the application sets the attribute ``android:debuggable=true``. If **Yes**, that causes CWE-489 vulnerabilities.
+
+Quark Script CWE-489.py
+===========================
+
+.. code-block:: python
+
+    from quark.script import getApplication
+
+    SAMPLE_PATH = "allsafe.apk"
+
+    if getApplication(SAMPLE_PATH).isDebuggable():
+        print(f"CWE-489 is detected in the {SAMPLE_PATH}")    
+
+Quark Script Result
+======================
+- **allsafe.apk**
+
+.. code-block:: TEXT
+    
+    $ python3 CWE-489.py
+    CWE-489 is detected in the allsafe.apk
+
+- **AndroGoat.apk**
+
+.. code-block:: TEXT
+    
+    $ python3 CWE-489.py
+    CWE-489 is detected in the AndroGoat.apk
+
+- **pivaa.apk**
+
+.. code-block:: TEXT
+    
+    $ python3 CWE-489.py
+    CWE-489 is detected in the pivaa.apk

--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -45,6 +45,10 @@ class AndroguardImp(BaseApkinfo):
 
     @property
     def application(self) -> XMLElement:
+        """Get the application data from the manifest file.
+
+        :return: an element instance of the application attribute
+        """
         if self.ret_type == "DEX":
             return []
 

--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -44,6 +44,15 @@ class AndroguardImp(BaseApkinfo):
             return []
 
     @property
+    def application(self) -> XMLElement:
+        if self.ret_type == "DEX":
+            return []
+
+        manifest_root = self.apk.get_android_manifest_xml()
+
+        return manifest_root.find("application")
+
+    @property
     def activities(self) -> List[XMLElement]:
         if self.ret_type == "DEX":
             return []

--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -45,9 +45,9 @@ class AndroguardImp(BaseApkinfo):
 
     @property
     def application(self) -> XMLElement:
-        """Get the application data from the manifest file.
+        """Get the application element from the manifest file.
 
-        :return: an element instance of the application attribute
+        :return: an application element
         """
         if self.ret_type == "DEX":
             return []

--- a/quark/core/interface/baseapkinfo.py
+++ b/quark/core/interface/baseapkinfo.py
@@ -72,6 +72,16 @@ class BaseApkinfo:
 
     @property
     @abstractmethod
+    def application(self) -> XMLElement:
+        """
+        Return the application from given APK.
+
+        :return: the application of APK
+        """
+        pass
+
+    @property
+    @abstractmethod
     def activities(self) -> List[XMLElement]:
         """
         Return all activity from given APK.

--- a/quark/core/interface/baseapkinfo.py
+++ b/quark/core/interface/baseapkinfo.py
@@ -74,9 +74,9 @@ class BaseApkinfo:
     @abstractmethod
     def application(self) -> XMLElement:
         """
-        Return the application from given APK.
+        Return the application element from the manifest file of given APK.
 
-        :return: the application of APK
+        :return: a application element
         """
         pass
 

--- a/quark/core/interface/baseapkinfo.py
+++ b/quark/core/interface/baseapkinfo.py
@@ -73,10 +73,9 @@ class BaseApkinfo:
     @property
     @abstractmethod
     def application(self) -> XMLElement:
-        """
-        Return the application element from the manifest file of given APK.
+        """Get the application element from the manifest file.
 
-        :return: a application element
+        :return: an application element
         """
         pass
 

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -246,11 +246,11 @@ class RizinImp(BaseApkinfo):
 
     @functools.cached_property
     def application(self) -> XMLElement:
-        """
-        Return the application from given APK.
+        """Get the application element from the manifest file.
 
-        :return: the application of APK
+        :return: an application element
         """
+
         axml = AxmlReader(self._manifest)
         root = axml.get_xml_tree()
 

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -245,6 +245,18 @@ class RizinImp(BaseApkinfo):
         return permission_list
 
     @functools.cached_property
+    def application(self) -> XMLElement:
+        """
+        Return the application from given APK.
+
+        :return: the application of APK
+        """
+        axml = AxmlReader(self._manifest)
+        root = axml.get_xml_tree()
+
+        return root.findall("application")
+
+    @functools.cached_property
     def activities(self) -> List[XMLElement]:
         """
         Return all activity from given APK.

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -254,7 +254,7 @@ class RizinImp(BaseApkinfo):
         axml = AxmlReader(self._manifest)
         root = axml.get_xml_tree()
 
-        return root.findall("application")
+        return root.find("application")
 
     @functools.cached_property
     def activities(self) -> List[XMLElement]:

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -70,7 +70,7 @@ class Application:
         return self.xml.get(realAttributeName, defaultValue)
 
     def isDebuggable(self) -> bool:
-        """Check if the application is debuggable.
+        """Check if the application sets `android:debuggable=true`.
 
         :return: True/False
         """
@@ -511,10 +511,10 @@ def getActivities(samplePath: PathLike) -> List[Activity]:
 
 
 def getApplication(samplePath: PathLike) -> Application:
-    """Get activities from a target sample.
+    """Get the application from the manifest of the target sample.
 
-    :param samplePath: target file
-    :return: python list containing activities
+    :param samplePath: the file path of the target sample
+    :return: the Application instance of the sample
     """
     quark = _getQuark(samplePath)
     apkinfo = quark.apkinfo

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -70,7 +70,7 @@ class Application:
         return self.xml.get(realAttributeName, defaultValue)
 
     def isDebuggable(self) -> bool:
-        """Check if the application is debuggable.
+        """Check if the application element sets `android:debuggable=true`.
 
         :return: True/False
         """
@@ -513,10 +513,10 @@ def getActivities(samplePath: PathLike) -> List[Activity]:
 
 
 def getApplication(samplePath: PathLike) -> Application:
-    """Get activities from a target sample.
+    """Get the application element from the manifest file of the target sample.
 
-    :param samplePath: target file
-    :return: python list containing activities
+    :param samplePath: the file path of the target sample
+    :return: the application elememt of the target sample
     """
     quark = _getQuark(samplePath)
     apkinfo = quark.apkinfo

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -54,6 +54,30 @@ class DefaultRuleset(Ruleset):
 DEFAULT_RULESET = DefaultRuleset(join(QUARK_RULE_PATH, "rules"))
 
 
+class Application:
+    def __init__(self, xml: XMLElement) -> None:
+        self.xml: XMLElement = xml
+
+    def __str__(self) -> str:
+        return self._getAttribute("label")
+
+    def _getAttribute(
+        self, attributeName: str, defaultValue: Any = None
+    ) -> Any:
+        realAttributeName = (
+            f"{{http://schemas.android.com/apk/res/android}}{attributeName}"
+        )
+        return self.xml.get(realAttributeName, defaultValue)
+
+    def isDebuggable(self) -> bool:
+        """Check if the application is debuggable.
+
+        :return: True/False
+        """
+        debuggable = self._getAttribute("debuggable")
+        return debuggable
+
+
 class Activity:
     def __init__(self, xml: XMLElement) -> None:
         self.xml: XMLElement = xml
@@ -454,8 +478,8 @@ class QuarkResult:
                 matchedMethods.append(calleeMethod)
 
         return [self._wrapMethodObject(
-               callerMethodObj, self.quark, matchedMethod
-               ) for matchedMethod in matchedMethods]
+            callerMethodObj, self.quark, matchedMethod
+        ) for matchedMethod in matchedMethods]
 
 
 def runQuarkAnalysis(samplePath: PathLike, ruleInstance: Rule) -> QuarkResult:
@@ -482,6 +506,18 @@ def getActivities(samplePath: PathLike) -> List[Activity]:
     apkinfo = quark.apkinfo
 
     return [Activity(xml) for xml in apkinfo.activities]
+
+
+def getApplication(samplePath: PathLike) -> Application:
+    """Get activities from a target sample.
+
+    :param samplePath: target file
+    :return: python list containing activities
+    """
+    quark = _getQuark(samplePath)
+    apkinfo = quark.apkinfo
+
+    return Application(apkinfo.application)
 
 
 def findMethodInAPK(

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -516,7 +516,7 @@ def getApplication(samplePath: PathLike) -> Application:
     """Get the application element from the manifest file of the target sample.
 
     :param samplePath: the file path of the target sample
-    :return: the application elememt of the target sample
+    :return: the application element of the target sample
     """
     quark = _getQuark(samplePath)
     apkinfo = quark.apkinfo

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -59,7 +59,7 @@ class Application:
         self.xml: XMLElement = xml
 
     def __str__(self) -> str:
-        return self._getAttribute("label")
+        return str(self._getAttribute("label"))
 
     def _getAttribute(
         self, attributeName: str, defaultValue: Any = None
@@ -70,14 +70,16 @@ class Application:
         return self.xml.get(realAttributeName, defaultValue)
 
     def isDebuggable(self) -> bool:
-        """Check if the application sets `android:debuggable=true`.
+        """Check if the application is debuggable.
 
         :return: True/False
         """
         debuggable = self._getAttribute("debuggable")
+        print(debuggable)
         if debuggable is None:
             return False
-        return debuggable.lower() == "true"
+
+        return str(debuggable).lower() == "true"
 
 
 class Activity:
@@ -511,10 +513,10 @@ def getActivities(samplePath: PathLike) -> List[Activity]:
 
 
 def getApplication(samplePath: PathLike) -> Application:
-    """Get the application from the manifest of the target sample.
+    """Get activities from a target sample.
 
-    :param samplePath: the file path of the target sample
-    :return: the Application instance of the sample
+    :param samplePath: target file
+    :return: python list containing activities
     """
     quark = _getQuark(samplePath)
     apkinfo = quark.apkinfo

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -75,7 +75,9 @@ class Application:
         :return: True/False
         """
         debuggable = self._getAttribute("debuggable")
-        return debuggable
+        if debuggable is None:
+            return False
+        return debuggable.lower() == "true"
 
 
 class Activity:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,13 @@ SAMPLES = [
         ),
         "fileName": "13667fe3b0ad496a0cd157f34b7e0c991d72a4db.apk",
     },
+    {
+        "sourceUrl": (
+            "https://github.com/quark-engine/apk-samples"
+            "/raw/master/malware-samples/Ahmyth.apk"
+        ),
+        "fileName": "Ahmyth.apk"
+    }
 ]
 
 
@@ -50,3 +57,8 @@ def SAMPLE_PATH_14d9f(tmp_path_factory: pytest.TempPathFactory) -> str:
 @pytest.fixture(scope="session")
 def SAMPLE_PATH_13667(tmp_path_factory: pytest.TempPathFactory) -> str:
     return downloadSample(tmp_path_factory, SAMPLES[1])
+
+
+@pytest.fixture(scope="session")
+def SAMPLE_PATH_Ahmyth(tmp_path_factory: pytest.TempPathFactory) -> str:
+    return downloadSample(tmp_path_factory, SAMPLES[2])

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -104,6 +104,17 @@ class TestApkinfo:
         assert set(apkinfo.permissions) == set(ans)
 
     @staticmethod
+    def test_application(apkinfo):
+        application = apkinfo.application
+
+        assert (
+            application.get(
+                "{http://schemas.android.com/apk/res/android}label"
+            )
+            == "@7F050001"
+        )
+
+    @staticmethod
     def test_activities(apkinfo):
         activities = apkinfo.activities
 

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -106,13 +106,10 @@ class TestApkinfo:
     @staticmethod
     def test_application(apkinfo):
         application = apkinfo.application
-
-        assert (
-            application.get(
-                "{http://schemas.android.com/apk/res/android}label"
-            )
-            == "@7F050001"
-        )
+        label = str(application.get(
+            "{http://schemas.android.com/apk/res/android}label"
+        ))
+        assert label == "@7F050001" or label == "2131034113"
 
     @staticmethod
     def test_activities(apkinfo):

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -12,6 +12,7 @@ from quark.script import (
     QuarkResult,
     Ruleset,
     getActivities,
+    getApplication,
     runQuarkAnalysis,
     findMethodInAPK,
 )
@@ -70,6 +71,18 @@ class TestDefaultRuleset:
 
         with pytest.raises(KeyError):
             _ = ruleset[1]
+
+
+class TestApplication:
+    @staticmethod
+    def testIsNotDebuggable(SAMPLE_PATH_Ahmyth):
+        application = getApplication(SAMPLE_PATH_Ahmyth)
+        assert application.isDebuggable() is False
+
+    @staticmethod
+    def testIsDebuggable(SAMPLE_PATH_13667):
+        application = getApplication(SAMPLE_PATH_13667)
+        assert application.isDebuggable() is True
 
 
 class TestActivity:


### PR DESCRIPTION
# Detect CWE-489 in Android Application (allsafe.apk, AndroGoat.apk, pivaa.apk)

This scenario seeks to find **active debug code** in the APK file. See [CWE-489](https://cwe.mitre.org/data/definitions/489.html) for more details.

Let’s use [allsafe.apk](https://github.com/t0thkr1s/allsafe), [AndroGoat.apk](https://github.com/satishpatnayak/AndroGoat), [pivaa.apk](https://github.com/HTBridge/pivaa), and the above APIs to show how the Quark script finds this vulnerability.

First, we use Quark API `getApplication` to get the application element in the manifest file. Then we use `applicationInstance.isDebuggable` to check if the application element sets the attribute `android:debuggable` to true. If **Yes**, that causes CWE-489 vulnerabilities.

## API Spec
### getApplication(samplePath)

-   **Description**: Get the application element from the manifest file of the target sample.
-   **params**:
    1.  samplePath: the file path of the target sample
-   **return**: the application element of the target sample

### applicationInstance.isDebuggable(none)

-   **Description**: Check if the application element sets `android:debuggable=true`.
-   **params**: none
-   **return**: True/False

## Quark Script CWE-489.py

The Quark Script below uses allsafe.apk to demonstrate. You can change the `SAMPLE_PATH` to the sample you want to detect. For example, `SAMPLE_PATH = AndroGoat.apk` or `SAMPLE_PATH = pivaa.apk`.

```python
from quark.script import getApplication

SAMPLE_PATH = "allsafe.apk"

if getApplication(SAMPLE_PATH).isDebuggable():
    print(f"CWE-489 is detected in {SAMPLE_PATH}.")
```

## Quark Script Result

-   **allsafe.apk**

```
$ python3 CWE-489.py
CWE-489 is detected in allsafe.apk
```

-   **AndroGoat.apk**

``` 
$ python3 CWE-489.py
CWE-489 is detected in AndroGoat.apk
```
-   **pivaa.apk**
    
```
$ python3 CWE-489.py
CWE-489 is detected in pivaa.apk
```