### PR TITLE
Modify CWE-798 code

### DIFF
--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -425,7 +425,7 @@ Quark Scipt: CWE-798.py
 
 Let's use the above APIs to show how the Quark script finds this vulnerability.
 
-First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the method ``SecretKeySpec``. Then, we get all the parameter values that are input to this method. From the returned parameter values, we identify it as an AES key and parse the key out of the values. Finally, we dump all strings in the APK file and check if the AES key is in the strings. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file. 
+First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the method ``SecretKeySpec``. Then, we get all the parameter values that are input to this method. From the returned parameter values, we identify it as an AES key and parse the key out of the values. Finally, by using the method ``isHardcoded``, we check if the AES key is in all strings in the APK file. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file. 
 
 .. code-block:: python
 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -425,7 +425,7 @@ Quark Scipt: CWE-798.py
 
 Let's use the above APIs to show how the Quark script finds this vulnerability.
 
-First, we design a detection rule findSecretKeySpec.json to spot on behavior using the method SecretKeySpec. Then, we get all the parameter values that are input to this method. And we parse the AES key out of the parameter values. Finally, we check if the AES key is hardcoded in the APK file. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file.
+First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the method ``SecretKeySpec``. Then, we get all the parameter values that are input to this method. And we parse the AES key out of the parameter values. Finally, we check if the AES key is hardcoded in the APK file. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file.
 
 .. code-block:: python
 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -439,17 +439,15 @@ First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior
     quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)
 
     for secretKeySpec in quarkResult.behaviorOccurList:
-        
-        allStrings = quarkResult.getAllStrings()
-        
+
         firstParam = secretKeySpec.getParamValues()[1]
         secondParam = secretKeySpec.getParamValues()[2]
-        
+
         if secondParam == "AES":
-            AESKey = re.findall(r'\((.*?)\)', firstParam)[1]
-            
-        if AESKey in allStrings:
-            print(f"Found hard-coded {secondParam} key {AESKey}")
+            AESKey = re.findall(r"\((.*?)\)", firstParam)[1]
+
+            if quarkResult.isHardcoded(AESKey):
+                print(f"Found hard-coded {secondParam} key {AESKey}")
 
 
 Quark Rule: findSecretKeySpec.json

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -425,7 +425,7 @@ Quark Scipt: CWE-798.py
 
 Let's use the above APIs to show how the Quark script finds this vulnerability.
 
-First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the method ``SecretKeySpec``. Then, we get all the parameter values that are input to this method. From the returned parameter values, we identify it as an AES key and parse the key out of the values. Finally, by using the method ``isHardcoded``, we check if the AES key is in all strings in the APK file. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file. 
+First, we design a detection rule findSecretKeySpec.json to spot on behavior using the method SecretKeySpec. Then, we get all the parameter values that are input to this method. And we parse the AES key out of the parameter values. Finally, we check if the AES key is hardcoded in the APK file. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file.
 
 .. code-block:: python
 


### PR DESCRIPTION
# Detect CWE-798 in Android Application (ovaa.apk)

This scenario seeks to find **hard-coded credentials** in the APK file.

## CWE-798 Use of Hard-coded Credentials

We analyze the definition of CWE-798 and identify its characteristics.

See [CWE-798](https://cwe.mitre.org/data/definitions/798.html) for more details.

![截圖 2024-02-23 下午7.03.46](https://hackmd.io/_uploads/B1p2sl8na.png)

Code of CWE-798 in ovaa.apk
=========================================

We use the [ovaa.apk](https://github.com/oversecured/ovaa) sample to explain the vulnerability code of CWE-798.

![截圖 2024-02-23 下午7.14.56](https://hackmd.io/_uploads/HJTBAl82T.png)




Quark Scipt: CWE-798.py
========================

Let’s use the above APIs to show how the Quark script finds this vulnerability.

First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the method ``SecretKeySpec``. Then, we get all the parameter values that are input to this method. And we parse the AES key out of the parameter values. Finally, we check if the AES key is hardcoded in the APK file. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file. 

```python
import re
from quark.script import runQuarkAnalysis, Rule

SAMPLE_PATH = "ovaa.apk"
RULE_PATH = "findSecretKeySpec.json"

ruleInstance = Rule(RULE_PATH)
quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)

for secretKeySpec in quarkResult.behaviorOccurList:

    firstParam = secretKeySpec.getParamValues()[1]
    secondParam = secretKeySpec.getParamValues()[2]

    if secondParam == "AES":
        AESKey = re.findall(r"\((.*?)\)", firstParam)[1]

        if quarkResult.isHardcoded(AESKey):
            print(f"Found hard-coded {secondParam} key {AESKey}")
```

Quark Rule: findSecretKeySpec.json
==================================

```json
{
    "crime": "Detect APK using SecretKeySpec.",
    "permission": [],
    "api": [
        {
            "descriptor": "()[B",
            "class": "Ljava/lang/String;",
            "method": "getBytes"
        },
        {
            "descriptor": "([BLjava/lang/String;)V",
            "class": "Ljavax/crypto/spec/SecretKeySpec;",
            "method": "<init>"
        }
    ],
    "score": 1,
    "label": []
}
```

Quark Script Result
=====================

```
$ python3 findSecretKeySpec.py 

Found hard-coded AES key 49u5gh249gh24985ghf429gh4ch8f23f
```
