### PR TITLE
Add Quark feature for retrieving receivers defined in this application.

### DIFF
--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -67,6 +67,16 @@ class AndroguardImp(BaseApkinfo):
         return application.findall("activity")
 
     @property
+    def receivers(self) -> List[XMLElement]:
+        if self.ret_type == "DEX":
+            return []
+
+        manifest_root = self.apk.get_android_manifest_xml()
+        application = manifest_root.find("application")
+
+        return application.findall("receiver")
+
+    @property
     def android_apis(self) -> Set[MethodObject]:
         apis = set()
 

--- a/quark/core/interface/baseapkinfo.py
+++ b/quark/core/interface/baseapkinfo.py
@@ -91,6 +91,16 @@ class BaseApkinfo:
 
     @property
     @abstractmethod
+    def receivers(self) -> List[XMLElement]:
+        """
+        Return all receivers from given APK.
+
+        :return: a list of all receivers
+        """
+        pass
+
+    @property
+    @abstractmethod
     def android_apis(self) -> Set[MethodObject]:
         """
         Return all Android native APIs from given APK.

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -267,7 +267,7 @@ class RizinImp(BaseApkinfo):
         root = axml.get_xml_tree()
 
         return root.findall("application/activity")
-    
+
     @functools.cached_property
     def receivers(self) -> List[XMLElement]:
         """

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -267,6 +267,18 @@ class RizinImp(BaseApkinfo):
         root = axml.get_xml_tree()
 
         return root.findall("application/activity")
+    
+    @functools.cached_property
+    def receivers(self) -> List[XMLElement]:
+        """
+        Return all receivers from given APK.
+
+        :return: a list of all receivers
+        """
+        axml = AxmlReader(self._manifest)
+        root = axml.get_xml_tree()
+
+        return root.findall("application/receiver")
 
     @property
     def android_apis(self) -> Set[MethodObject]:

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -113,6 +113,37 @@ class Activity:
         return exported
 
 
+class Receiver:
+    def __init__(self, xml: XMLElement) -> None:
+        self.xml: XMLElement = xml
+
+    def __str__(self) -> str:
+        return self._getAttribute("name")
+
+    def _getAttribute(
+        self, attributeName: str, defaultValue: Any = None
+    ) -> Any:
+        realAttributeName = (
+            f"{{http://schemas.android.com/apk/res/android}}{attributeName}"
+        )
+        return self.xml.get(realAttributeName, defaultValue)
+
+    def hasIntentFilter(self) -> bool:
+        """Check if the receiver has an intent filter.
+
+        :return: True/False
+        """
+        return self.xml.find("intent-filter") is not None
+
+    def isExported(self) -> bool:
+        """Check if the receiver is exported.
+
+        :return: True/False
+        """
+        exported = self._getAttribute("exported", self.hasIntentFilter())
+        return exported == 'true'
+
+
 class Method:
     def __init__(
         self,
@@ -520,6 +551,18 @@ def getActivities(samplePath: PathLike) -> List[Activity]:
     apkinfo = quark.apkinfo
 
     return [Activity(xml) for xml in apkinfo.activities]
+
+
+def getReceivers(samplePath: PathLike) -> List[Receiver]:
+    """Get receivers from a target sample.
+
+    :param samplePath: target file
+    :return: python list containing receivers
+    """
+    quark = _getQuark(samplePath)
+    apkinfo = quark.apkinfo
+
+    return [Receiver(xml) for xml in apkinfo.receivers]
 
 
 def getApplication(samplePath: PathLike) -> Application:

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -123,6 +123,36 @@ class TestApkinfo:
             == "com.example.google.service.MainActivity"
         )
 
