### PR TITLE
Optimize the document of Quark Script CWE-338

### DIFF
--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1933,7 +1933,7 @@ We analyze the definition of CWE-338 and identify its characteristics.
 
 See `CWE-338 <https://cwe.mitre.org/data/definitions/338.html>`_ for more details.
 
-.. image:: https://imgur.com/qXNSQER.jpg
+.. image:: https://imgur.com/SSTvgYO.jpg
 
 Code of CWE-338 in pivaa.apk
 =============================
@@ -1968,7 +1968,7 @@ First, we design a detection rule ``useMethodOfPRNG.json`` to spot on behavior t
                 for keyword in CREDENTIAL_KEYWORDS):
                 print("CWE-338 is detected in %s" % prngCaller.fullName)
 
-useMethodOfPRNG.json
+Quark Rule: useMethodOfPRNG.json
 ========================
 .. code-block:: json
     

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1921,17 +1921,32 @@ Quark Script Result
 	$ python3 CWE-23.py
 	CWE-23 is detected in method, Loversecured/ovaa/providers/TheftOverwriteProvider; openFile (Landroid/net/Uri; Ljava/lang/String;)Landroid/os/ParcelFileDescriptor;
 
-Detect CWE-338 in Android Application (pivva.apk)
-------------------------------------------------------
+Detect CWE-338 in Android Application
+--------------------------------------
 
-This scenario aims to detect the **Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG).** See `CWE-338 <https://cwe.mitre.org/data/definitions/338.html>`_ for more details.
+This scenario seeks to find **Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)**.
 
-To demonstrate how the Quark script finds this vulnerability, we will use the `pivaa <https://github.com/HTBridge/pivaa>`_ APK file and the above APIs.
+CWE-338: Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
+=============================================================================
 
-First, we design a detection rule ``useMethodOfPRNG.json`` to spot on behavior that uses Pseudo Random Number Generator (PRNG). Then, we use API ``methodInstance.getXrefFrom()`` to get the caller method of PRNG. Finally, we use some keywords such as “token”, “password”, and “encrypt” to check if the PRNG is for credential usage.
+We analyze the definition of CWE-338 and identify its characteristics.
+
+See `CWE-338 <https://cwe.mitre.org/data/definitions/338.html>`_ for more details.
+
+.. image:: https://imgur.com/qXNSQER.jpg
+
+Code of CWE-338 in pivaa.apk
+=============================
+
+We use the `pivaa.apk <https://github.com/HTBridge/pivaa>`_ sample to explain the vulnerability code of CWE-338.
+
+.. image:: https://imgur.com/OPmo8Df.jpg
 
 Quark Script CWE-338.py
 ========================
+
+First, we design a detection rule ``useMethodOfPRNG.json`` to spot on behavior that uses Pseudo Random Number Generator (PRNG). Then, we use API ``methodInstance.getXrefFrom()`` to get the caller method of PRNG. Finally, we use some keywords such as “token”, “password”, and “encrypt” to check if the PRNG is for credential usage.
+
 .. code-block:: python
      
     from quark.script import runQuarkAnalysis, Rule

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -1969,7 +1969,7 @@ First, we design a detection rule ``useMethodOfPRNG.json`` to spot on behavior t
                 print("CWE-338 is detected in %s" % prngCaller.fullName)
 
 Quark Rule: useMethodOfPRNG.json
-========================
+=================================
 .. code-block:: json
     
     {


### PR DESCRIPTION
# Detect CWE-338 in Android Application

This scenario seeks to find **Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)**.

## CWE-338: Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)

We analyze the definition of CWE-338 and identify its characteristics.

See [CWE-338](https://cwe.mitre.org/data/definitions/338.html) for more details.

![image](https://imgur.com/SSTvgYO.jpg)

## Code of CWE-338 in pivaa.apk

We use the [pivaa.apk](https://github.com/HTBridge/pivaa) sample to explain the vulnerability code of CWE-338.

![image](https://imgur.com/OPmo8Df.jpg)

## Quark Script CWE-338.py

First, we design a detection rule ``useMethodOfPRNG.json`` to spot on behavior that uses Pseudo Random Number Generator (PRNG). Then, we use API ``methodInstance.getXrefFrom()`` to get the caller method of PRNG. Finally, we use some keywords such as “token”, “password”, and “encrypt” to check if the PRNG is for credential usage.

```python
from quark.script import runQuarkAnalysis, Rule

SAMPLE_PATH = "pivaa.apk"
RULE_PATH = "useMethodOfPRNG.json"

CREDENTIAL_KEYWORDS = [
    "token", "password", "account", "encrypt",
    "authentication", "authorization", "id", "key"
]

ruleInstance = Rule(RULE_PATH)
quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)

for usePRNGMethod in quarkResult.behaviorOccurList:
    for prngCaller in usePRNGMethod.methodCaller.getXrefFrom():
        if any(keyword in prngCaller.fullName
            for keyword in CREDENTIAL_KEYWORDS):
            print("CWE-338 is detected in %s" % prngCaller.fullName)
```
    
## useMethodOfPRNG.json

```json
{
    "crime": "Use method of PRNG",
    "permission": [],
    "api": [
        {
            "class": "Ljava/util/Random;",
            "method": "<init>",
            "descriptor": "()V"
        },
        {
            "class": "Ljava/util/Random;",
            "method": "nextInt",
            "descriptor": "(I)I"
        }
    ],
    "score": 1,
    "label": []
}
```

## Quark Script Result

```TEXT
$ python CWE-338.py
CWE-338 is detected in Lcom/htbridge/pivaa/EncryptionActivity$2; onClick (Landroid/view/View;)V
```
