### PR TITLE
Add method reference for show_rule_classification in the document

### DIFF
--- a/docs/source/quark_method_reference.rst
+++ b/docs/source/quark_method_reference.rst
@@ -1421,11 +1421,15 @@ Here is the process of ``show_rule_classification``.
 		- Using self.quark_analysis.call_graph_analysis_list and MAX_SEARCH_LAYER as parameters.
 		- Store the returned rule classification data in the data_bundle variable.
 
-	3. Call the output_parent_function_table function to display the rule classification data in a table format. 
-
-	4. Call the output_parent_function_json function convert the rule classification data into JSON format and save it to a file named "rules_classification.json".
-
-	5. Call the output_parent_function_graph function create a graphical representation of the rule classifications using the graphviz library.
+	3. Call the output_parent_function_table function to display tables on the console. 
+        	- The first column of the table is "Parent Function", and the second column displays the name of that parent function. 
+        	- Subsequent rows list the "Crime Description" associated with that parent function.
+   
+    	4. Call the output_parent_function_json function output a JSON file named "rules_classification.json".
+        	- The structure of the file is a list containing multiple dictionaries. Each dictionary has two keys: parent and crime. 
+ 
+    	5. Call the output_parent_function_graph function create a PNG format graphic file.
+        	- This graphic displays the reference relationships between parent functions and the crime descriptions associated with each parent function.
 
 
 Here is the flowchart of ``show_rule_classification``.

--- a/docs/source/quark_method_reference.rst
+++ b/docs/source/quark_method_reference.rst
@@ -1415,20 +1415,20 @@ Here is the process of ``show_rule_classification``.
 
 .. code-block:: TEXT
 
-	1. Call the print_info function to display the "Rules Classification".
+	1. Call the print_info function to display "Rules Classification".
 
 	2. Invoke the get_rule_classification_data function
-		- Using self.quark_analysis.call_graph_analysis_list and MAX_SEARCH_LAYER as parameters.
+		- Use self.quark_analysis.call_graph_analysis_list and MAX_SEARCH_LAYER as parameters.
 		- Store the returned rule classification data in the data_bundle variable.
 
 	3. Call the output_parent_function_table function to display tables on the console. 
         	- The first column of the table is "Parent Function", and the second column displays the name of that parent function. 
         	- Subsequent rows list the "Crime Description" associated with that parent function.
    
-    	4. Call the output_parent_function_json function output a JSON file named "rules_classification.json".
+    	4. Call the output_parent_function_json function to output a JSON file named "rules_classification.json".
         	- The structure of the file is a list containing multiple dictionaries. Each dictionary has two keys: parent and crime. 
  
-    	5. Call the output_parent_function_graph function create a PNG format graphic file.
+    	5. Call the output_parent_function_graph function to create a PNG format graphic file.
         	- This graphic displays the reference relationships between parent functions and the crime descriptions associated with each parent function.
 
 

--- a/docs/source/quark_method_reference.rst
+++ b/docs/source/quark_method_reference.rst
@@ -1421,11 +1421,11 @@ Here is the process of ``show_rule_classification``.
 		- Using self.quark_analysis.call_graph_analysis_list and MAX_SEARCH_LAYER as parameters.
 		- Store the returned rule classification data in the data_bundle variable.
 
-	3. Call the output_parent_function_table function to output the data from data_bundle in table format.
+	3. Call the output_parent_function_table function to display the rule classification data in a table format. 
 
-	4. Call the output_parent_function_json function to output the data from data_bundle in JSON format.
+	4. Call the output_parent_function_json function convert the rule classification data into JSON format and save it to a file named "rules_classification.json".
 
-	5. Call the output_parent_function_graph function to display the data from data_bundle as a graph or chart.
+	5. Call the output_parent_function_graph function create a graphical representation of the rule classifications using the graphviz library.
 
 
 Here is the flowchart of ``show_rule_classification``.

--- a/docs/source/quark_method_reference.rst
+++ b/docs/source/quark_method_reference.rst
@@ -1409,7 +1409,7 @@ show_rule_classification
 
 **The algorithm of show_rule_classification**
 
-The function ``show_rule_classification`` display rule classification information by fetching relevant data and then outputting it in table, JSON, and graphical formats.
+The function ``show_rule_classification`` extracts rule classification data, highlighting the links between parent functions and associated crimes. It then displays this data in table, JSON, and graphical formats.
 
 Here is the process of ``show_rule_classification``.
 
