### PR TITLE
Make find_method match methods without giving the descriptor or class/method names (#467)

### DIFF
--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -99,9 +99,20 @@ class AndroguardImp(BaseApkinfo):
         method_name: Optional[str] = ".*",
         descriptor: Optional[str] = ".*",
     ) -> MethodObject:
-        regex_class_name = re.escape(class_name)
-        regex_method_name = f"^{re.escape(method_name)}$"
-        regex_descriptor = re.escape(descriptor)
+        if class_name != ".*":
+            regex_class_name = re.escape(class_name)
+        else:
+            regex_class_name = class_name
+
+        if method_name != ".*":
+            regex_method_name = f"^{re.escape(method_name)}$"
+        else:
+            regex_method_name = f"^{method_name}$"
+
+        if descriptor != ".*":
+            regex_descriptor = re.escape(descriptor)
+        else:
+            regex_descriptor = descriptor
 
         method_result = self.analysis.find_methods(
             classname=regex_class_name,
@@ -109,8 +120,9 @@ class AndroguardImp(BaseApkinfo):
             descriptor=regex_descriptor,
         )
 
-        result = next(method_result, None)
-        return self._convert_to_method_object(result) if result else None
+        # result = next(method_result, None)
+        # return self._convert_to_method_object(result) if result else None
+        return [self._convert_to_method_object(item) for item in method_result]
 
     @functools.lru_cache()
     def upperfunc(self, method_object: MethodObject) -> Set[MethodObject]:

--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -98,7 +98,7 @@ class AndroguardImp(BaseApkinfo):
         class_name: Optional[str] = ".*",
         method_name: Optional[str] = ".*",
         descriptor: Optional[str] = ".*",
-    ) -> list:
+    ) -> List[MethodObject]:
         if class_name != ".*":
             regex_class_name = re.escape(class_name)
         else:
@@ -120,8 +120,6 @@ class AndroguardImp(BaseApkinfo):
             descriptor=regex_descriptor,
         )
 
-        # result = next(method_result, None)
-        # return self._convert_to_method_object(result) if result else None
         return [self._convert_to_method_object(item) for item in method_result]
 
     @functools.lru_cache()

--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -99,15 +99,24 @@ class AndroguardImp(BaseApkinfo):
         method_name: Optional[str] = ".*",
         descriptor: Optional[str] = ".*",
     ) -> List[MethodObject]:
+        if not class_name:
+            class_name = ".*"
+
         if class_name != ".*":
             regex_class_name = re.escape(class_name)
         else:
             regex_class_name = class_name
 
+        if not method_name:
+            method_name = ".*"
+
         if method_name != ".*":
             regex_method_name = f"^{re.escape(method_name)}$"
         else:
             regex_method_name = f"^{method_name}$"
+
+        if not descriptor:
+            descriptor = ".*"
 
         if descriptor != ".*":
             regex_descriptor = re.escape(descriptor)

--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -98,7 +98,7 @@ class AndroguardImp(BaseApkinfo):
         class_name: Optional[str] = ".*",
         method_name: Optional[str] = ".*",
         descriptor: Optional[str] = ".*",
-    ) -> MethodObject:
+    ) -> list:
         if class_name != ".*":
             regex_class_name = re.escape(class_name)
         else:

--- a/quark/core/interface/baseapkinfo.py
+++ b/quark/core/interface/baseapkinfo.py
@@ -124,7 +124,7 @@ class BaseApkinfo:
         class_name: Optional[str] = ".*",
         method_name: Optional[str] = ".*",
         descriptor: Optional[str] = ".*",
-    ) -> MethodObject:
+    ) -> List[MethodObject]:
         """
         Find method from given class_name, method_name and the descriptor.
         default is find all method.
@@ -132,7 +132,7 @@ class BaseApkinfo:
         :param class_name: the class name of the Android API
         :param method_name: the method name of the Android API
         :param descriptor: the descriptor of the Android API
-        :return: a generator of MethodObject
+        :return: a list with MethodObjects
         """
         pass
 

