### PR TITLE
Optimize CWE-749 and CWE-780 document

### DIFF
--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -941,14 +941,14 @@ We analyze the definition of CWE-749 and identify its characteristics.
 
 See `CWE-749 <https://cwe.mitre.org/data/definitions/749.html>`_ for more details.
 
-.. image:: https://imgur.com/aigP2KY.png
+.. image:: https://imgur.com/5NtfoUp.png
 
 Code of CWE-749 in MSTG-Android-Java.apk
 =============================================
 
 We use the `MSTG-Android-Java.apk <https://github.com/OWASP/MASTG-Hacking-Playground>`_ sample to explain the vulnerability code of CWE-749.
 
-.. image:: https://imgur.com/gQvmkiH.png
+.. image:: https://imgur.com/7W47pnH.png
 
 Quark Script CWE-749.py
 ===========================
@@ -1080,14 +1080,14 @@ We analyze the definition of CWE-780 and identify its characteristics.
 
 See `CWE-780 <https://cwe.mitre.org/data/definitions/780.html>`_ for more details.
 
-.. image:: https://imgur.com/zvy67Si.png
+.. image:: https://imgur.com/NZCEqjr.png
 
 Code of CWE-780 in dvba.apk
 =========================================
 
 We use the `MSTG-Android-Java.apk <https://github.com/OWASP/MASTG-Hacking-Playground>`_ sample to explain the vulnerability code of CWE-780.
 
-.. image:: https://imgur.com/svn8iz0.png
+.. image:: https://imgur.com/r2yLr9E.png
 
 Quark Scipt: CWE-780.py
 ========================

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -929,17 +929,33 @@ Quark Script Result
 	CWE-926 is detected in the activity, com.app.damnvulnerablebank.SplashScreen
 
 
-Detect CWE-749 in Android Application (MSTG-Android-Java.apk)
--------------------------------------------------------------
+Detect CWE-749 in Android Application
+----------------------------------------------
 
-This scenario seeks to find **exposed methods or functions** in the APK file. See `CWE-749 <https://cwe.mitre.org/data/definitions/749.html>`_ for more details.
+This scenario seeks to find **exposed methods or functions** in the APK file.
 
-Let's use this `APK <https://github.com/OWASP/MASTG-Hacking-Playground>`_ and the above APIs to show how Quark script find this vulnerability.
+CWE-749 Exposed Dangerous Method or Function
+=================================================
 
-First, we design a detection rule ``configureJsExecution.json`` to spot on behavior using method ``setJavascriptEnabled``. Then, we use API ``methodInstance.getArguments()`` to check if it enables JavaScript execution on websites. Finally, we look for calls to method ``addJavaScriptInterface`` in the caller method. If **yes**, the APK exposes methods or functions to websites. That causes CWE-749 vulnerability.
+We analyze the definition of CWE-749 and identify its characteristics.
+
+See `CWE-749 <https://cwe.mitre.org/data/definitions/749.html>`_ for more details.
+
+.. image:: https://imgur.com/aigP2KY.png
+
+Code of CWE-749 in MSTG-Android-Java.apk
+=============================================
+
+We use the `MSTG-Android-Java.apk <https://github.com/OWASP/MASTG-Hacking-Playground>`_ sample to explain the vulnerability code of CWE-749.
+
+.. image:: https://imgur.com/gQvmkiH.png
 
 Quark Script CWE-749.py
-=======================
+===========================
+
+Let’s use the above APIs to show how the Quark script finds this vulnerability.
+
+First, we design a detection rule ``configureJsExecution.json`` to spot on behavior using the method ``setJavascriptEnabled``. Then, we use the API ``methodInstance.getArguments()`` to check if it enables JavaScript execution on websites. Finally, we look for calls to the method ``addJavaScriptInterface`` in the caller method. If yes, the APK exposes methods or functions to websites. That causes CWE-749 vulnerability.
 
 .. code-block:: python
 
