### PR TITLE
Optimize the document of Quark Script CWE-88

### DIFF
--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -2108,17 +2108,19 @@ We analyze the definition of CWE-88 and identify its characteristics.
 
 See `CWE-88 <https://cwe.mitre.org/data/definitions/88.html>`_ for more details.
 
-.. image:: https://imgur.com/7EBPGUT.png
+.. image:: https://imgur.com/5vfXkIE.png
 
 Code of CWE-88 in vuldroid.apk
-=========================================
+===============================
 
 We use the `vuldroid.apk <https://github.com/jaiswalakshansh/Vuldroid>`_ sample to explain the vulnerability code of CWE-88.
 
-.. image:: https://imgur.com/emnvGcE.png
+.. image:: https://imgur.com/recX0t5.png
 
-Quark Script: CWE-88.py
-========================
+CWE-88 Detection Process Using Quark Script API
+================================================
+
+.. image:: https://imgur.com/s7Ajr6M.png
 
 Let‘s use the above APIs to show how the Quark script finds this vulnerability.
 
@@ -2130,44 +2132,50 @@ Then we check if the method neutralizes any special elements in the argument.
 
 If the neutralization is not complete, then it may cause CWE-88 vulnerability.
 
+Quark Script: CWE-88.py
+========================
+
+.. image:: https://imgur.com/f8Yee3P.png
+
 .. code-block:: python
 
     from quark.script import runQuarkAnalysis, Rule, findMethodInAPK
 
-    SAMPLE_PATH = "Vuldroid.apk"
-    RULE_PATH = "ExternalStringCommand.json"
+        SAMPLE_PATH = "Vuldroid.apk"
+        RULE_PATH = "ExternalStringCommand.json"
 
 
-    STRING_MATCHING_API = set([
-        ("Ljava/lang/String;", "contains", "(Ljava/lang/CharSequence)Z"),
-        ("Ljava/lang/String;", "indexOf", "(I)I"),
-        ("Ljava/lang/String;", "indexOf", "(Ljava/lang/String;)I"),
-        ("Ljava/lang/String;", "matches", "(Ljava/lang/String;)Z"),
-        ("Ljava/lang/String;", "replaceAll", "(Ljava/lang/String; Ljava/lang/String;)Ljava/lang/String;")
-    ])
+        STRING_MATCHING_API = set([
+            ("Ljava/lang/String;", "contains", "(Ljava/lang/CharSequence)Z"),
+            ("Ljava/lang/String;", "indexOf", "(I)I"),
+            ("Ljava/lang/String;", "indexOf", "(Ljava/lang/String;)I"),
+            ("Ljava/lang/String;", "matches", "(Ljava/lang/String;)Z"),
+            ("Ljava/lang/String;", "replaceAll", "(Ljava/lang/String; Ljava/lang/String;)Ljava/lang/String;")
+        ])
 
-    delimeter = "-"
+        delimeter = "-"
 
-    ruleInstance = Rule(RULE_PATH)
-    quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)
+        ruleInstance = Rule(RULE_PATH)
+        quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)
 
-    for ExternalStringCommand in quarkResult.behaviorOccurList:
+        for ExternalStringCommand in quarkResult.behaviorOccurList:
 
-        methodCalled = set()
-        caller = ExternalStringCommand.methodCaller
+            methodCalled = set()
+            caller = ExternalStringCommand.methodCaller
 
-        for method in ExternalStringCommand.getMethodsInArgs():
-            methodCalled.add(method.fullName)
+            for method in ExternalStringCommand.getMethodsInArgs():
+                methodCalled.add(method.fullName)
 
-        if methodCalled.intersection(STRING_MATCHING_API) and not ExternalStringCommand.hasString(delimeter):
-            continue
-        else:
-            print(f"CWE-88 is detected in method, {caller.fullName}")
+            if methodCalled.intersection(STRING_MATCHING_API) and not ExternalStringCommand.hasString(delimeter):
+                continue
+            else:
+                print(f"CWE-88 is detected in method, {caller.fullName}")
 
 
-                
 Quark Rule: ExternalStringCommand.json
