### PR TITLE
Fix permission analysis in the radare2 core for APKs with UTF-8 encoding

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,13 @@ SAMPLES = [
             "/raw/master/malware-samples/Ahmyth.apk"
         ),
         "fileName": "Ahmyth.apk"
+    },
+    {
+        "sourceUrl": (
+            "https://github.com/quark-engine/apk-samples"
+            "/raw/master/vulnerable-samples/pivaa.apk"
+        ),
+        "fileName": "pivaa.apk"
     }
 ]
 
@@ -62,3 +69,8 @@ def SAMPLE_PATH_13667(tmp_path_factory: pytest.TempPathFactory) -> str:
 @pytest.fixture(scope="session")
 def SAMPLE_PATH_Ahmyth(tmp_path_factory: pytest.TempPathFactory) -> str:
     return downloadSample(tmp_path_factory, SAMPLES[2])
+
+
+@pytest.fixture(scope="session")
+def SAMPLE_PATH_pivaa(tmp_path_factory: pytest.TempPathFactory) -> str:
+    return downloadSample(tmp_path_factory, SAMPLES[3])

--- a/tests/core/test_axmlreader.py
+++ b/tests/core/test_axmlreader.py
@@ -11,7 +11,6 @@ import pytest
 from quark.core.axmlreader import AxmlReader, ResValue
 
 
-
 @pytest.fixture(
     scope="function",
     params=(("radare2"), ("rizin")),
@@ -33,6 +32,11 @@ def extractManifest(samplePath: PathLike) -> str:
 @pytest.fixture(scope="session")
 def MANIFEST_PATH_14d9f(SAMPLE_PATH_14d9f):
     return extractManifest(SAMPLE_PATH_14d9f)
+
+
+@pytest.fixture(scope="session")
+def MANIFEST_PATH_pivaa(SAMPLE_PATH_pivaa):
+    return extractManifest(SAMPLE_PATH_pivaa)
 
 
 class TestAxmlReader:
@@ -57,9 +61,14 @@ class TestAxmlReader:
         assert axmlReader.axml_size == 7676
 
     @staticmethod
-    def testGetString(core_library, MANIFEST_PATH_14d9f):
+    def testGetStringFromUtf16Apk(core_library, MANIFEST_PATH_14d9f):
         axmlReader = AxmlReader(MANIFEST_PATH_14d9f, core_library)
         assert axmlReader.get_string(13) == "manifest"
+
+    @staticmethod
+    def testGetStringFromUtf8Apk(core_library, MANIFEST_PATH_pivaa):
+        axmlReader = AxmlReader(MANIFEST_PATH_pivaa, core_library)
+        assert axmlReader.get_string(58) == "manifest"
 
     @staticmethod
     def testGetAttributes(core_library, MANIFEST_PATH_14d9f):


### PR DESCRIPTION
Refer to Issue #599 .