@@ -1052,17 +1068,33 @@ Quark Script Result
     CWE-532 is detected in method, Lcom/google/firebase/auth/FirebaseAuth; d (Lc/c/b/h/o;)V
 
 
-Detect CWE-780 in Android Application (MSTG-Android-Java.apk)
--------------------------------------------------------------
+Detect CWE-780 in Android Application
+-----------------------------------------
 
-This scenario seeks to find **the use of the RSA algorithm without Optimal Asymmetric Encryption Padding (OAEP)**. See `CWE-780 <https://cwe.mitre.org/data/definitions/780.html>`_ for more details.
+This scenario seeks to find **the use of the RSA algorithm without Optimal Asymmetric Encryption Padding (OAEP)** in the APK file.
 
-Let's use this `APK <https://github.com/OWASP/MASTG-Hacking-Playground>`_ and the above APIs to show how the Quark script find this vulnerability.
+CWE-780 Use of RSA Algorithm without OAEP
+============================================
+
+We analyze the definition of CWE-798 and identify its characteristics.
+
+See `CWE-780 <https://cwe.mitre.org/data/definitions/780.html>`_ for more details.
+
+.. image:: https://imgur.com/zvy67Si.png
+
+Code of CWE-780 in dvba.apk
+=========================================
+
+We use the `MSTG-Android-Java.apk <https://github.com/OWASP/MASTG-Hacking-Playground>`_ sample to explain the vulnerability code of CWE-780.
+
+.. image:: https://imgur.com/svn8iz0.png
+
+Quark Scipt: CWE-780.py
+========================
+
+Let’s use the above APIs to show how the Quark script finds this vulnerability.
 
 We first design a detection rule ``useOfCryptographicAlgo.json`` to spot on behavior using the cryptographic algorithm. Then, we use API ``behaviorInstance.hasString(pattern, isRegex)`` to filter behaviors using the RSA algorithm. Finally, we use the same API to check if the algorithm runs without the OAEP scheme. If the answer is YES, the plaintext is predictable.
-
-Quark Script CWE-780.py
-=======================
 
 .. code-block:: python
 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1076,7 +1076,7 @@ This scenario seeks to find **the use of the RSA algorithm without Optimal Asymm
 CWE-780 Use of RSA Algorithm without OAEP
 ============================================
 
-We analyze the definition of CWE-798 and identify its characteristics.
+We analyze the definition of CWE-780 and identify its characteristics.
 
 See `CWE-780 <https://cwe.mitre.org/data/definitions/780.html>`_ for more details.
 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -941,7 +941,7 @@ We analyze the definition of CWE-749 and identify its characteristics.
 
 See `CWE-749 <https://cwe.mitre.org/data/definitions/749.html>`_ for more details.
 
-.. image:: https://imgur.com/hmihGze.png
+.. image:: https://imgur.com/KiA0vRD.png
 
 Code of CWE-749 in MSTG-Android-Java.apk
 =============================================

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -941,14 +941,14 @@ We analyze the definition of CWE-749 and identify its characteristics.
 
 See `CWE-749 <https://cwe.mitre.org/data/definitions/749.html>`_ for more details.
 
-.. image:: https://imgur.com/KiA0vRD.png
+.. image:: https://imgur.com/hmihGze.png
 
 Code of CWE-749 in MSTG-Android-Java.apk
 =============================================
 
 We use the `MSTG-Android-Java.apk <https://github.com/OWASP/MASTG-Hacking-Playground>`_ sample to explain the vulnerability code of CWE-749.
 
-.. image:: https://imgur.com/yngclNu.png
+.. image:: https://imgur.com/KiA0vRD.png
 
 Quark Script CWE-749.py
 ===========================

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -941,21 +941,21 @@ We analyze the definition of CWE-749 and identify its characteristics.
 
 See `CWE-749 <https://cwe.mitre.org/data/definitions/749.html>`_ for more details.
 
-.. image:: https://imgur.com/5NtfoUp.png
+.. image:: https://imgur.com/hmihGze.png
 
 Code of CWE-749 in MSTG-Android-Java.apk
 =============================================
 
 We use the `MSTG-Android-Java.apk <https://github.com/OWASP/MASTG-Hacking-Playground>`_ sample to explain the vulnerability code of CWE-749.
 