@@ -1434,7 +1434,7 @@ Here is the process of ``show_rule_classification``.
 
 Here is the flowchart of ``show_rule_classification``.
 
-.. image:: https://i.imgur.com/hvOAs8M.png
+.. image:: https://i.imgur.com/im3ER02.png
 
 **The code of show_rule_classification**
 

--- a/docs/source/quark_method_reference.rst
+++ b/docs/source/quark_method_reference.rst
@@ -1403,3 +1403,46 @@ Here is the flowchart of ``show_call_graph``.
             call_graph(call_graph_analysis, output_format)
         print_success("Call Graph Completed")
 
+
+show_rule_classification
+===============================
+
+**The algorithm of show_rule_classification**
+
+The function ``show_rule_classification`` display rule classification information by fetching relevant data and then outputting it in table, JSON, and graphical formats.
+
+Here is the process of ``show_rule_classification``.
+
+.. code-block:: TEXT
+
+	1. Call the print_info function to display the "Rules Classification".
+
+	2. Invoke the get_rule_classification_data function
+		- Using self.quark_analysis.call_graph_analysis_list and MAX_SEARCH_LAYER as parameters.
+		- Store the returned rule classification data in the data_bundle variable.
+
+	3. Call the output_parent_function_table function to output the data from data_bundle in table format.
+
+	4. Call the output_parent_function_json function to output the data from data_bundle in JSON format.
+
+	5. Call the output_parent_function_graph function to display the data from data_bundle as a graph or chart.
+
+
+Here is the flowchart of ``show_rule_classification``.
+
+.. image:: https://i.imgur.com/dULiqhS.png
+
+**The code of show_rule_classification**
+
+.. code-block:: python
+
+    def show_rule_classification(self):
+        print_info("Rules Classification")
+
+        data_bundle = get_rule_classification_data(
+            self.quark_analysis.call_graph_analysis_list, MAX_SEARCH_LAYER
+        )
+
+        output_parent_function_table(data_bundle)
+        output_parent_function_json(data_bundle)
+        output_parent_function_graph(data_bundle)

--- a/docs/source/quark_method_reference.rst
+++ b/docs/source/quark_method_reference.rst
@@ -1434,7 +1434,7 @@ Here is the process of ``show_rule_classification``.
 
 Here is the flowchart of ``show_rule_classification``.
 
-.. image:: https://i.imgur.com/dULiqhS.png
+.. image:: https://i.imgur.com/hvOAs8M.png
 
 **The code of show_rule_classification**
 


### PR DESCRIPTION
show_rule_classification
===============================

**The algorithm of show_rule_classification**

The function ``show_rule_classification`` extracts rule classification data, highlighting the links between parent functions and associated crimes. It then displays this data in table, JSON, and graphical formats.

Here is the process of ``show_rule_classification``.

```
1. Call the print_info function to display "Rules Classification".

2. Invoke the get_rule_classification_data function
    - Use self.quark_analysis.call_graph_analysis_list and MAX_SEARCH_LAYER as parameters.
    - Store the returned rule classification data in the data_bundle variable.

3. Call the output_parent_function_table function to display tables on the console. 
    - The first column of the table is "Parent Function", and the second column displays the name of that parent function. 
    - Subsequent rows list the "Crime Description" associated with that parent function.
   
4. Call the output_parent_function_json function to output a JSON file named "rules_classification.json".
    - The structure of the file is a list containing multiple dictionaries. Each dictionary has two keys: parent and crime. 
 
5. Call the output_parent_function_graph function to create a PNG format graphic file.
    - This graphic displays the reference relationships between parent functions and the crime descriptions associated with each parent function.
```

Here is the flowchart of ``show_rule_classification``.

![](https://i.imgur.com/im3ER02.png)

**The code of show_rule_classification**


```python
def show_rule_classification(self):
    print_info("Rules Classification")

    data_bundle = get_rule_classification_data(
        self.quark_analysis.call_graph_analysis_list, MAX_SEARCH_LAYER
    )

    output_parent_function_table(data_bundle)
    output_parent_function_json(data_bundle)
    output_parent_function_graph(data_bundle)
```