### PR TITLE
New document file quark_method_reference.rst and new instruction of find_previous_method in document.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,6 +29,7 @@ This guide will explain how to set up Quark, use it, and customize it.
    contribution
    organization
    doc
+   quark_method_reference
    quark_inside_index
    modules
    faq

--- a/docs/source/quark_method_reference.rst
+++ b/docs/source/quark_method_reference.rst
@@ -10,7 +10,7 @@ find_previous_method
 -  **Description** The find_previous_method method uses a DFS algorithm
    to collect all MethodObjects called by the **parent_method** and add
    them to the specified **wrapper**. The search starts from the
-   **base_method** and and goes on recursively until there are no more
+   **base_method** and goes on recursively until there are no more
    levels or all candidates have been processed.
 
 -  **Param**

--- a/docs/source/quark_method_reference.rst
+++ b/docs/source/quark_method_reference.rst
@@ -20,7 +20,7 @@ The find_previous_method method uses a DFS algorithm to collect all MethodObject
     4. If "method_set" is not None then check if "parent_function" is in "method_set".
        - If yes, append "base_method" to "wrapper".
        - If no, then iterate through each item in "method_set".
-            - If the item is in "visited_methods", continue to the next item.
+            - If the item is in "visited_methods", skip it and continue to the next item.
             - If not, call "find_previous_method" again with the current item, "parent_function", "wrapper", and "visited_methods".
 
 **The code of find_previous_method**

--- a/docs/source/quark_method_reference.rst
+++ b/docs/source/quark_method_reference.rst
@@ -18,7 +18,8 @@ find_previous_method
    -  **base_method**: the base function which needs to be searched.
    -  **parent_function**: the top-level function which calls the basic
       function.
-   -  **wrapper**: list is used to track each function.
+   -  **wrapper**: python list, which contains the targeted
+      parent_method.
    -  **visited_methods**: set with tested method.
 
 -  **Return** None

--- a/docs/source/quark_method_reference.rst
+++ b/docs/source/quark_method_reference.rst
@@ -1,46 +1,60 @@
++++++++++++++++++++++++
 Quark Method Reference
-======================
++++++++++++++++++++++++
 
-quark.core.qurk.py
-------------------
+quark.core.quark.py
+--------------------
 
 find_previous_method
-~~~~~~~~~~~~~~~~~~~~
+=====================
 
--  **Description** The find_previous_method method uses a DFS algorithm
-   to collect all MethodObjects called by the **parent_method** and add
-   them to the specified **wrapper**. The search starts from the
-   **base_method** and goes on recursively until there are no more
-   levels or all candidates have been processed.
+**The algorithm of find_previous_method**
 
--  **Param**
+The find_previous_method method uses a DFS algorithm to collect all MethodObjects called by the parent_method and add them to the specified wrapper. The search starts from the base_method and goes on recursively until there are no more levels or all candidates have been processed.
 
-   -  **base_method**: the base function which needs to be searched.
-   -  **parent_function**: the top-level function which calls the basic
-      function.
-   -  **wrapper**: python list, which contains the targeted
-      parent_method.
-   -  **visited_methods**: set with tested method.
+.. code-block:: TEXT
 
--  **Return** None
+    1. Initialize an empty set "visited_methods" if it is not provided.
+    2. Get a set "method_set" using "self.apkinfo.upperfunc(base_method)".
+    3. Add "base_method" to the "visited_methods" set.
+    4. If "method_set" is not None then check if "parent_function" is in "method_set".
+       - If yes, append "base_method" to "wrapper".
+       - If no, then iterate through each item in "method_set".
+            - If the item is in "visited_methods", continue to the next item.
+            - If not, call "find_previous_method" again with the current item, "parent_function", "wrapper", and "visited_methods".
 
--  **Algorithm**
+**The code of find_previous_method**
 
-   1. Initialize an empty set **visited_methods** if it is not provided.
-   2. Get a set **method_set** using
-      **self.apkinfo.upperfunc(base_method)**
-   3. Add **base_method** to the **visited_methods** set.
-   4. If **method_set** is not **None**:
+.. code-block:: python
 
