### PR TITLE
Add document link of CWE-502 showcase to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@
 *   [CWE-327](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-327-in-android-application-injuredandroid-apk)  Use of a Broken or Risky Cryptographic Algorithm 
 *   [CWE-328](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-328-in-android-application-allsafe-apk)  Use of Weak Hash 
 *   [CWE-338](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-338-in-android-application-pivva-apk)  Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG) 
-*   [CWE-489](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-489-in-android-application-allsafe-apk-androgoat-apk-pivaa-apk)  Active Debug Code 
+*   [CWE-489](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-489-in-android-application-allsafe-apk-androgoat-apk-pivaa-apk)  Active Debug Code
+*   [CWE-502](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-502-in-android-application-pivaa)  Deserialization of Untrusted Data
 *   [CWE-532](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-532-in-android-application-dvba-apk)  Insertion of Sensitive Information into Log File 
 *   [CWE-749](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-749-in-android-application-mstg-android-java-apk)  Exposed Dangerous Method or Function 
 *   [CWE-780](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-780-in-android-application-mstg-android-java-apk)  Use of RSA Algorithm without OAEP 


### PR DESCRIPTION
# Add document link of CWE-502 showcase to the README

Refer to PR [#572](https://github.com/quark-engine/quark-engine/pull/572)

This PR adds the link of the CWE-502 showcase to the README

* [CWE-502](https://quark-engine.readthedocs.io/en/latest/quark_script.html#detect-cwe-502-in-android-application-pivaa)  Deserialization of Untrusted Data