### PR TITLE
Add quark script case for CWE-925.

### DIFF
--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -6,7 +6,7 @@ import re
 import functools
 from os import PathLike
 from os.path import abspath, isfile, join
-from typing import Any, List, Tuple, Union
+from typing import Any, Iterable, List, Tuple, Union
 
 from quark.config import DIR_PATH as QUARK_RULE_PATH
 from quark.core.analysis import QuarkAnalysis
@@ -111,6 +111,43 @@ class Activity:
         """
         exported = self._getAttribute("exported", self.hasIntentFilter())
         return exported
+
+
+class Receiver:
+    def __init__(self, xml: XMLElement) -> None:
+        self.xml: XMLElement = xml
+
+    def __str__(self) -> str:
+        return self._getAttribute("name")
+
+    def _getAttribute(
+        self, attributeName: str, defaultValue: Any = None
+    ) -> Any:
+        realAttributeName = (
+            f"{{http://schemas.android.com/apk/res/android}}{attributeName}"
+        )
+        return self.xml.get(realAttributeName, defaultValue)
+
+    def hasIntentFilter(self) -> bool:
+        """Check if the receiver has an intent filter.
+
+        :return: True/False
+        """
+        return self.xml.find("intent-filter") is not None
+
+    def isExported(self) -> bool:
+        """Check if the receiver is exported.
+
+        According to the documentation from Android Developer guide.
+        Note:
+            If the attribute exported is unspecified, the default value depends on whether the broadcast receiver contains intent filters. 
+            If the receiver contains at least one intent filter, then the default value is "true". 
+            Otherwise, the default value is "false".
+
+        :return: True/False
+        """
+        exported = self._getAttribute("exported", self.hasIntentFilter())
+        return str(exported).lower() == 'true'
 
 
 class Method:
@@ -523,6 +560,18 @@ def getActivities(samplePath: PathLike) -> List[Activity]:
     return [Activity(xml) for xml in apkinfo.activities]
 
 
+def getReceivers(samplePath: PathLike) -> List[Receiver]:
+    """Get receivers from a target sample.
+
+    :param samplePath: target file
+    :return: python list containing receivers
+    """
+    quark = _getQuark(samplePath)
+    apkinfo = quark.apkinfo
+
+    return [Receiver(xml) for xml in apkinfo.receivers]
+
+
 def getApplication(samplePath: PathLike) -> Application:
     """Get the application element from the manifest file of the target sample.
 
@@ -579,3 +628,47 @@ def findMethodInAPK(
             for caller in list(caller_set)
         ]
     return caller_methods