--- a/quark/core/parallelquark.py
+++ b/quark/core/parallelquark.py
@@ -67,7 +67,7 @@ class ParallelQuark(Quark):
                 rule_obj.api[i]["class"],
                 rule_obj.api[i]["method"],
                 rule_obj.api[i]["descriptor"],
-            )
+            )[0]
             for i in range(2)
         ]
 
@@ -80,7 +80,7 @@ class ParallelQuark(Quark):
 
         if result[0] >= 4:
             analysis.level_4_result = [
-                self.apkinfo.find_method(method[0], method[1], method[2])
+                self.apkinfo.find_method(method[0], method[1], method[2])[0]
                 for method in result[1]
             ]
             analysis.parent_wrapper_mapping = result[3]
@@ -88,7 +88,7 @@ class ParallelQuark(Quark):
         if result[0] >= 5:
             behavior_list = [
                 tuple(
-                    self.apkinfo.find_method(method[0], method[1], method[2])
+                    self.apkinfo.find_method(method[0], method[1], method[2])[0]
                     for method in behavior
                 )
                 for behavior in result[2]

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -402,7 +402,7 @@ class Quark:
             class_name, method_name, descriptor_name
         )
         if source_method:
-            return [source_method]
+            return source_method
 
         # Potential Method
         potential_method_list = [

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -321,12 +321,16 @@ class RizinImp(BaseApkinfo):
         if class_name != ".*":
             for dex_index in dex_list:
                 method_dict = self._get_methods_classified(dex_index)
-                filtered_methods += list(filter(method_filter, method_dict[class_name]))
+                filtered_methods += list(
+                    filter(method_filter, method_dict[class_name])
+                )
         else:
             for dex_index in dex_list:
                 method_dict = self._get_methods_classified(dex_index)
                 for key_name in method_dict:
-                    filtered_methods += list(filter(method_filter, method_dict[key_name]))
+                    filtered_methods += list(
+                        filter(method_filter, method_dict[key_name])
+                    )
 
         return filtered_methods
 

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -295,17 +295,38 @@ class RizinImp(BaseApkinfo):
         method_name: Optional[str] = ".*",
         descriptor: Optional[str] = ".*",
     ) -> list:
+        if not class_name:
+            class_name = ".*"
+
+        if not method_name:
+            method_name = ".*"
+
+        if method_name != ".*":
+            method_name = re.escape(method_name)
+
+        if not descriptor:
+            descriptor = ".*"
+
+        if descriptor != ".*":
+            descriptor = re.escape(descriptor)
+
         def method_filter(method):
-            return (not method_name or method_name == method.name) and (
-                not descriptor or descriptor == method.descriptor
+            return re.match(method_name, method.name) and re.match(
+                descriptor, method.descriptor
             )
 
         dex_list = range(self._number_of_dex)
         filtered_methods = list()
 
-        for dex_index in dex_list:
-            method_dict = self._get_methods_classified(dex_index)
-            filtered_methods += list(filter(method_filter, method_dict[class_name]))
+        if class_name != ".*":
+            for dex_index in dex_list:
+                method_dict = self._get_methods_classified(dex_index)
+                filtered_methods += list(filter(method_filter, method_dict[class_name]))
+        else:
+            for dex_index in dex_list:
+                method_dict = self._get_methods_classified(dex_index)
+                for key_name in method_dict:
+                    filtered_methods += list(filter(method_filter, method_dict[key_name]))
 
         return filtered_methods
 

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -294,7 +294,7 @@ class RizinImp(BaseApkinfo):
         class_name: Optional[str] = ".*",
         method_name: Optional[str] = ".*",
         descriptor: Optional[str] = ".*",
-    ) -> list:
+    ) -> List[MethodObject]:
         if not class_name:
             class_name = ".*"
 

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -294,21 +294,20 @@ class RizinImp(BaseApkinfo):
         class_name: Optional[str] = ".*",
         method_name: Optional[str] = ".*",
         descriptor: Optional[str] = ".*",
-    ) -> MethodObject:
+    ) -> list:
         def method_filter(method):
             return (not method_name or method_name == method.name) and (
                 not descriptor or descriptor == method.descriptor
             )
 
         dex_list = range(self._number_of_dex)
