### PR TITLE
Add Quark Script feature for checking some dedicated methods can be called in target MethodObj.

### DIFF
--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -580,7 +580,7 @@ def findMethodInAPK(
 
 def checkMethodCalls(
         samplePath: PathLike,
-        targetMethod: Union[Tuple[str, str, str], Method],
+        targetMethod: Union[Tuple[str, str, str], MethodObject],
         checkMethods: List[Tuple[str, str, str]]) -> bool:
     """Check if specific methods can be called or defined within a `targetMethod`
 
@@ -595,14 +595,16 @@ def checkMethodCalls(
     """
 
     quark = _getQuark(samplePath)
-    if isinstance(targetMethod, tuple):
+    if isinstance(targetMethod, List):
         # Find the method in the APK with the given class name, method name, and descriptor
-        target_methods = quark.apkinfo.find_method(*targetMethod)
+        temp_methods = quark.apkinfo.find_method(*targetMethod)
+        if isinstance(temp_methods, MethodObject):
+            target_methods = [temp_methods]
     else:
         # targetMethod is already a Method object
         target_methods = [targetMethod]
 
-    if not len(target_methods) == 1 or not isinstance(target_methods[0], Method):
+    if not len(target_methods) == 1 or not isinstance(target_methods[0], MethodObject):
         return False
 
     xrefToList = {i for i, _ in quark.apkinfo.lowerfunc(target_methods[0])}

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -587,13 +587,13 @@ def checkMethodCalls(
     :param samplePath: target file
     :param targetMethod: python list contains the class name,
                          method name, and descriptor of the target method
-                         or a Method Object 
+                         or a Method Object.
     :param checkMethods: python list contains the class name,
                          method name, and descriptor of the target method
 
     :return: bool that indicate specific methods can be called or defined within a `target method` or not.
     """
-    
+
     quark = _getQuark(samplePath)
     if isinstance(targetMethod, tuple):
         # Find the method in the APK with the given class name, method name, and descriptor

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -11,6 +11,7 @@ from quark.script import (
     Method,
     QuarkResult,
     Ruleset,
+    checkMethodCalls,
     getActivities,
     getApplication,
     runQuarkAnalysis,
@@ -462,3 +463,18 @@ def testfindMethodInAPK(SAMPLE_PATH_14d9f) -> None:
     )
 
     assert len(method) == 2
+
+
+def testCheckMethodCalls(SAMPLE_PATH_13667) -> None:
+    TARGET_METHOD = [
+        'Lcom/example/google/service/SMSReceiver;',
+        'onReceive',
+        '(Landroid/content/Context; Landroid/content/Intent;)V'
+    ]
+    CHECK_METHODS = [
+        ['Landroid/content/Intent;', 'getAction', '()Ljava/lang/String;']
+    ]
+
+    methodCalled = checkMethodCalls(SAMPLE_PATH_13667, TARGET_METHOD, CHECK_METHODS)
+
+    assert methodCalled is True


### PR DESCRIPTION
# Add Quark Script feature for checking some dedicated methods can be called in target MethodObj.

We've added a new feature to Quark Script that allows users to check if specific methods can be called or defined within a `targetMethod`. This feature, called `checkMethodCalls`, enables users to determine whether the specified methods can be called from the target method. 

## API Spec
**Quark.script.getReceivers**
* **Descripton:** Check if specific methods can be called or defined within a `targetMethod`.
* **Params:** 
    * **samplePath**: target file
    * **targetMethod**: python list contains the class name,method name, and descriptor of the target method or a Method Object
    * **checkMethods**: python list contains the class name,
                         method name, and descriptor of the target method
 * **return:** bool that indicate specific methods can be called or defined within a `target method` or not.