-      -  
+    def find_previous_method(
+        self, base_method, parent_function, wrapper, visited_methods=None
+    ):
+        """
+        Find the method under the parent function, based on base_method before to parent_function.
+        This will append the method into wrapper.
 
-         a. Check if **parent_function** is in **method_set**.
+        :param base_method: the base function which needs to be searched.
+        :param parent_function: the top-level function which calls the basic function.
+        :param wrapper: python list, which contains the targeted parent_method.
+        :param visited_methods: set with tested method.
+        :return: None
+        """
+        if visited_methods is None:
+            visited_methods = set()
 
-         -  If yes, append **base_method** to **wrapper**.
-         -  If no, then iterate through each item in **method_set**.
+        method_set = self.apkinfo.upperfunc(base_method)
+        visited_methods.add(base_method)
 
-            -  If the item is in **visited_methods**, continue to the
-               next item.
-            -  If not, call **find_previous_method** again with the
-               current item, **parent_function**, **wrapper**, and
-               **visited_methods**.
+        if method_set is not None:
+
+            if parent_function in method_set:
+                wrapper.append(base_method)
+            else:
+                for item in method_set:
+                    # prevent to test the tested methods.
+                    if item in visited_methods:
+                        continue
+                    self.find_previous_method(
+                        item, parent_function, wrapper, visited_methods
+                    )

--- a/docs/source/quark_method_reference.rst
+++ b/docs/source/quark_method_reference.rst
@@ -36,7 +36,7 @@ The find_previous_method method uses a DFS algorithm to collect all MethodObject
 
         :param base_method: the base function which needs to be searched.
         :param parent_function: the top-level function which calls the basic function.
-        :param wrapper: python list, which contains the targeted parent_method.
+        :param wrapper: list is used to track each function.
         :param visited_methods: set with tested method.
         :return: None
         """

--- a/docs/source/quark_method_reference.rst
+++ b/docs/source/quark_method_reference.rst
@@ -1,0 +1,24 @@
+Quark Method Reference
+======================
+
+quark.core.qurk.py
+------------------
+
+find_previous_method
+~~~~~~~~~~~~~~~~~~~~
+
+-  **Description** The find_previous_method method uses a DFS algorithm
+   to collect all MethodObjects called by the **parent_method** and add
+   them to the specified **wrapper**. The search starts from the
+   **base_method** and and goes on recursively until there are no more
+   levels or all candidates have been processed.
+
+-  **Param**
+
+   -  **base_method**: the base function which needs to be searched.
+   -  **parent_function**: the top-level function which calls the basic
+      function.
+   -  **wrapper**: list is used to track each function.
+   -  **visited_methods**: set with tested method.
+
+-  **Return** None

--- a/docs/source/quark_method_reference.rst
+++ b/docs/source/quark_method_reference.rst
@@ -22,3 +22,24 @@ find_previous_method
    -  **visited_methods**: set with tested method.
 
 -  **Return** None
+
+-  **Algorithm**
+
+   1. Initialize an empty set **visited_methods** if it is not provided.
+   2. Get a set **method_set** using
+      **self.apkinfo.upperfunc(base_method)**
+   3. Add **base_method** to the **visited_methods** set.
+   4. If **method_set** is not **None**:
+
+      -  
+
+         a. Check if **parent_function** is in **method_set**.
+
+         -  If yes, append **base_method** to **wrapper**.
+         -  If no, then iterate through each item in **method_set**.
+
+            -  If the item is in **visited_methods**, continue to the
+               next item.
+            -  If not, call **find_previous_method** again with the
+               current item, **parent_function**, **wrapper**, and
+               **visited_methods**.

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -62,10 +62,8 @@ class Quark:
         self, base_method, parent_function, wrapper, visited_methods=None
     ):
         """