-.. image:: https://imgur.com/7W47pnH.png
+.. image:: https://imgur.com/2CkUeXq.png
 
 Quark Script CWE-749.py
 ===========================
 
 Let’s use the above APIs to show how the Quark script finds this vulnerability.
 
-First, we design a detection rule ``configureJsExecution.json`` to spot on behavior using the method ``setJavascriptEnabled``. Then, we use the API ``methodInstance.getArguments()`` to check if it enables JavaScript execution on websites. Finally, we look for calls to the method ``addJavaScriptInterface`` in the caller method. If yes, the APK exposes methods or functions to websites. That causes CWE-749 vulnerability.
+First, we design a detection rule ``configureJsExecution.json`` to spot on behavior using the method ``setJavascriptEnabled``. Then, we use the API ``methodInstance.getArguments()`` to check if it enables JavaScript execution on websites. Finally, we look for calls to the method ``addJavaScriptInterface`` in the caller method. If yes, the APK exposes dangerous methods or functions to websites. That causes CWE-749 vulnerability.
 
 .. code-block:: python
 
@@ -1080,14 +1080,14 @@ We analyze the definition of CWE-780 and identify its characteristics.
 
 See `CWE-780 <https://cwe.mitre.org/data/definitions/780.html>`_ for more details.
 
-.. image:: https://imgur.com/NZCEqjr.png
+.. image:: https://imgur.com/veZNZcg.png
 
 Code of CWE-780 in dvba.apk
 =========================================
 
 We use the `MSTG-Android-Java.apk <https://github.com/OWASP/MASTG-Hacking-Playground>`_ sample to explain the vulnerability code of CWE-780.
 
-.. image:: https://imgur.com/r2yLr9E.png
+.. image:: https://imgur.com/c03senv.png
 
 Quark Scipt: CWE-780.py
 ========================

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -948,7 +948,7 @@ Code of CWE-749 in MSTG-Android-Java.apk
 
 We use the `MSTG-Android-Java.apk <https://github.com/OWASP/MASTG-Hacking-Playground>`_ sample to explain the vulnerability code of CWE-749.
 
-.. image:: https://imgur.com/2CkUeXq.png
+.. image:: https://imgur.com/yngclNu.png
 
 Quark Script CWE-749.py
 ===========================


### PR DESCRIPTION
# Detect CWE-749 in Android Application

This scenario seeks to find **exposed methods or functions** in the APK file. 

## CWE-749 Exposed Dangerous Method or Function

We analyze the definition of CWE-749 and identify its characteristics.

