### PR TITLE
Switch Quark's default core library to the Shuriken-based

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Install Shuriken-Analyzer
       run: |
-        pip install git+https://github.com/Fare9/Shuriken-Analyzer.git@main#subdirectory=shuriken/bindings/Python/
+        pip install git+https://github.com/Fare9/Shuriken-Analyzer.git@7f2e45f8714ca2d920fc2c2957c1de275edcbe23#subdirectory=shuriken/bindings/Python/
 
     - name: Install Quark-Engine
       run: pip install .

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -49,7 +49,7 @@ jobs:
 
     - name: Install Shuriken-Analyzer for MacOS
       run: |
-        pip install git+https://github.com/Fare9/Shuriken-Analyzer.git@main#subdirectory=shuriken/bindings/Python/
+        pip install git+https://github.com/Fare9/Shuriken-Analyzer.git@7f2e45f8714ca2d920fc2c2957c1de275edcbe23#subdirectory=shuriken/bindings/Python/
       if: matrix.os == 'macos-13'
 
     - name: Install MacPorts

--- a/quark/agent/agentTools.py
+++ b/quark/agent/agentTools.py
@@ -58,7 +58,7 @@ def initQuarkObject(apk_path: str):
     """
     global quark
 
-    quark_lib = "androguard"
+    quark_lib = "shuriken"
     quark = Quark(apk_path, core_library=quark_lib)
 
     return "Quark initialized successfully"

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -138,7 +138,7 @@ logo()
         case_sensitive=False
     ),
     required=False,
-    default="androguard",
+    default="shuriken",
 )
 @click.option(
     "--multi-process",

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -43,7 +43,7 @@ MAX_SEARCH_LAYER = 3
 class Quark:
     """Quark module is used to check quark's five-stage theory"""
 
-    def __init__(self, apk, core_library="androguard"):
+    def __init__(self, apk, core_library="shuriken"):
         """
 
         :param apk: the filename of the apk.

--- a/quark/forensic/forensic.py
+++ b/quark/forensic/forensic.py
@@ -4,6 +4,7 @@
 
 from quark.core.apkinfo import AndroguardImp
 from quark.core.rzapkinfo import RizinImp
+from quark.core.shurikenapkinfo import ShurikenImp
 from quark.utils.regex import (
     extract_url,
     extract_ip,
@@ -16,8 +17,10 @@ from quark.utils.regex import (
 class Forensic:
     __slots__ = ["apk", "all_strings"]
 
-    def __init__(self, apkpath, core_library="androguard"):
-        if core_library == "rizin":
+    def __init__(self, apkpath, core_library="shuriken"):
+        if core_library == "shuriken":
+            self.apkinfo = ShurikenImp(apkpath)
+        elif core_library == "rizin":
             self.apk = RizinImp(apkpath)
         elif core_library == "androguard":
             self.apk = AndroguardImp(apkpath)

--- a/quark/report.py
+++ b/quark/report.py
@@ -16,7 +16,7 @@ class Report:
     def __init__(self):
         self.quark = None
 
-    def analysis(self, apk, rule, core_library="androguard"):
+    def analysis(self, apk, rule, core_library="shuriken"):
         """
         The main function of Quark-Engine analysis, the analysis is based on the provided APK file.
 

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ required_requirements = [
     "rzpipe",
     "click",
     "r2pipe==1.8.0",
+    "ShurikenAnalyzer @ git+https://github.com/Fare9/Shuriken-Analyzer.git@7f2e45f8714ca2d920fc2c2957c1de275edcbe23#subdirectory=shuriken/bindings/Python/"
 ]
 
 quarkAgentRequirements = [


### PR DESCRIPTION
Refer to Issue #728 .

- [ ] Ensure Quark passes the unit tests and the smoke tests on Linux, macOS, and Windows platforms.
- [ ] Ensure Quark Agent, Quark-Script, and Quark Report showcase work as expected.
- [ ] Ensure Quark is installable via Pip, Pipenv, Kali Package, and Docker Image.
- [ ] Ensure the integrations with IntelOwl, Jadx, MobSF, and Apklab work as expected.