### PR TITLE
Optimize the CWE-798 document.

### DIFF
--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -398,7 +398,7 @@ Method (callComponentMethod) with urls is detected triggered!
 .. image:: https://i.imgur.com/ryV3f57.jpg
 
 
-Detect CWE-798 in Android Application (ovaa.apk)
+Detect CWE-798 in Android Application
 ------------------------------------------------
 
 This scenario seeks to find hard-coded credentials in the APK file. 
@@ -423,9 +423,9 @@ We use the `ovaa.apk <https://github.com/oversecured/ovaa>`_ sample to explain t
 Quark Scipt: CWE-798.py
 ========================
 
-Let's use the above APIs to show how Quark script find this vulnerability.
+Let's use the above APIs to show how the Quark script finds this vulnerability.
 
-First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior uses method ``SecretKeySpec``. Then, we get all the parameter values that input to this method. From the returned parameter values, we identify it's a AES key and parse the key out of the values. Finally, we dump all strings in the APK file and check if the AES key is in the strings. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file. 
+First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using method ``SecretKeySpec``. Then, we get all the parameter values that are input to this method. From the returned parameter values, we identify it as an AES key and parse the key out of the values. Finally, we dump all strings in the APK file and check if the AES key is in the strings. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file. 
 
 .. code-block:: python
 
@@ -485,20 +485,6 @@ Quark Script Result
     $ python3 findSecretKeySpec.py 
 
     Found hard-coded AES key 49u5gh249gh24985ghf429gh4ch8f23f
-
-
-Hard-Coded AES key in the APK file
-===================================
-
-.. code-block:: TEXT
-
-    const-string v2, "49u5gh249gh24985ghf429gh4ch8f23f"
-
-    invoke-virtual {v2}, Ljava/lang/String;->getBytes()[B
-
-    move-result-object v2
-
-    invoke-direct {v1, v2, v0}, Ljavax/crypto/spec/SecretKeySpec;-><init>([BLjava/lang/String;)V
 
 
 Detect CWE-94 in Android Application (ovaa.apk)

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -417,8 +417,6 @@ Code of CWE-798 in ovaa.apk
 
 We use the `ovaa.apk <https://github.com/oversecured/ovaa>`_ sample to explain the vulnerability code of CWE-798.
 
-![截圖 2024-02-23 下午7.14.56](https://hackmd.io/_uploads/HJTBAl82T.png)
-
 .. image:: https://i.imgur.com/ikaJlDW.jpg
 
 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -425,7 +425,7 @@ Quark Scipt: CWE-798.py
 
 Let's use the above APIs to show how the Quark script finds this vulnerability.
 
-First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using method ``SecretKeySpec``. Then, we get all the parameter values that are input to this method. From the returned parameter values, we identify it as an AES key and parse the key out of the values. Finally, we dump all strings in the APK file and check if the AES key is in the strings. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file. 
+First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the method ``SecretKeySpec``. Then, we get all the parameter values that are input to this method. From the returned parameter values, we identify it as an AES key and parse the key out of the values. Finally, we dump all strings in the APK file and check if the AES key is in the strings. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file. 
 
 .. code-block:: python
 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -401,14 +401,33 @@ Method (callComponentMethod) with urls is detected triggered!
 Detect CWE-798 in Android Application (ovaa.apk)
 ------------------------------------------------
 
-This scenario seeks to find hard-coded credentials in the APK file. See `CWE-798 <https://cwe.mitre.org/data/definitions/798.html>`_ for more details.
+This scenario seeks to find hard-coded credentials in the APK file. 
 
-Let's use this `APK <https://github.com/oversecured/ovaa>`_ and the above APIs to show how Quark script find this vulnerability.
+CWE-798 Use of Hard-coded Credentials
+============================================
 
-First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior uses method ``SecretKeySpec``. Then, we get all the parameter values that input to this method. From the returned parameter values, we identify it's a AES key and parse the key out of the values. Finally, we dump all strings in the APK file and check if the AES key is in the strings. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file. 
+We analyze the definition of CWE-798 and identify its characteristics.
+
+See `CWE-798 <https://cwe.mitre.org/data/definitions/798.html>`_  for more details.
+
+.. image:: https://i.imgur.com/0G9APpf.jpg
+
+Code of CWE-798 in ovaa.apk
+=========================================
+
+We use the `ovaa.apk <https://github.com/oversecured/ovaa>`_ sample to explain the vulnerability code of CWE-798.
+
+![截圖 2024-02-23 下午7.14.56](https://hackmd.io/_uploads/HJTBAl82T.png)
+
+.. image:: https://i.imgur.com/ikaJlDW.jpg
+
 
 Quark Scipt: CWE-798.py
 ========================
+
+Let's use the above APIs to show how Quark script find this vulnerability.
+
+First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior uses method ``SecretKeySpec``. Then, we get all the parameter values that input to this method. From the returned parameter values, we identify it's a AES key and parse the key out of the values. Finally, we dump all strings in the APK file and check if the AES key is in the strings. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file. 
 
 .. code-block:: python
 


### PR DESCRIPTION
Detect CWE-798 in Android Application (ovaa.apk)
-------------------------------------------------------

This scenario seeks to find **hard-coded credentials** in the APK file.

CWE-798 Use of Hard-coded Credentials
====================================

We analyze the definition of CWE-798  and identify its characteristics.

See [CWE-798](https://cwe.mitre.org/data/definitions/798.html)  for more details.

![截圖 2024-02-23 下午7.03.46](https://hackmd.io/_uploads/B1p2sl8na.png)

Code of CWE-798 in ovaa.apk
=========================================

We use the [ovaa.apk](https://github.com/oversecured/ovaa) sample to explain the vulnerability code of CWE-798.

![截圖 2024-02-23 下午7.14.56](https://hackmd.io/_uploads/HJTBAl82T.png)




Quark Scipt: CWE-798.py
========================

Let's use the above APIs to show how the Quark script finds this vulnerability.

First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the method ``SecretKeySpec``. Then, we get all the parameter values that are input to this method. From the returned parameter values, we identify it as an AES key and parse the key out of the values. Finally, we dump all strings in the APK file and check if the AES key is in the strings. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file. 

```python
import re
from quark.script import runQuarkAnalysis, Rule

SAMPLE_PATH = "ovaa.apk"
RULE_PATH = "findSecretKeySpec.json"

ruleInstance = Rule(RULE_PATH)
quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)

for secretKeySpec in quarkResult.behaviorOccurList:

    allStrings = quarkResult.getAllStrings()

    firstParam = secretKeySpec.getParamValues()[1]
    secondParam = secretKeySpec.getParamValues()[2]

    if secondParam == "AES":
        AESKey = re.findall(r'\((.*?)\)', firstParam)[1]

    if AESKey in allStrings:
        print(f"Found hard-coded {secondParam} key {AESKey}")
```

Quark Rule: findSecretKeySpec.json
==================================

```json
{
    "crime": "Detect APK using SecretKeySpec.",
    "permission": [],
    "api": [
        {
            "descriptor": "()[B",
            "class": "Ljava/lang/String;",
            "method": "getBytes"
        },
        {
            "descriptor": "([BLjava/lang/String;)V",
            "class": "Ljavax/crypto/spec/SecretKeySpec;",
            "method": "<init>"
        }
    ],
    "score": 1,
    "label": []
}
```

Quark Script Result
=====================

```
$ python3 findSecretKeySpec.py 

Found hard-coded AES key 49u5gh249gh24985ghf429gh4ch8f23f
```