+    @staticmethod
+    def test_receivers(apkinfo):
+        receivers = apkinfo.receivers
+
+        assert len(receivers) == 4
+        assert (
+            receivers[0].get(
+                "{http://schemas.android.com/apk/res/android}name"
+            )
+            == "com.example.google.service.SMSServiceBootReceiver"
+        )
+        assert (
+            receivers[1].get(
+                "{http://schemas.android.com/apk/res/android}name"
+            )
+            == "com.example.google.service.SMSReceiver"
+        )
+        assert (
+            receivers[2].get(
+                "{http://schemas.android.com/apk/res/android}name"
+            )
+            == "TaskRequest"
+        )
+        assert (
+            receivers[3].get(
+                "{http://schemas.android.com/apk/res/android}name"
+            )
+            == "com.example.google.service.MyDeviceAdminReceiver"
+        )
+
     def test_android_apis(self, apkinfo):
         api = {
             MethodObject(

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -13,6 +13,7 @@ from quark.script import (
     Ruleset,
     getActivities,
     getApplication,
+    getReceivers,
     runQuarkAnalysis,
     findMethodInAPK,
 )
@@ -106,6 +107,26 @@ class TestActivity:
         activity = getActivities(SAMPLE_PATH_13667)[0]
         assert activity.isExported() is True
 
+class TestReceiver:
+    @staticmethod
+    def testHasNoIntentFilter(SAMPLE_PATH_13667):
+        receiver = getReceivers(SAMPLE_PATH_13667)[2]
+        assert receiver.hasIntentFilter() is False
+
+    @staticmethod
+    def testHasIntentFilter(SAMPLE_PATH_Ahmyth):
+        receiver = getReceivers(SAMPLE_PATH_Ahmyth)[0]
+        assert receiver.hasIntentFilter() is True
+
+    @staticmethod
+    def testIsNotExported(SAMPLE_PATH_13667):
+        receiver = getReceivers(SAMPLE_PATH_13667)[2]
+        assert receiver.isExported() is False
+
+    @staticmethod
+    def testIsExported(SAMPLE_PATH_Ahmyth):
+        receiver = getReceivers(SAMPLE_PATH_Ahmyth)[0]
+        assert receiver.isExported() is True
 
 class TestMethod:
     @staticmethod
@@ -451,6 +472,13 @@ def testGetActivities(SAMPLE_PATH_14d9f) -> None:
 
     assert len(activities) == 1
     assert str(activities[0]) == "com.google.progress.BackGroundActivity"
+
+
+def testGetReceivers(SAMPLE_PATH_Ahmyth) -> None:
+    receivers = getReceivers(SAMPLE_PATH_Ahmyth)
+
+    assert len(receivers) == 1
+    assert str(receivers[0]) == "ahmyth.mine.king.ahmyth.MyReceiver"
 
 
 def testfindMethodInAPK(SAMPLE_PATH_14d9f) -> None:


### PR DESCRIPTION
# Add Quark feature for retrieving receivers defined in this application.

First, we have implemented a Quark property called `receivers` that retrieves all receiver components declared in the AndroidManifest.xml file in Quark apkinfo.

Second, we define a class `Receiver`  that represents a single receiver component declared in this application in Quark Script.

Finally, we have implemented the `getReceivers` function to extract information about declared receiver components in an Android APK file and return a list of Receiver instances.

## Class Spec
**Quark.scrript.Receiver**
* **Description:** Class represents a single receiver component declared in the application.
* **Constructor:** 
    *  Quark.script.Receiver.\_\_init\_\_
        * Description: Constructor of Receiver class with AndroidManifest.xml file.
        *  Params: 
            *  xml: Receiver XMLElement class instance from AndroidManifest.xml. 
* **Properties:** 
    * xml : Receiver XMLElement class instance from AndroidManifest.xml. 
* **Methods** 
    * Quark.script.Receiver.hasIntentFilter
        * Description: Indicate whether this Receiver has IntentFilter or not.
        *  Params: None
    * Quark.script.Receiver.isExported
        * Description: Indicate whether this Receiver is Exported or not.
        *  Params: None
 

## API Spec
**@property Quark.core.receivers**
* **Description:** Quark property that contains all receiver components declared in the AndroidManifest.xml file.

**Quark.script.getReceivers**
* **Description:** Get receivers from a target sample. 
* **Params:** 
    * samplePath: PathLike 
* **Return:** python list containing receivers.


## Test Script of Class Receiver
```python
class TestReceiver:
    @staticmethod
    def testHasNoIntentFilter(SAMPLE_PATH_13667):
        receiver = getReceivers(SAMPLE_PATH_13667)[2]
        assert receiver.hasIntentFilter() is False

    @staticmethod
    def testHasIntentFilter(SAMPLE_PATH_Ahmyth):
        receiver = getReceivers(SAMPLE_PATH_Ahmyth)[0]
        assert receiver.hasIntentFilter() is True

    @staticmethod
    def testIsNotExported(SAMPLE_PATH_13667):
        receiver = getReceivers(SAMPLE_PATH_13667)[2]
        assert receiver.isExported() is False

    @staticmethod
    def testIsExported(SAMPLE_PATH_Ahmyth):
        receiver = getReceivers(SAMPLE_PATH_Ahmyth)[0]
        assert receiver.isExported() is True
```

## Test property of Quark.receivers
```python
   @staticmethod
    def test_receivers(apkinfo):
        receivers = apkinfo.receivers

        assert len(receivers) == 4
        assert (
            receivers[0].get(
                "{http://schemas.android.com/apk/res/android}name"
            )
            == "com.example.google.service.SMSServiceBootReceiver"
        )
        assert (
            receivers[1].get(
                "{http://schemas.android.com/apk/res/android}name"
            )
            == "com.example.google.service.SMSReceiver"
        )
        assert (
            receivers[2].get(
                "{http://schemas.android.com/apk/res/android}name"
            )
            == "TaskRequest"
        )
        assert (
            receivers[3].get(
                "{http://schemas.android.com/apk/res/android}name"
            )
            == "com.example.google.service.MyDeviceAdminReceiver"
        )
```

## Test Script of API getReceivers
```python
def testGetReceivers(SAMPLE_PATH_Ahmyth) -> None:
    receivers = getReceivers(SAMPLE_PATH_Ahmyth)

    assert len(receivers) == 1
    assert str(receivers[0]) == "ahmyth.mine.king.ahmyth.MyReceiver"
```