-        The find_previous_method method uses a DFS algorithm to collect all MethodObjects
-        called by the parent_method and add them to the specified wrapper.
-        The search starts from the base_method and goes on recursively
-        until there are no more levels or all candidates have been processed.
+        Find the method under the parent function, based on base_method before to parent_function.
+        This will append the method into wrapper.
 
         :param base_method: the base function which needs to be searched.
         :param parent_function: the top-level function which calls the basic function.

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -64,12 +64,12 @@ class Quark:
         """
         The find_previous_method method uses a DFS algorithm to collect all MethodObjects
         called by the parent_method and add them to the specified wrapper.
-        The search starts from the base_method and and goes on recursively
+        The search starts from the base_method and goes on recursively
         until there are no more levels or all candidates have been processed.
 
         :param base_method: the base function which needs to be searched.
         :param parent_function: the top-level function which calls the basic function.
-        :param wrapper: list is used to track each function.
+        :param wrapper: python list, which contains the targeted parent_method.
         :param visited_methods: set with tested method.
         :return: None
         """

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -62,9 +62,9 @@ class Quark:
         self, base_method, parent_function, wrapper, visited_methods=None
     ):
         """
-        The find_previous_method method uses a DFS algorithm to collect all MethodObjects 
-        called by the parent_method and add them to the specified wrapper. 
-        The search starts from the base_method and and goes on recursively 
+        The find_previous_method method uses a DFS algorithm to collect all MethodObjects
+        called by the parent_method and add them to the specified wrapper.
+        The search starts from the base_method and and goes on recursively
         until there are no more levels or all candidates have been processed.
 
         :param base_method: the base function which needs to be searched.

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -62,8 +62,10 @@ class Quark:
         self, base_method, parent_function, wrapper, visited_methods=None
     ):
         """
-        Find the method under the parent function, based on base_method before to parent_function.
-        This will append the method into wrapper.
+        The find_previous_method method uses a DFS algorithm to collect all MethodObjects 
+        called by the parent_method and add them to the specified wrapper. 
+        The search starts from the base_method and and goes on recursively 
+        until there are no more levels or all candidates have been processed.
 
         :param base_method: the base function which needs to be searched.
         :param parent_function: the top-level function which calls the basic function.

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -67,7 +67,7 @@ class Quark:
 
         :param base_method: the base function which needs to be searched.
         :param parent_function: the top-level function which calls the basic function.
-        :param wrapper: python list, which contains the targeted parent_method.
+        :param wrapper: list is used to track each function.
         :param visited_methods: set with tested method.
         :return: None
         """


### PR DESCRIPTION
# Quark Method Reference

## quark.core.quark.py

### find_previous_method

**The algorithm of find_previous_method**

The find_previous_method method uses a DFS algorithm to collect all 
MethodObjects called by the parent_method and add them to the specified
wrapper. The search starts from the base_method and goes on recursively
until there are no more levels or all candidates have been processed.

``` TEXT
1. Initialize an empty set "visited_methods" if it is not provided.
2. Get a set "method_set" using "self.apkinfo.upperfunc(base_method)".
3. Add "base_method" to the "visited_methods" set.
4. If "method_set" is not None then check if "parent_function" is in "method_set".
   - If yes, append "base_method" to "wrapper".
   - If no, then iterate through each item in "method_set".
        - If the item is in "visited_methods", skip it and continue to the next item.
        - If not, call "find_previous_method" again with the current item, "parent_function", "wrapper", and "visited_methods".
```

**The code of find_previous_method**

``` python
def find_previous_method(
    self, base_method, parent_function, wrapper, visited_methods=None
):
    """
    Find the method under the parent function, based on base_method before to parent_function.
    This will append the method into wrapper.

    :param base_method: the base function which needs to be searched.
    :param parent_function: the top-level function which calls the basic function.
    :param wrapper: list is used to track each function.
    :param visited_methods: set with tested method.
    :return: None
    """
    if visited_methods is None:
        visited_methods = set()

    method_set = self.apkinfo.upperfunc(base_method)
    visited_methods.add(base_method)

    if method_set is not None:

        if parent_function in method_set:
            wrapper.append(base_method)
        else:
            for item in method_set:
                # prevent to test the tested methods.
                if item in visited_methods:
                    continue
                self.find_previous_method(
                    item, parent_function, wrapper, visited_methods
                )
```
