### PR TITLE
Add document link of CWE-940 showcase to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@
 *   [CWE-798](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-798-in-android-application-ovaa-apk)  Use of Hard-coded Credentials 
 *   [CWE-921](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-921-in-android-application-ovaa-apk)  Storage of Sensitive Data in a Mechanism without Access Control 
 *   [CWE-925](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-925-in-android-application-insecurebankv2-androgoat)  Improper Verification of Intent by Broadcast Receiver
-*   [CWE-926](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-926-in-android-application-dvba-apk)  Improper Export of Android Application Components 
+*   [CWE-926](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-926-in-android-application-dvba-apk)  Improper Export of Android Application Components
+*   [CWE-940](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-940-in-android-application-ovaa-vuldroid)  Improper Verification of Source of a Communication Channel 
  
 # Quick Start
 


### PR DESCRIPTION
# Add document link of CWE-940 showcase to the README

Refer to PR [#539](https://github.com/quark-engine/quark-engine/pull/539)

This PR adds the link of the CWE-940 showcase to the README

* [CWE-940](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-940-in-android-application-ovaa-vuldroid)  Improper Verification of Source of a Communication Channel 