See [CWE-749](https://cwe.mitre.org/data/definitions/749.html) for more details.

![image](https://imgur.com/hmihGze.png)

Code of CWE-749 in MSTG-Android-Java.apk
=========================================
We use the [MSTG-Android-Java.apk](https://github.com/OWASP/MASTG-Hacking-Playground) sample to explain the vulnerability code of CWE-749.

![image](https://imgur.com/KiA0vRD.png)

Quark Scipt: CWE-749.py
========================

Let’s use the above APIs to show how the Quark script finds this vulnerability.

First, we design a detection rule ``configureJsExecution.json`` to spot on behavior using the method ``setJavascriptEnabled``. Then, we use the API ``methodInstance.getArguments()`` to check if it enables JavaScript execution on websites. Finally, we look for calls to the method ``addJavaScriptInterface`` in the caller method. If yes, the APK exposes dangerous methods or functions to websites. That causes CWE-749 vulnerability.

```python
from quark.script import runQuarkAnalysis, Rule

SAMPLE_PATH = "MSTG-Android-Java.apk"
RULE_PATH = "configureJsExecution.json"

targetMethod = [
    "Landroid/webkit/WebView;",
    "addJavascriptInterface",
    "(Ljava/lang/Object; Ljava/lang/String;)V"
]

ruleInstance = Rule(RULE_PATH)
quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)

for configureJsExecution in quarkResult.behaviorOccurList:

    caller = configureJsExecution.methodCaller
    secondAPI = configureJsExecution.secondAPI

    enableJS = secondAPI.getArguments()[1]
    exposeAPI = quarkResult.findMethodInCaller(caller, targetMethod)

    if enableJS and exposeAPI:
        print(f"CWE-749 is detected in method, {caller.fullName}")
```

Quark Rule: configureJsExecution.json
==================================
```json
{
    "crime": "Configure JavaScript execution on websites",
    "permission": [],
    "api": [
        {
            "class": "Landroid/webkit/WebView;",
            "method": "getSettings",
            "descriptor": "()Landroid/webkit/WebSettings;"
        },
        {
            "class": "Landroid/webkit/WebSettings;",
            "method": "setJavaScriptEnabled",
            "descriptor": "(Z)V"
        }
    ],
    "score": 1,
    "label": []
}
```

Quark Script Result
=====================
```
$ python3 CWE-749.py

CWE-749 is detected in method, Lsg/vp/owasp_mobile/OMTG_Android/OMTG_ENV_005_WebView_Remote; onCreate (Landroid/os/Bundle;)V
CWE-749 is detected in method, Lsg/vp/owasp_mobile/OMTG_Android/OMTG_ENV_005_WebView_Local; onCreate (Landroid/os/Bundle;)V
```

# Detect CWE-780 in Android Application

This scenario seeks to find **the use of the RSA algorithm without Optimal Asymmetric Encryption Padding (OAEP)** in the APK file.

## CWE-780 Use of RSA Algorithm without OAEP

We analyze the definition of CWE-780 and identify its characteristics.

See [CWE-780](https://cwe.mitre.org/data/definitions/780.html) for more details.

![image](https://imgur.com/veZNZcg.png)

Code of CWE-780 in dvba.apk
=========================================

We use the [MSTG-Android-Java.apk](https://github.com/OWASP/MASTG-Hacking-Playground) sample to explain the vulnerability code of CWE-780.

![image](https://imgur.com/c03senv.png)

Quark Scipt: CWE-780.py
========================

Let’s use the above APIs to show how the Quark script finds this vulnerability.

We first design a detection rule ``useOfCryptographicAlgo.json`` to spot on behavior using the cryptographic algorithm. Then, we use API ``behaviorInstance.hasString(pattern, isRegex)`` to filter behaviors using the RSA algorithm. Finally, we use the same API to check if the algorithm runs without the OAEP scheme. If the answer is YES, the plaintext is predictable.

```python
from quark.script import Rule, runQuarkAnalysis

SAMPLE_PATH = "MSTG-Android-Java.apk"
RULE_PATH = "useOfCryptographicAlgo.json"

ruleInstance = Rule(RULE_PATH)
quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)

for useCryptographicAlgo in quarkResult.behaviorOccurList:
    methodCaller = useCryptographicAlgo.methodCaller

    if useCryptographicAlgo.hasString(
        "RSA"
    ) and not useCryptographicAlgo.hasString("OAEP"):
        print(f"CWE-780 is detected in method, {methodCaller.fullName}")
```

Quark Rule: useOfCryptographicAlgo.json
==================================

```json
{
    "crime": "Use of cryptographic algorithm",
    "permission": [],
    "api": [
        {
            "class": "Ljavax/crypto/Cipher;",
            "method": "getInstance",
            "descriptor": "(Ljava/lang/String; Ljava/lang/String;)Ljavax/crypto/Cipher"
        },
        {
            "class": "Ljavax/crypto/Cipher;",
            "method": "init",
            "descriptor": "(I Ljava/security/Key;)V"
        }
    ],
    "score": 1,
    "label": []
}
```

Quark Script Result
=====================

```
$ python3 CWE-780.py
CWE-780 is detected in method, Lsg/vp/owasp_mobile/OMTG_Android/OMTG_DATAST_001_KeyStore; encryptString (Ljava/lang/String;)V
```