-=========================================
+=======================================
+
+.. image:: https://imgur.com/s9QNF19.png
 
 .. code-block:: json
 
@@ -2190,14 +2198,14 @@ Quark Rule: ExternalStringCommand.json
         "label": []
     }
 
-
 Quark Script Result
-======================
+====================
 
 .. code-block:: TEXT
 
     $ python3 CWE-88.py
     CWE-88 is detected in method, Lcom/vuldroid/application/RootDetection; onCreate (Landroid/os/Bundle;)V
+
 
 
 Detect CWE-925 in Android Application


### PR DESCRIPTION
# Detect CWE-88 in Android Application 

This scenario seeks to find **Argument Injection** in the APK file.

## CWE-88 Improper Neutralization of Argument Delimiters in a Command

We analyze the definition of CWE-88 and identify its characteristics.

See [CWE-88](https://cwe.mitre.org/data/definitions/88.html) for more details.

![image](https://imgur.com/5vfXkIE.png)

## Code of CWE-88 in vuldroid.apk

We use the [vuldroid.apk](https://github.com/jaiswalakshansh/Vuldroid) sample to explain the vulnerability code of CWE-88.

![image](https://imgur.com/recX0t5.png)

## CWE-88 Detection Process Using Quark Script API

![image](https://imgur.com/s7Ajr6M.png)

Let‘s use the above APIs to show how the Quark script finds this vulnerability.

First, we design a detection rule ``ExternalStringsCommands.json`` to spot on behavior using external strings as commands.

Next, we use Quark API ``behaviorInstance.getMethodsInArgs()`` to get the methods that passed the external command.

Then we check if the method neutralizes any special elements in the argument.

If the neutralization is not complete, then it may cause CWE-88 vulnerability.

## Quark Script: CWE-88.py

![image](https://imgur.com/f8Yee3P.png)

```python
from quark.script import runQuarkAnalysis, Rule, findMethodInAPK

    SAMPLE_PATH = "Vuldroid.apk"
    RULE_PATH = "ExternalStringCommand.json"


    STRING_MATCHING_API = set([
        ("Ljava/lang/String;", "contains", "(Ljava/lang/CharSequence)Z"),
        ("Ljava/lang/String;", "indexOf", "(I)I"),
        ("Ljava/lang/String;", "indexOf", "(Ljava/lang/String;)I"),
        ("Ljava/lang/String;", "matches", "(Ljava/lang/String;)Z"),
        ("Ljava/lang/String;", "replaceAll", "(Ljava/lang/String; Ljava/lang/String;)Ljava/lang/String;")
    ])

    delimeter = "-"

    ruleInstance = Rule(RULE_PATH)
    quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)

    for ExternalStringCommand in quarkResult.behaviorOccurList:

        methodCalled = set()
        caller = ExternalStringCommand.methodCaller

        for method in ExternalStringCommand.getMethodsInArgs():
            methodCalled.add(method.fullName)

        if methodCalled.intersection(STRING_MATCHING_API) and not ExternalStringCommand.hasString(delimeter):
            continue
        else:
            print(f"CWE-88 is detected in method, {caller.fullName}")

```

## Quark Rule: ExternalStringCommand.json

![image](https://imgur.com/s9QNF19.png)

```json
{
    "crime": "Using external strings as commands",
    "permission": [],
    "api": [
        {
            "class": "Landroid/content/Intent;",
            "method": "getStringExtra",
            "descriptor": "(Ljava/lang/String;)Ljava/lang/String"
        },
        {
            "class": "Ljava/lang/Runtime;",
            "method": "exec",
            "descriptor": "(Ljava/lang/String;)Ljava/lang/Process"
        }
    ],
    "score": 1,
    "label": []
}
```

## Quark Script Result

```
$ python3 CWE-88.py
CWE-88 is detected in method, Lcom/vuldroid/application/RootDetection; onCreate (Landroid/os/Bundle;)V
```
