### PR TITLE
Add document link of CWE-78 showcase to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@
 *   [CWE-020](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-20-in-android-application-diva-apk)  Improper Input Validation 
 *   [CWE-022](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-22-in-android-application-ovaa-apk-and-insecurebankv2-apk)  Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal') 
 *   [CWE-023](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-23-in-android-application-ovaa-apk-and-insecurebankv2-apk)  Relative Path Traversal
-*   [CWE-073](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-73-in-android-application-ovaa-apk)   External Control of File Name or Path 
+*   [CWE-073](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-73-in-android-application-ovaa-apk)   External Control of File Name or Path
+*   [CWE-078](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-78-in-android-application-vuldroid-apk)   Improper Neutralization of Special Elements used in an OS Command
 *   [CWE-088](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-88-in-android-application-vuldroid-apk)  Improper Neutralization of Argument Delimiters in a Command
 *   [CWE-089](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-89-in-android-application-androgoat-apk)  Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection') 
 *   [CWE-094](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-94-in-android-application-ovaa-apk)  Improper Control of Generation of Code ('Code Injection') 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1994,7 +1994,7 @@ Quark Script Result
 Detect CWE-78 in Android Application (Vuldroid.apk)
 ------------------------------------------------------
 
-This scenario seeks to find **Improper Neutralization of Special Elements used in an OS Command**. See `CWE-78 <https://cwe.mitre.org/data/definitions/78.html>`_ for more details.
+This scenario seeks to find **Improper Neutralization of Argument Delimiters in a Command**. See `CWE-78 <https://cwe.mitre.org/data/definitions/78.html>`_ for more details.
 
 Let‘s use this `APK <https://github.com/jaiswalakshansh/Vuldroid>`_ and the above APIs to show how the Quark script finds this vulnerability.
 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1994,7 +1994,7 @@ Quark Script Result
 Detect CWE-78 in Android Application (Vuldroid.apk)
 ------------------------------------------------------
 
-This scenario seeks to find **Improper Neutralization of Argument Delimiters in a Command**. See `CWE-78 <https://cwe.mitre.org/data/definitions/78.html>`_ for more details.
+This scenario seeks to find **Improper Neutralization of Special Elements used in an OS Command**. See `CWE-78 <https://cwe.mitre.org/data/definitions/78.html>`_ for more details.
 
 Let‘s use this `APK <https://github.com/jaiswalakshansh/Vuldroid>`_ and the above APIs to show how the Quark script finds this vulnerability.
 


### PR DESCRIPTION
# Add document link of CWE-78 showcase to the README

Refer to PR [#519](https://github.com/quark-engine/quark-engine/pull/519)

This PR adds the link of the CWE-78 showcase to the README

* [CWE-78](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-78-in-android-application-vuldroid-apk)