### PR TITLE
Optimize the document of Quark Script CWE-798

### DIFF
--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -399,33 +399,39 @@ Method (callComponentMethod) with urls is detected triggered!
 
 
 Detect CWE-798 in Android Application
-------------------------------------------------
+-------------------------------------------------
 
-This scenario seeks to find hard-coded credentials in the APK file. 
+This scenario seeks to find **hard-coded credentials** in the APK file.
 
 CWE-798 Use of Hard-coded Credentials
-============================================
+======================================
 
 We analyze the definition of CWE-798 and identify its characteristics.
 
-See `CWE-798 <https://cwe.mitre.org/data/definitions/798.html>`_  for more details.
+See `CWE-798 <https://cwe.mitre.org/data/definitions/798.html>`_ for more details.
 
-.. image:: https://i.imgur.com/0G9APpf.jpg
+.. image:: https://imgur.com/rkoJ8so.png
 
 Code of CWE-798 in ovaa.apk
-=========================================
+============================
 
 We use the `ovaa.apk <https://github.com/oversecured/ovaa>`_ sample to explain the vulnerability code of CWE-798.
 
-.. image:: https://i.imgur.com/ikaJlDW.jpg
+.. image:: https://imgur.com/lBjgAqQ.png
 
+CWE-798 Detection Process Using Quark Script API
+=================================================
 
-Quark Script: CWE-798.py
+.. image:: https://imgur.com/5pMc01a.png
+
+Let’s use the above APIs to show how the Quark script finds this vulnerability.
+
+First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the method ``SecretKeySpec``. Then, we get all the parameter values that are input to this method. And we parse the AES key from the parameter values. Finally, we check if the AES key is hardcoded in the APK file. If the answer is **YES**, BINGO!!! We find hard-coded credentials in the APK file.
+
+Quark Scipt: CWE-798.py
 ========================
 
-Let's use the above APIs to show how the Quark script finds this vulnerability.
-
-First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the method ``SecretKeySpec``. Then, we get all the parameter values that are input to this method. And we parse the AES key out of the parameter values. Finally, we check if the AES key is hardcoded in the APK file. If the answer is YES, BINGO!!! We find hard-coded credentials in the APK file.
+.. image:: https://imgur.com/s9q5XSp.png
 
 .. code-block:: python
 
@@ -449,9 +455,10 @@ First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior
             if quarkResult.isHardcoded(AESKey):
                 print(f"Found hard-coded {secondParam} key {AESKey}")
 
-
 Quark Rule: findSecretKeySpec.json
-==================================
+===================================
+
+.. image:: https://imgur.com/2BYOE70.png
 
 .. code-block:: json
 
@@ -474,15 +481,14 @@ Quark Rule: findSecretKeySpec.json
         "label": []
     }
 
-
 Quark Script Result
-=====================
+====================
 
 .. code-block:: TEXT
 
-    $ python3 findSecretKeySpec.py 
-
+    $ python3 CWE-798.py
     Found hard-coded AES key 49u5gh249gh24985ghf429gh4ch8f23f
+
 
 
 Detect CWE-94 in Android Application 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -422,13 +422,13 @@ We use the `ovaa.apk <https://github.com/oversecured/ovaa>`_ sample to explain t
 CWE-798 Detection Process Using Quark Script API
 =================================================
 
-.. image:: https://imgur.com/IRFU9K8.png
+.. image:: https://imgur.com/R8CfDqD.png
 
 Let’s use the above APIs to show how the Quark script finds this vulnerability.
 
-First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the constructor ``SecretKeySpec``. Second, we get all the input parameter values from this constructor. Then, we parse the AES key from the parameter values. Finally, we check if the AES key is hardcoded in the APK file. If the answer is **YES**, BINGO!!! We find hard-coded credentials in the APK file.
+First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the constructor ``SecretKeySpec``. Second, we get all the parameter values from this constructor. Then, we parse the AES key from the parameter values. Finally, we check if the AES key is hardcoded in the APK file. If the answer is **YES**, BINGO!!! We find hard-coded credentials in the APK file.
 
-Quark Scipt: CWE-798.py
+Quark Script: CWE-798.py
 ========================
 
 .. image:: https://imgur.com/IOyrqDc.png
@@ -1054,7 +1054,7 @@ We use the `dvba.apk <https://github.com/rewanthtammana/Damn-Vulnerable-Bank>`_ 
 
 .. image:: https://imgur.com/THWm2gN.jpg
 
-Quark Scipt: CWE-532.py
+Quark Script: CWE-532.py
 ========================
 
 Let's use the above APIs to show how the Quark script finds this vulnerability.

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -403,35 +403,35 @@ Detect CWE-798 in Android Application
 
 This scenario seeks to find **hard-coded credentials** in the APK file.
 
-CWE-798 Use of Hard-coded Credentials
+CWE-798: Use of Hard-coded Credentials
 ======================================
 
 We analyze the definition of CWE-798 and identify its characteristics.
 
 See `CWE-798 <https://cwe.mitre.org/data/definitions/798.html>`_ for more details.
 