+        filtered_methods = list()
 
         for dex_index in dex_list:
             method_dict = self._get_methods_classified(dex_index)
-            filtered_methods = filter(method_filter, method_dict[class_name])
-            try:
-                return next(filtered_methods)
-            except StopIteration:
-                continue
+            filtered_methods += list(filter(method_filter, method_dict[class_name]))
+
+        return filtered_methods
 
     @functools.lru_cache
     def upperfunc(self, method_object: MethodObject) -> Set[MethodObject]:

--- a/quark/evaluator/pyeval.py
+++ b/quark/evaluator/pyeval.py
@@ -673,11 +673,11 @@ class PyEval:
         ):
             next_class_pool.clear()
             for class_name in class_pool:
-                method = self.apkinfo.find_method(class_name, method_name, descriptor)[0]
+                method_list = self.apkinfo.find_method(class_name, method_name, descriptor)
 
-                if method:
+                if method_list:
                     return PyEval.get_method_pattern(
-                        method.class_name, method.name, method.descriptor
+                        method_list[0].class_name, method_list[0].name, method_list[0].descriptor
                     )
 
                 next_class_pool.update(

--- a/quark/evaluator/pyeval.py
+++ b/quark/evaluator/pyeval.py
@@ -673,7 +673,7 @@ class PyEval:
         ):
             next_class_pool.clear()
             for class_name in class_pool:
-                method = self.apkinfo.find_method(class_name, method_name, descriptor)
+                method = self.apkinfo.find_method(class_name, method_name, descriptor)[0]
 
                 if method:
                     return PyEval.get_method_pattern(

--- a/quark/evaluator/pyeval.py
+++ b/quark/evaluator/pyeval.py
@@ -673,11 +673,15 @@ class PyEval:
         ):
             next_class_pool.clear()
             for class_name in class_pool:
