### PR TITLE
Exclude the Quark tests from installation.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/quark-engine/quark-engine",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=("tests",)),
     package_data={
         "quark.core.axmlreader": ["axml_definition"],
         "quark.webreport": [


### PR DESCRIPTION
Refer to #480.

Before the fix, the issue can be reproduce:

```Bash
$ git clone --depth=1 https://github.com/quark-engine/quark-engine && cd quark-engine
$ pip install . && cd ..
$ python -c "import pathlib, quark; print('\n'.join(list(map(str, (pathlib.Path(quark.__file__).parent.parent / 'tests').glob('*')))))"

PYTHON_DIR/lib/python3.8/site-packages/tests/conftest.py
PYTHON_DIR/lib/python3.8/site-packages/tests/__init__.py
PYTHON_DIR/lib/python3.8/site-packages/tests/test_report.py
PYTHON_DIR/lib/python3.8/site-packages/tests/__pycache__
PYTHON_DIR/lib/python3.8/site-packages/tests/test_freshquark.py
```

After the fix, the tests is excluded:

```Bash
$ git clone --depth=1 https://github.com/quark-engine/quark-engine && cd quark-engine
$ pip install . && cd ..
$ python -c "import pathlib, quark; print('\n'.join(list(map(str, (pathlib.Path(quark.__file__).parent.parent / 'tests').glob('*')))))"

```

**File changed**
- setup.py