### PR TITLE
Use MacPorts to install packages for MacOS and fix Codecov errors in CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,9 +61,10 @@ jobs:
         pytest --cov=./ --cov-report=xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v4.4.0
       with:
         fail_ci_if_error: true
         flags: unittests
         token: ${{ secrets.CODECOV_TOKEN }}
+        version: v0.6.0 
 

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -44,9 +44,13 @@ jobs:
         # Install click >= 8.0.0 for CLI supports
         python -m pip install click==8.0.3
 
+    - name: Install MacPorts
+      uses: melusina-org/setup-macports@v1
+      if: matrix.os == 'macos-13'
+
     - run: sudo apt-get -y install graphviz
       if: matrix.os == 'ubuntu-latest'
-    - run: brew install graphviz
+    - run: sudo port install graphviz
       if: matrix.os == 'macos-13'
     - run: choco install graphviz
       if: matrix.os == 'windows-latest'


### PR DESCRIPTION
Close #657.

