### PR TITLE
Add property `receivers` to Quark Engine.

### DIFF
--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -68,7 +68,8 @@ class AndroguardImp(BaseApkinfo):
 
     @property
     def receivers(self) -> List[XMLElement]:
-        """Get all receiver elements from the manifest file.
+        """
+        Return all receivers from given APK.
 
         :return: a list of all receivers
         """

--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -69,7 +69,7 @@ class AndroguardImp(BaseApkinfo):
     @property
     def receivers(self) -> List[XMLElement]:
         """
-        Return all receivers from given APK.
+        Return all receivers from the given APK.
 
         :return: a list of all receivers
         """

--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -68,6 +68,10 @@ class AndroguardImp(BaseApkinfo):
 
     @property
     def receivers(self) -> List[XMLElement]:
+        """Get all receiver elements from the manifest file.
+
+        :return: a list of all receivers
+        """
         if self.ret_type == "DEX":
             return []
 

--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -67,6 +67,16 @@ class AndroguardImp(BaseApkinfo):
         return application.findall("activity")
 
     @property
+    def receivers(self) -> List[XMLElement]:
+        if self.ret_type == "DEX":
+            return []
+
+        manifest_root = self.apk.get_android_manifest_xml()
+        application = manifest_root.find("application")
+
+        return application.findall("receiver")
+
+    @property
     def android_apis(self) -> Set[MethodObject]:
         apis = set()
 

--- a/quark/core/interface/baseapkinfo.py
+++ b/quark/core/interface/baseapkinfo.py
@@ -91,6 +91,16 @@ class BaseApkinfo:
 
     @property
     @abstractmethod
+    def receivers(self) -> List[XMLElement]:
+        """
+        Return all receivers from given APK.
+
+        :return: a list of all receivers
+        """
+        pass
+
+    @property
+    @abstractmethod
     def android_apis(self) -> Set[MethodObject]:
         """
         Return all Android native APIs from given APK.

--- a/quark/core/interface/baseapkinfo.py
+++ b/quark/core/interface/baseapkinfo.py
@@ -93,7 +93,7 @@ class BaseApkinfo:
     @abstractmethod
     def receivers(self) -> List[XMLElement]:
         """
-        Return all receivers from given APK.
+        Return all receivers from the given APK.
 
         :return: a list of all receivers
         """

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -271,7 +271,7 @@ class RizinImp(BaseApkinfo):
     @functools.cached_property
     def receivers(self) -> List[XMLElement]:
         """
-        Return all receivers from given APK.
+        Return all receivers from the given APK.
 
         :return: a list of all receivers
         """

--- a/quark/core/rzapkinfo.py
+++ b/quark/core/rzapkinfo.py
@@ -268,6 +268,18 @@ class RizinImp(BaseApkinfo):
 
         return root.findall("application/activity")
 
+    @functools.cached_property
+    def receivers(self) -> List[XMLElement]:
+        """
+        Return all receivers from given APK.
+
+        :return: a list of all receivers
+        """
+        axml = AxmlReader(self._manifest)
+        root = axml.get_xml_tree()
+
+        return root.findall("application/receiver")
+
     @property
     def android_apis(self) -> Set[MethodObject]:
         return {

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -123,6 +123,36 @@ class TestApkinfo:
             == "com.example.google.service.MainActivity"
         )
 
+    @staticmethod
+    def test_receivers(apkinfo):
+        receivers = apkinfo.receivers
+
+        assert len(receivers) == 4
+        assert (
+            receivers[0].get(
+                "{http://schemas.android.com/apk/res/android}name"
+            )
+            == "com.example.google.service.SMSServiceBootReceiver"
+        )
+        assert (
+            receivers[1].get(
+                "{http://schemas.android.com/apk/res/android}name"
+            )
+            == "com.example.google.service.SMSReceiver"
+        )
+        assert (
+            receivers[2].get(
+                "{http://schemas.android.com/apk/res/android}name"
+            )
+            == "TaskRequest"
+        )
+        assert (
+            receivers[3].get(
+                "{http://schemas.android.com/apk/res/android}name"
+            )
+            == "com.example.google.service.MyDeviceAdminReceiver"
+        )
+
     def test_android_apis(self, apkinfo):
         api = {
             MethodObject(


### PR DESCRIPTION
##  Add property `receivers` to Quark Engine.
* **Description:** : This property is used to present all Receiver components defined in AndroidManifest.xml file.
*  **File Changes:** 
    *  quark-engine/quark/core/apkinfo.py
    *  quark-engine/quark/core/interface/baseapkinfo.py
    *  quark-engine/quark/core/rzapkinfo.py
    *  quark-engine/tests/core/test_apkinfo.py