-.. image:: https://imgur.com/rkoJ8so.png
+.. image:: https://imgur.com/CO4w6zw.png
 
 Code of CWE-798 in ovaa.apk
 ============================
 
 We use the `ovaa.apk <https://github.com/oversecured/ovaa>`_ sample to explain the vulnerability code of CWE-798.
 
-.. image:: https://imgur.com/lBjgAqQ.png
+.. image:: https://imgur.com/Cg7DacP.png
 
 CWE-798 Detection Process Using Quark Script API
 =================================================
 
-.. image:: https://imgur.com/5pMc01a.png
+.. image:: https://imgur.com/IRFU9K8.png
 
 Let’s use the above APIs to show how the Quark script finds this vulnerability.
 
-First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the method ``SecretKeySpec``. Then, we get all the parameter values that are input to this method. And we parse the AES key from the parameter values. Finally, we check if the AES key is hardcoded in the APK file. If the answer is **YES**, BINGO!!! We find hard-coded credentials in the APK file.
+First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the constructor ``SecretKeySpec``. Second, we get all the input parameter values from this constructor. Then, we parse the AES key from the parameter values. Finally, we check if the AES key is hardcoded in the APK file. If the answer is **YES**, BINGO!!! We find hard-coded credentials in the APK file.
 
 Quark Scipt: CWE-798.py
 ========================
 
-.. image:: https://imgur.com/s9q5XSp.png
+.. image:: https://imgur.com/IOyrqDc.png
 
 .. code-block:: python
 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -410,7 +410,7 @@ We analyze the definition of CWE-798 and identify its characteristics.
 
 See `CWE-798 <https://cwe.mitre.org/data/definitions/798.html>`_ for more details.
 
-.. image:: https://imgur.com/CO4w6zw.png
+.. image:: https://imgur.com/gCVcbO9.png
 
 Code of CWE-798 in ovaa.apk
 ============================

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -410,7 +410,7 @@ We analyze the definition of CWE-798 and identify its characteristics.
 
 See `CWE-798 <https://cwe.mitre.org/data/definitions/798.html>`_ for more details.
 
-.. image:: https://imgur.com/gCVcbO9.png
+.. image:: https://imgur.com/rF8J8hE.png
 
 Code of CWE-798 in ovaa.apk
 ============================


### PR DESCRIPTION
# Detect CWE-798 in Android Application

This scenario seeks to find **hard-coded credentials** in the APK file.

## CWE-798: Use of Hard-coded Credentials

We analyze the definition of CWE-798 and identify its characteristics.

See [CWE-798](https://cwe.mitre.org/data/definitions/798.html) for more details.

![image](https://imgur.com/rF8J8hE.png)

## Code of CWE-798 in ovaa.apk

We use the [ovaa.apk](https://github.com/oversecured/ovaa) sample to explain the vulnerability code of CWE-798.

![image](https://imgur.com/Cg7DacP.png)

## CWE-798 Detection Process Using Quark Script API

![image](https://imgur.com/R8CfDqD.png)

Let’s use the above APIs to show how the Quark script finds this vulnerability.

First, we design a detection rule ``findSecretKeySpec.json`` to spot on behavior using the constructor ``SecretKeySpec``. Second, we get all the parameter values from this constructor. Then, we parse the AES key from the parameter values. Finally, we check if the AES key is hardcoded in the APK file. If the answer is **YES**, BINGO!!! We find hard-coded credentials in the APK file.

## Quark Script: CWE-798.py

![image](https://imgur.com/IOyrqDc.png)

```python
import re
from quark.script import runQuarkAnalysis, Rule

SAMPLE_PATH = "ovaa.apk"
RULE_PATH = "findSecretKeySpec.json"

ruleInstance = Rule(RULE_PATH)
quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)

for secretKeySpec in quarkResult.behaviorOccurList:

    firstParam = secretKeySpec.secondAPI.getArguments()[1]
    secondParam = secretKeySpec.secondAPI.getArguments()[2]

    if secondParam == "AES":
        AESKey = re.findall(r"\((.*?)\)", firstParam)[1]

        if quarkResult.isHardcoded(AESKey):
            print(f"Found hard-coded {secondParam} key {AESKey}")
```

## Quark Rule: findSecretKeySpec.json

![image](https://imgur.com/2BYOE70.png)

```json
{
    "crime": "Detect APK using SecretKeySpec.",
    "permission": [],
    "api": [
        {
            "descriptor": "()[B",
            "class": "Ljava/lang/String;",
            "method": "getBytes"
        },
        {
            "descriptor": "([BLjava/lang/String;)V",
            "class": "Ljavax/crypto/spec/SecretKeySpec;",
            "method": "<init>"
        }
    ],
    "score": 1,
    "label": []
}
```

## Quark Script Result

```TEXT
$ python3 CWE-798.py
Found hard-coded AES key 49u5gh249gh24985ghf429gh4ch8f23f
```