+
+
+def checkMethodCalls(
+        samplePath: PathLike,
+        targetMethod: Union[Tuple[str, str, str], MethodObject],
+        checkMethods: List[Tuple[str, str, str]]) -> bool:
+    """Check if any of the specific methods shown in the `targetMethod`
+
+    :param samplePath: target file
+    :param targetMethod: python list contains the class name,
+                         method name, and descriptor of the target method
+                         or a Method Object.
+    :param checkMethods: python list contains the class name,
+                         method name, and descriptor of the target method
+
+    :return: bool that indicate specific methods can be called or defined within a `target method` or not.
+    """
+    _target_methods = []
+    _overlap_list = []
+    _xref_to_list = {}
+
+    quark = _getQuark(samplePath)
+    if isinstance(targetMethod, Iterable):
+        # Find the method in the APK with the given class name, method name, and descriptor
+        _target_methods = quark.apkinfo.find_method(*targetMethod)
+        if isinstance(_target_methods, MethodObject):
+            _target_methods = [_target_methods]
+    else:
+        # targetMethod is already a Method object
+        _target_methods = [targetMethod]
+
+    if not len(_target_methods) == 1 or not isinstance(_target_methods[0], MethodObject):
+        return False
+
+    for candidate in checkMethods:
+        tmp = quark.apkinfo.find_method(*candidate)
+        if isinstance(tmp, MethodObject):
+            _overlap_list.append(tmp)
+        else:
+            _overlap_list.extend(tmp)
+
+    _xref_to_list = {i for i, _ in quark.apkinfo.lowerfunc(_target_methods[0])}
+
+    return any(set(_overlap_list).intersection(_xref_to_list))

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -645,30 +645,24 @@ def checkMethodCalls(
 
     :return: bool that indicate specific methods can be called or defined within a `target method` or not.
     """
-    _target_methods = []
-    _overlap_list = []
-    _xref_to_list = {}
+    targetMethodSet = set()
+    checkMethodSet = set()
+    targetLowerFuncSet = set()
 
     quark = _getQuark(samplePath)
     if isinstance(targetMethod, Iterable):
         # Find the method in the APK with the given class name, method name, and descriptor
-        _target_methods = quark.apkinfo.find_method(*targetMethod)
-        if isinstance(_target_methods, MethodObject):
-            _target_methods = [_target_methods]
+        targetMethodSet.update(quark.apkinfo.find_method(*targetMethod))
     else:
         # targetMethod is already a Method object
-        _target_methods = [targetMethod]
+        targetMethodSet.add(MethodObject)
 
-    if not len(_target_methods) == 1 or not isinstance(_target_methods[0], MethodObject):
+    if not targetMethodSet:
         return False
 
     for candidate in checkMethods:
-        tmp = quark.apkinfo.find_method(*candidate)
-        if isinstance(tmp, MethodObject):
-            _overlap_list.append(tmp)
-        else:
-            _overlap_list.extend(tmp)
+        checkMethodSet.update(quark.apkinfo.find_method(*candidate))
 
-    _xref_to_list = {i for i, _ in quark.apkinfo.lowerfunc(_target_methods[0])}
+    targetLowerFuncSet = {i for i, _ in quark.apkinfo.lowerfunc(targetMethodSet.pop())}
 
-    return any(set(_overlap_list).intersection(_xref_to_list))
+    return any(checkMethodSet.intersection(targetLowerFuncSet))

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -139,10 +139,13 @@ class Receiver:
         """Check if the receiver is exported.
 
         According to the documentation from Android Developer guide.
-        Note:
-            If the attribute exported is unspecified, the default value depends on whether the broadcast receiver contains intent filters. 
-            If the receiver contains at least one intent filter, then the default value is "true". 
-            Otherwise, the default value is "false".
+        "
+        If the attribute exported is unspecified, the default value depends on whether
+        the broadcast receiver contains intent filters.
+        If the receiver contains at least one intent filter,
+        then the default value is "true".
+        Otherwise, the default value is "false".
+        "
 
         :return: True/False
         """

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -11,7 +11,9 @@ from quark.script import (
     Method,
     QuarkResult,
     Ruleset,
+    checkMethodCalls,
     getActivities,
+    getReceivers,
     getApplication,
     runQuarkAnalysis,
     findMethodInAPK,
@@ -105,6 +107,28 @@ class TestActivity:
     def testIsExported(SAMPLE_PATH_13667):
         activity = getActivities(SAMPLE_PATH_13667)[0]
         assert activity.isExported() is True
+
+
+class TestReceiver:
+    @staticmethod
+    def testHasNoIntentFilter(SAMPLE_PATH_13667):
+        receiver = getReceivers(SAMPLE_PATH_13667)[2]
+        assert receiver.hasIntentFilter() is False
+
+    @staticmethod
+    def testHasIntentFilter(SAMPLE_PATH_13667):
+        receiver = getReceivers(SAMPLE_PATH_13667)[0]
+        assert receiver.hasIntentFilter() is True
+
+    @staticmethod
+    def testIsNotExported(SAMPLE_PATH_13667):
+        receiver = getReceivers(SAMPLE_PATH_13667)[2]
+        assert receiver.isExported() is False
+
+    @staticmethod
+    def testIsExported(SAMPLE_PATH_13667):
+        receiver = getReceivers(SAMPLE_PATH_13667)[0]
+        assert receiver.isExported() is True
 
 
 class TestMethod:
@@ -453,6 +477,13 @@ def testGetActivities(SAMPLE_PATH_14d9f) -> None:
     assert str(activities[0]) == "com.google.progress.BackGroundActivity"
 
 
+def testGetReceivers(SAMPLE_PATH_14d9f) -> None:
+    receivers = getReceivers(SAMPLE_PATH_14d9f)
+
+    assert len(receivers) == 1
+    assert str(receivers[0]) == "com.google.progress.BootReceiver"
+
+
 def testfindMethodInAPK(SAMPLE_PATH_14d9f) -> None:
 
     method = findMethodInAPK(SAMPLE_PATH_14d9f, [
@@ -462,3 +493,22 @@ def testfindMethodInAPK(SAMPLE_PATH_14d9f) -> None:
     )
 
     assert len(method) == 2
+
+
+def testCheckMethodCalls(SAMPLE_PATH_14d9f) -> None:
+    targetMethod = [
+        "Lcom/google/progress/WifiCheckTask;",
+        "checkWifiCanOrNotConnectServer",
+        "([Ljava/lang/String;)Z"
+    ]
+
+    checkMethods  = []
+    checkMethods.append(tuple([
+        "Landroid/util/Log;",
+        "e",
+        "(Ljava/lang/String; Ljava/lang/String;)I"
+    ]))
+
+    assert checkMethodCalls("14d9f1a92dd984d6040cc41ed06e273e.apk", targetMethod, checkMethods) is True
+
+


### PR DESCRIPTION
# Detect CWE-925 in Android Application (InsecureBankv2, AndroGoat)

This scenario seeks to find **Improper Verification of Intent by Broadcast Receiver**. See [CWE-925](https://cwe.mitre.org/data/definitions/925.html) for more details.

Let’s use both two of apks ([InsecureBankv2](https://github.com/dineshshetty/Android-InsecureBankv2) and [AndroGoat](https://github.com/satishpatnayak/AndroGoat)) to show how the Quark script finds this vulnerability.

In the first step, we use the `getReceivers` API to find all `Receiver` components defined in the Android application. Then, we exclude any receivers that are not exported.

In the second step, our goal is to verify the **intentAction** is properly validated in each receiver which is identified in the previous step. To do this, we use the `checkMethodCalls` function.

Finally, if any receiver's **onReceive** method exhibits improper verification on **intentAction**, it could indicate a potential CWE-925 vulnerability.

## API Spec
**receiverInstance.hasIntentFilter()**
* **Description:** Check if the receiver has an intent-filter.
* **params:** None
* **Return:** True/False

**receiverInstance.isExported()**
* **Description:** Check if the receiver is exported.
* **params:** None
* **Return:** True/False

**getReceivers(samplePath)**
* **Description:** Get receivers from a target sample.
* **params:**
    * samplePath:  target file
* **Return:** python list containing receivers

**checkMethodCalls(samplePath, targetMethod, checkMethods)**
* **Description:**  Check if any of the specific methods shown in the `targetMethod`
* **params:**
    * samplePath: target file
    * targetMethod:  python list contains the class name,method name, and descriptor of the target method or a Method Object.
    * checkMethods: python list contains the class name, method name, and descriptor of the target method.
* **Return:** bool that indicate specific methods can be called or defined within a `target method` or not.


## Quark Script CWE-925.py
```python
from quark.script import checkMethodCalls, getReceivers

SAMPLE_PATHS = ["AndroGoat.apk", "InsecureBankv2.apk"]

TARGET_METHOD = [
    '',
    'onReceive',
    '(Landroid/content/Context; Landroid/content/Intent;)V'
]

CHECK_METHODS = [
    ['Landroid/content/Intent;', 'getAction', '()Ljava/lang/String;']
]

for filepath in SAMPLE_PATHS:
    receivers = getReceivers(filepath)
    for receiver in receivers:
        if receiver.isExported():
            className = "L"+str(receiver).replace('.', '/')+';'
            TARGET_METHOD[0] = className
            if not checkMethodCalls(filepath, TARGET_METHOD, CHECK_METHODS):
                print(f"CWE-925 is detected in method, {className}")

```
## Quark Script Result
```
$ python CWE-925.py
CWE-925 is detected in method, Lowasp/sat/agoat/ShowDataReceiver;
CWE-925 is detected in method, Lcom/android/insecurebankv2/MyBroadCastReceiver;
```
