### PR TITLE
Add document link of CWE-88 showcase to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 *   [CWE-020](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-20-in-android-application-diva-apk)  Improper Input Validation 
 *   [CWE-022](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-22-in-android-application-ovaa-apk-and-insecurebankv2-apk)  Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal') 
 *   [CWE-023](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-23-in-android-application-ovaa-apk-and-insecurebankv2-apk)  Relative Path Traversal
+*   [CWE-088](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-88-in-android-application-vuldroid-apk)  Improper Neutralization of Argument Delimiters in a Command
 *   [CWE-089](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-89-in-android-application-androgoat-apk)  Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection') 
 *   [CWE-094](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-94-in-android-application-ovaa-apk)  Improper Control of Generation of Code ('Code Injection') 
 *   [CWE-295](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-295-in-android-application-insecureshop-apk)  Improper Certificate Validation 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1832,4 +1832,3 @@ Quark Script Result
 
     $ python3 CWE-88.py
     CWE-88 is detected in method, Lcom/vuldroid/application/RootDetection; onCreate (Landroid/os/Bundle;)V
-

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1747,15 +1747,15 @@ Detect CWE-88 in Android Application (Vuldroid.apk)
 
 This scenario seeks to find **Improper Neutralization of Argument Delimiters in a Command**. See `CWE-88 <https://cwe.mitre.org/data/definitions/88.html>`_ for more details.
 
-Let’s use this `APK <https://github.com/jaiswalakshansh/Vuldroid>`_ and the above APIs to show how the Quark script find this vulnerability.
+Let‘s use this `APK <https://github.com/jaiswalakshansh/Vuldroid>`_ and the above APIs to show how the Quark script finds this vulnerability.
 
-First, we design a detection rule ``ExternalStringsCommands.json`` to spot on behavior use external strings as commands.
+First, we design a detection rule ``ExternalStringsCommands.json`` to spot on behavior using external strings as commands.
 
 Next, we use Quark API ``quarkResultInstance.findMethodInCaller(callerMethod, targetMethod)`` to check if there are any APIs in the caller method for string matching. 
 
-If NO, the APK does not neutralize special elements within the argument, which may cause CWE-22 vulnerability. 
+If NO, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
 
-If YES, check if there are any delimiters use in string matching for filter. if NOT, the APK does not neutralize special elements within the argument, which may cause CWE-22 vulnerability. 
+If YES, check if there are any delimiters used in string matching for a filter. IF NOT, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
 
 
 Quark Script CWE-88.py
@@ -1829,7 +1829,6 @@ Quark Script Result
 - **vuldroid.apk**
 
 .. code-block:: TEXT
-
 $ python3 CWE-88.py
 CWE-88 is detected in method, Lcom/vuldroid/application/RootDetection; onCreate (Landroid/os/Bundle;)V
 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1755,7 +1755,7 @@ Next, we use Quark API ``quarkResultInstance.findMethodInCaller(callerMethod, ta
 
 If NOT, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
 
-If YES, check if there are any delimiters used in string matching for a filter. IF NOT, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
+If YES, check if there are any delimiters used in string matching for a filter. If NOT, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
 
 
 Quark Script CWE-88.py

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1753,7 +1753,7 @@ First, we design a detection rule ``ExternalStringsCommands.json`` to spot on be
 
 Next, we use Quark API ``quarkResultInstance.findMethodInCaller(callerMethod, targetMethod)`` to check if any APIs in the caller method for string matching. 
 
-If Not, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
+If NOT, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
 
 If YES, check if there are any delimiters used in string matching for a filter. IF NOT, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
 
@@ -1826,7 +1826,7 @@ Quark Rule: ExternalStringCommand.json
 
 Quark Script Result
 ======================
-- **vuldroid.apk**
+- **Vuldroid.apk**
 
 .. code-block:: TEXT
 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1751,9 +1751,9 @@ Let‘s use this `APK <https://github.com/jaiswalakshansh/Vuldroid>`_ and the ab
 
 First, we design a detection rule ``ExternalStringsCommands.json`` to spot on behavior using external strings as commands.
 
-Next, we use Quark API ``quarkResultInstance.findMethodInCaller(callerMethod, targetMethod)`` to check if there are any APIs in the caller method for string matching. 
+Next, we use Quark API ``quarkResultInstance.findMethodInCaller(callerMethod, targetMethod)`` to check if any APIs in the caller method for string matching. 
 
-If NO, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
+If Not, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
 
 If YES, check if there are any delimiters used in string matching for a filter. IF NOT, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
 
@@ -1767,7 +1767,7 @@ The Quark Script below uses Vuldroid.apk to demonstrate.
 
     from quark.script import runQuarkAnalysis, Rule
 
-    SAMPLE_PATH = "vuldroid.apk"
+    SAMPLE_PATH = "Vuldroid.apk"
     RULE_PATH = "ExternalStringCommand.json"
 
 
@@ -1829,6 +1829,7 @@ Quark Script Result
 - **vuldroid.apk**
 
 .. code-block:: TEXT
-$ python3 CWE-88.py
-CWE-88 is detected in method, Lcom/vuldroid/application/RootDetection; onCreate (Landroid/os/Bundle;)V
+
+    $ python3 CWE-88.py
+    CWE-88 is detected in method, Lcom/vuldroid/application/RootDetection; onCreate (Landroid/os/Bundle;)V
 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1753,9 +1753,9 @@ First, we design a detection rule ``ExternalStringsCommands.json`` to spot on be
 
 Next, we use Quark API ``quarkResultInstance.findMethodInCaller(callerMethod, targetMethod)`` to check if any APIs in the caller method for string matching. 
 
-If NOT, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
+If NO, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
 
-If YES, check if there are any delimiters used in string matching for a filter. If NOT, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
+If YES, check if there are any delimiters used in string matching for a filter. If NO, the APK does not neutralize special elements within the argument, which may cause CWE-88 vulnerability. 
 
 
 Quark Script CWE-88.py


### PR DESCRIPTION
Refer to PR [#503](https://github.com/quark-engine/quark-engine/pull/503)

This PR adds the link of the CWE-88 showcase to the README.

* [CWE-88](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-88-in-android-application-vuldroid-apk)