-                method_list = self.apkinfo.find_method(class_name, method_name, descriptor)
+                method_list = self.apkinfo.find_method(
+                    class_name, method_name, descriptor
+                )
 
                 if method_list:
                     return PyEval.get_method_pattern(
-                        method_list[0].class_name, method_list[0].name, method_list[0].descriptor
+                        method_list[0].class_name,
+                        method_list[0].name,
+                        method_list[0].descriptor,
                     )
 
                 next_class_pool.update(

--- a/quark/radiocontrast.py
+++ b/quark/radiocontrast.py
@@ -27,7 +27,7 @@ class RadioContrast:
 
         self.method = self.apkinfo.find_method(
             class_name=classname, method_name=methodname, descriptor=descriptor,
-        )
+        )[0]
 
         if self.method is None:
             raise ValueError("Target method not found!")

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -560,11 +560,14 @@ def findMethodInAPK(
             return None
 
     quark = _getQuark(samplePath)
-    method = quark.apkinfo.find_method(
-        class_name=targetMethod[0],
-        method_name=targetMethod[1],
-        descriptor=targetMethod[2]
-    )
+    try:
+        method = quark.apkinfo.find_method(
+            class_name=targetMethod[0],
+            method_name=targetMethod[1],
+            descriptor=targetMethod[2]
+        )
+    except:
+         method = quark.apkinfo.find_method()
 
     if not method:
         return []

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -538,7 +538,7 @@ def getApplication(samplePath: PathLike) -> Application:
 def findMethodInAPK(
     samplePath: PathLike,
     targetMethod: Union[List[str], Method]
-) -> list:
+) -> List[Method]:
     """Find the target method in APK.
 
     :param samplePath: target file

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -183,51 +183,77 @@ class TestApkinfo:
 
         assert test_custom_method.issubset(apkinfo.all_methods)
 
-    def test_find_method(self, apkinfo):
-        result1 = apkinfo.find_method(
-            "Ljava/lang/reflect/Field;", "setAccessible", "(Z)V"
-        )
-
-        assert isinstance(result1[0], MethodObject)
-        assert str(result1[0].class_name) == "Ljava/lang/reflect/Field;"
-        assert str(result1[0].name) == "setAccessible"
-        assert str(result1[0].descriptor) == "(Z)V"
-
+    @pytest.mark.parametrize(
+        "test_input, expected",
+        [
+            (
+                [
+                    "Ljava/lang/reflect/Field;",
+                    "setAccessible",
+                    "(Z)V",
+                ],
+                [
+                    "Ljava/lang/reflect/Field;",
+                    "setAccessible",
+                    "(Z)V",
+                ],
+            ),
+            (
+                [
+                    "",
+                    "onReceive",
+                    "(Landroid/content/Context; Landroid/content/Intent;)V",
+                ],
+                [
+                    "Landroid/support/v4/media/TransportMediatorJellybeanMR2$3;",
+                    "onReceive",
+                    "(Landroid/content/Context; Landroid/content/Intent;)V",
+                ],
+            ),
+            (
+                [
+                    "Landroid/support/v4/media/TransportMediatorJellybeanMR2$3;",
+                    "",
+                    "(Landroid/content/Context; Landroid/content/Intent;)V",
+                ],
+                [
+                    "Landroid/support/v4/media/TransportMediatorJellybeanMR2$3;",
+                    "onReceive",
+                    "(Landroid/content/Context; Landroid/content/Intent;)V",
+                ],
+            ),
+            (
+                [
+                    "Landroid/support/v4/media/TransportMediatorJellybeanMR2$3;",
+                    "onReceive",
+                    "",
+                ],
+                [
+                    "Landroid/support/v4/media/TransportMediatorJellybeanMR2$3;",
+                    "onReceive",
+                    "(Landroid/content/Context; Landroid/content/Intent;)V",
+                ],
+            ),
+            (
+                [None, None, None],
+                [
+                    "Landroid/support/v4/media/TransportMediatorJellybeanMR2$3;",
+                    "onReceive",
+                    "(Landroid/content/Context; Landroid/content/Intent;)V",
+                ],
+            ),
+        ],
+    )
+    def test_find_method(self, apkinfo, test_input, expected):
+        result = apkinfo.find_method(test_input[0], test_input[1], test_input[2])
         expect_method = MethodObject(
-            "Landroid/support/v4/media/TransportMediatorJellybeanMR2$3;",
-            "onReceive",
-            "(Landroid/content/Context; Landroid/content/Intent;)V",
-            "public",
-        )
-        result2 = apkinfo.find_method(
-            method_name="onReceive",
-            descriptor="(Landroid/content/Context; Landroid/content/Intent;)V",
-        )
-        result3 = apkinfo.find_method(
-            class_name="",
-            method_name="onReceive",
-            descriptor="(Landroid/content/Context; Landroid/content/Intent;)V",
-        )
-        result4 = apkinfo.find_method(
-            class_name="",
-            method_name="onReceive",
-            descriptor="",
+            expected[0],
+            expected[1],
+            expected[2],
         )
 
-        assert isinstance(result2, list)
-        assert len(result2) == 5
-        assert expect_method in result2
-
-        assert isinstance(result3, list)
-        assert len(result3) == 5
-        assert expect_method in result3
-
-        assert isinstance(result4, list)
-        assert len(result4) == 5
-        assert expect_method in result4
-
-        assert result2 == result3
-        assert result3 == result4
+        assert isinstance(result, list)
+        assert expect_method in result
 
     def test_upperfunc(self, apkinfo):
         api = apkinfo.find_method(

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -183,6 +183,7 @@ class TestApkinfo:
 
         assert test_custom_method.issubset(apkinfo.all_methods)
 
+    @staticmethod
     @pytest.mark.parametrize(
         "test_input, expected",
         [
@@ -235,7 +236,11 @@ class TestApkinfo:
                 ],
             ),
             (
-                [None, None, None],
+                [
+                    None,
+                    None,
+                    None,
+                ],
                 [
                     "Landroid/support/v4/media/TransportMediatorJellybeanMR2$3;",
                     "onReceive",
@@ -244,7 +249,7 @@ class TestApkinfo:
             ),
         ],
     )
-    def test_find_method(self, apkinfo, test_input, expected):
+    def test_find_method(apkinfo, test_input, expected):
         result = apkinfo.find_method(test_input[0], test_input[1], test_input[2])
         expect_method = MethodObject(
             expected[0],

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -186,7 +186,7 @@ class TestApkinfo:
     def test_find_method(self, apkinfo):
         result = apkinfo.find_method(
             "Ljava/lang/reflect/Field;", "setAccessible", "(Z)V"
-        )
+        )[0]
 
         assert isinstance(result, MethodObject)
         assert str(result.class_name) == "Ljava/lang/reflect/Field;"
@@ -198,13 +198,13 @@ class TestApkinfo:
             "Lcom/example/google/service/ContactsHelper;",
             "<init>",
             "(Landroid/content/Context;)V",
-        )
+        )[0]
 
         expect_function = apkinfo.find_method(
             "Lcom/example/google/service/SMSReceiver;",
             "isContact",
             "(Ljava/lang/String;)Ljava/lang/Boolean;",
-        )
+        )[0]
 
         upper_methods = list(apkinfo.upperfunc(api))
 
@@ -215,7 +215,7 @@ class TestApkinfo:
             "Lcom/example/google/service/WebServiceCalling;",
             "Send",
             "(Landroid/os/Handler; Ljava/lang/String;)V",
-        )
+        )[0]
 
         expect_method = MethodObject(
             "Ljava/lang/StringBuilder;",
@@ -261,7 +261,7 @@ class TestApkinfo:
             class_name="Landroid/support/v4/app/FragmentManagerImpl;",
             method_name="execPendingActions",
             descriptor="()Z",
-        )
+        )[0]
 
         bytecodes = list(apkinfo.get_method_bytecode(method))
 
@@ -273,13 +273,13 @@ class TestApkinfo:
             "Lcom/example/google/service/SMSReceiver;",
             "isContact",
             "(Ljava/lang/String;)Ljava/lang/Boolean;",
-        )
+        )[0]
 
         expect_method = apkinfo.find_method(
             "Lcom/example/google/service/ContactsHelper;",
             "<init>",
             "(Landroid/content/Context;)V",
-        )
+        )[0]
         expect_offset = 10
 
         upper_methods = apkinfo.lowerfunc(method)

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -184,14 +184,50 @@ class TestApkinfo:
         assert test_custom_method.issubset(apkinfo.all_methods)
 
     def test_find_method(self, apkinfo):
-        result = apkinfo.find_method(
+        result1 = apkinfo.find_method(
             "Ljava/lang/reflect/Field;", "setAccessible", "(Z)V"
-        )[0]
+        )
 
-        assert isinstance(result, MethodObject)
-        assert str(result.class_name) == "Ljava/lang/reflect/Field;"
-        assert str(result.name) == "setAccessible"
-        assert str(result.descriptor) == "(Z)V"
+        assert isinstance(result1[0], MethodObject)
+        assert str(result1[0].class_name) == "Ljava/lang/reflect/Field;"
+        assert str(result1[0].name) == "setAccessible"
+        assert str(result1[0].descriptor) == "(Z)V"
+
+        expect_method = MethodObject(
+            "Landroid/support/v4/media/TransportMediatorJellybeanMR2$3;",
+            "onReceive",
+            "(Landroid/content/Context; Landroid/content/Intent;)V",
+            "public",
+        )
+        result2 = apkinfo.find_method(
+            method_name="onReceive",
+            descriptor="(Landroid/content/Context; Landroid/content/Intent;)V",
+        )
+        result3 = apkinfo.find_method(
+            class_name="",
+            method_name="onReceive",
+            descriptor="(Landroid/content/Context; Landroid/content/Intent;)V",
+        )
+        result4 = apkinfo.find_method(
+            class_name="",
+            method_name="onReceive",
+            descriptor="",
+        )
+
+        assert isinstance(result2, list)
+        assert len(result2) == 5
+        assert expect_method in result2
+
+        assert isinstance(result3, list)
+        assert len(result3) == 5
+        assert expect_method in result3
+
+        assert isinstance(result4, list)
+        assert len(result4) == 5
+        assert expect_method in result4
+
+        assert result2 == result3
+        assert result3 == result4
 
     def test_upperfunc(self, apkinfo):
         api = apkinfo.find_method(

--- a/tests/core/test_quark.py
+++ b/tests/core/test_quark.py
@@ -95,12 +95,12 @@ class TestQuark:
             "Lcom/google/progress/ContactsCollecter;",
             "getContactList",
             "()Ljava/lang/String;",
-        )
+        )[0]
         base_method = quark_obj.apkinfo.find_method(
             "Landroid/telephony/TelephonyManager",
             "getCellLocation",
             "()Landroid/telephony/CellLocation;",
-        )
+        )[0]
         wrapper = []
 
         quark_obj.find_previous_method(base_method, parent_function, wrapper)
@@ -110,7 +110,7 @@ class TestQuark:
     def test_find_previous_method_with_result(self, quark_obj):
         parent_function = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/AndroidClientService;", "sendMessage", "()V"
-        )
+        )[0]
 
         wrapper = []
 
@@ -118,11 +118,11 @@ class TestQuark:
             "Landroid/telephony/TelephonyManager",
             "getCellLocation",
             "()Landroid/telephony/CellLocation;",
-        )
+        )[0]
 
         expect_method_analysis = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/Locate;", "getLocation", "()Ljava/lang/String;"
-        )
+        )[0]
 
         expected_list = [expect_method_analysis]
 
@@ -152,14 +152,14 @@ class TestQuark:
     def test_find_intersection_with_result(self, quark_obj):
         location_api = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/Locate;", "getLocation", "()Ljava/lang/String;"
-        )
+        )[0]
         location_api_upper = quark_obj.apkinfo.upperfunc(location_api)
 
         sms_api = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/SMSHelper;",
             "sendSms",
             "(Ljava/lang/String; Ljava/lang/String;)I",
-        )
+        )[0]
         sms_api_upper = quark_obj.apkinfo.upperfunc(sms_api)
 
         with pytest.raises(ValueError, match="Set is Null"):
@@ -176,13 +176,13 @@ class TestQuark:
         expected_result_location = {
             quark_obj.apkinfo.find_method(
                 "Lcom/google/progress/AndroidClientService;", "doByte", "([B)V"
-            ),
+            )[0],
             quark_obj.apkinfo.find_method(
                 "Lcom/google/progress/AndroidClientService;", "sendMessage", "()V"
-            ),
+            )[0],
             quark_obj.apkinfo.find_method(
                 "Lcom/google/progress/AndroidClientService$2;", "run", "()V"
-            ),
+            )[0],
         }
 
         assert (
@@ -205,7 +205,7 @@ class TestQuark:
     def test_check_sequence_with_lists_containing_invalid_type(self, quark_obj):
         mutual_parent = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/AndroidClientService;", "sendMessage", "()V"
-        )
+        )[0]
         first_method_list = [1, 2, 3]
         second_method_list = [4, 5, 6]
 
@@ -219,16 +219,16 @@ class TestQuark:
 
         location_method = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/Locate;", "getLocation", "()Ljava/lang/String;"
-        )
+        )[0]
         sendSms_method = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/SMSHelper;",
             "sendSms",
             "(Ljava/lang/String; Ljava/lang/String;)I",
-        )
+        )[0]
 
         mutual_parent_true = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/AndroidClientService;", "sendMessage", "()V"
-        )
+        )[0]
 
         result = quark_obj.check_sequence(
             mutual_parent_true,
@@ -243,17 +243,17 @@ class TestQuark:
             "Lcom/google/progress/SMSHelper;",
             "sendSms",
             "(Ljava/lang/String; Ljava/lang/String;)I",
-        )
+        )[0]
 
         mutual_parent_true = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/AndroidClientService;", "sendMessage", "()V"
-        )
+        )[0]
 
         contact_method = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/ContactsCollecter;",
             "getContactList",
             "()Ljava/lang/String;",
-        )
+        )[0]
 
         result = quark_obj.check_sequence(
             mutual_parent_true,
@@ -267,11 +267,11 @@ class TestQuark:
         # Send Location via SMS
         sendSms_method = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/AndroidClientService$2;", "run", "()V"
-        )
+        )[0]
 
         mutual_parent_false = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/AndroidClientService$2;", "run", "()V"
-        )
+        )[0]
 
         # # Send contact via SMS
 
@@ -279,7 +279,7 @@ class TestQuark:
             "Lcom/google/progress/ContactsCollecter;",
             "getContactList",
             "()Ljava/lang/String;",
-        )
+        )[0]
 
         result = quark_obj.check_sequence(
             mutual_parent_false,
@@ -303,7 +303,7 @@ class TestQuark:
     def test_check_parameter_with_lists_containing_invalid_type(self, quark_obj):
         mutual_parent = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/AndroidClientService;", "sendMessage", "()V"
-        )
+        )[0]
         first_method_list = [1, 2, 3]
         second_method_list = [4, 5, 6]
 
@@ -318,16 +318,16 @@ class TestQuark:
                 "Lcom/google/progress/SMSHelper;",
                 "sendSms",
                 "(Ljava/lang/String; Ljava/lang/String;)I",
-            )
+            )[0]
         ]
         first_method = [
             quark_obj.apkinfo.find_method(
                 "Lcom/google/progress/Locate;", "getLocation", "()Ljava/lang/String;"
-            )
+            )[0]
         ]
         mutual_parent = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/AndroidClientService;", "sendMessage", "()V"
-        )
+        )[0]
 
         assert (
             quark_obj.check_parameter(mutual_parent, first_method, second_method)
@@ -338,7 +338,7 @@ class TestQuark:
         first_method_list = [
             quark_obj.apkinfo.find_method(
                 "Lcom/google/progress/AndroidClientService$2;", "run", "()V"
-            )
+            )[0]
         ]
 
         second_method_list = [
@@ -346,11 +346,11 @@ class TestQuark:
                 "Lcom/google/progress/ContactsCollecter;",
                 "getContactList",
                 "()Ljava/lang/String;",
-            )
+            )[0]
         ]
         mutual_parent = quark_obj.apkinfo.find_method(
             "Lcom/google/progress/AndroidClientService;", "sendMessage", "()V"
-        )
+        )[0]
 
         result = quark_obj.check_parameter(
             mutual_parent, first_method_list, second_method_list

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -130,7 +130,7 @@ class TestMethod:
                 "Lcom/google/progress/WifiCheckTask;",
                 "checkWifiCanOrNotConnectServer",
                 "()Z",
-            )
+            )[0]
         )
         method = Method(QUARK_ANALYSIS_RESULT_FOR_RULE_68, methodObj)
 
@@ -155,7 +155,7 @@ class TestMethod:
                 "Lcom/google/progress/WifiCheckTask;",
                 "checkWifiCanOrNotConnectServer",
                 "([Ljava/lang/String;)Z",
-            )
+            )[0]
         )
         method = Method(QUARK_ANALYSIS_RESULT_FOR_RULE_68, methodObj)
 
@@ -178,7 +178,7 @@ class TestMethod:
         ) -> Method:
             methodObj = quarkResult.quark.apkinfo.find_method(
                 className, methodName, descriptor
-            )
+            )[0]
             return Method(quarkResult, methodObj)
 
         def __getMethodWithTarget(
@@ -222,14 +222,14 @@ class TestMethod:
                 class_name="Landroid/util/Log;",
                 method_name="e",
                 descriptor="(Ljava/lang/String; Ljava/lang/String;)I",
-            )
+            )[0]
 
         callerMethodObj = \
             QUARK_ANALYSIS_RESULT_FOR_RULE_68.quark.apkinfo.find_method(
                 class_name="Lcom/google/progress/WifiCheckTask;",
                 method_name="CloseWifi",
                 descriptor="()V",
-            )
+            )[0]
 
         targetMethod = Method(methodObj=targetMethod)
         callerMethodInstance = __getMethodWithTarget(
@@ -340,7 +340,7 @@ class TestQuarkReuslt:
                 "Lcom/google/progress/WifiCheckTask;",
                 "checkWifiCanOrNotConnectServer",
                 "()Z",
-            )
+            )[0]
         )
         method = Method(QUARK_ANALYSIS_RESULT_FOR_RULE_68, methodObj)
 
@@ -365,7 +365,7 @@ class TestQuarkReuslt:
                 "Lcom/google/progress/WifiCheckTask;",
                 "checkWifiCanOrNotConnectServer",
                 "([Ljava/lang/String;)Z",
-            )
+            )[0]
         )
         method = Method(QUARK_ANALYSIS_RESULT_FOR_RULE_68, methodObj)
 
@@ -419,7 +419,7 @@ class TestQuarkReuslt:
                 "Lcom/google/progress/WifiCheckTask;",
                 "checkWifiCanOrNotConnectServer",
                 "([Ljava/lang/String;)Z",
-            )
+            )[0]
         )
         caller = Method(QUARK_ANALYSIS_RESULT_FOR_RULE_68, callerObj)
 
@@ -428,7 +428,7 @@ class TestQuarkReuslt:
                 "Landroid/util/Log;",
                 "e",
                 "(Ljava/lang/String; Ljava/lang/String;)I",
-            )
+            )[0]
         )
         target = Method(QUARK_ANALYSIS_RESULT_FOR_RULE_68, targetObj)
 

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -29,7 +29,7 @@ def parent_method(analysis_object):
         "Lahmyth/mine/king/ahmyth/ConnectionManager;",
         "sendReq",
         "()V",
-    )
+    )[0]
 
 
 @pytest.fixture(scope="function")
@@ -38,7 +38,7 @@ def connect_method_1(analysis_object):
         "Lio/socket/client/Socket;",
         "connect",
         "()Lio/socket/client/Socket;",
-    )
+    )[0]
 
 
 @pytest.fixture(scope="function")
@@ -47,7 +47,7 @@ def connect_method_2(analysis_object):
         "Lahmyth/mine/king/ahmyth/ConnectionManager$1;",
         "<init>",
         "()V",
-    )
+    )[0]
 
 
 @pytest.fixture(scope="function")
@@ -56,7 +56,7 @@ def leaf_method_1(analysis_object):
         "Lio/socket/client/Socket;",
         "open",
         "()Lio/socket/client/Socket;",
-    )
+    )[0]
 
 
 @pytest.fixture(scope="function")
@@ -65,7 +65,7 @@ def leaf_method_2(analysis_object):
         "Ljava/lang/Object;",
         "<init>",
         "()V",
-    )
+    )[0]
 
 
 def test_wrapper_lookup_with_result(

--- a/tests/utils/test_output.py
+++ b/tests/utils/test_output.py
@@ -42,17 +42,17 @@ def analysis_element_1(analysis_object):
         "Lcom/google/progress/Locate;",
         "getLocation",
         "()Ljava/lang/String;",
-    )
+    )[0]
     first_api = analysis_object.find_method(
         "Lorg/apache/http/HttpResponse;",
         "getEntity",
         "()Lorg/apache/http/HttpEntity;",
-    )
+    )[0]
     second_api = analysis_object.find_method(
         "Lorg/json/JSONObject;",
         "put",
         "(Ljava/lang/String; I)Lorg/json/JSONObject;",
-    )
+    )[0]
 
     return {
         "crime": "The Crime",
@@ -71,17 +71,17 @@ def analysis_element_2(analysis_object):
         "Lcom/google/progress/AndroidClientService;",
         "sendMessage",
         "()V",
-    )
+    )[0]
     first_api = analysis_object.find_method(
         "Lcom/google/progress/FileList;",
         "getInfo",
         "()Ljava/lang/String;",
-    )
+    )[0]
     second_api = analysis_object.find_method(
         "Lcom/google/progress/SMSHelper;",
         "sendSms",
         "(Ljava/lang/String; Ljava/lang/String;)I",
-    )
+    )[0]
 
     return {
         "crime": "Another Crime",


### PR DESCRIPTION
Fix #467 .

**Code change**

* quark/core/apkinfo.py
* quark/core/interface/baseapkinfo.py
* quark/core/parallelquark.py
* quark/core/quark.py
* quark/core/rzapkinfo.py
* quark/evaluator/pyeval.py
* quark/radiocontrast.py
* quark/script/__ init __.py
* tests/core/test_apkinfo.py
* tests/core/test_quark.py
* tests/script/test_script.py
* tests/utils/test_graph.py
* tests/utils/test_output.py