### PR TITLE
Add Quark script showcase of detecting CWE-329

### DIFF
--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -2969,8 +2969,8 @@ CWE-329 Detection Process Using Quark Script API
 ================================================
 
 
-.. image:: https://i.postimg.cc/6pQZqWL2/Screenshot-2025-07-11-17-14-23.png
-   :target: https://i.postimg.cc/6pQZqWL2/Screenshot-2025-07-11-17-14-23.png
+.. image:: https://i.postimg.cc/50cscyh2/Screenshot-2025-07-12-10-02-34.png
+   :target: https://i.postimg.cc/50cscyh2/Screenshot-2025-07-12-10-02-34.png
    :alt:
 
 
@@ -2984,8 +2984,8 @@ Quark Script CWE-329.py
 =======================
 
 
-.. image:: https://i.postimg.cc/XqbJxDWY/Screenshot-2025-07-11-22-49-45.png
-   :target: https://i.postimg.cc/XqbJxDWY/Screenshot-2025-07-11-22-49-45.png
+.. image:: https://i.postimg.cc/prCCnZpm/Screenshot-2025-07-12-10-02-58.png
+   :target: https://i.postimg.cc/prCCnZpm/Screenshot-2025-07-12-10-02-58.png
    :alt:
 
 

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -2933,3 +2933,124 @@ Quark Script Result
     $ python CWE-601.py
     CWE-601 is detected in Loversecured/ovaa/activities/DeeplinkActivity; processDeeplink (Landroid/net/Uri;)V
     CWE-601 is detected in Loversecured/ovaa/activities/LoginActivity; onLoginFinished ()V
+
+
+Detect CWE-329 in Android Application
+-------------------------------------
+
+This scenario seeks to find **Generation of Predictable IV with CBC Mode** in the APK file.
+
+CWE-329: Generation of Predictable IV with CBC Mode
+===================================================
+
+We analyze the definition of CWE-329 and identify its characteristics.
+
+See `CWE-329 <https://cwe.mitre.org/data/definitions/329.html>`_ for more details.
+
+
+.. image:: https://i.postimg.cc/ZY6WjB5z/Screenshot-2025-07-11-17-13-40.png
+   :target: https://i.postimg.cc/ZY6WjB5z/Screenshot-2025-07-11-17-13-40.png
+   :alt:
+
+
+Code of CWE-329 in pivaa.apk
+============================
+
+We use the `InsecureBankv2.apk <https://github.com/dineshshetty/Android-InsecureBankv2>`_ sample to explain the vulnerability code of CWE-329.
+
+
+.. image:: https://i.postimg.cc/LXgBX9SB/Screenshot-2025-07-11-17-46-25.png
+   :target: https://i.postimg.cc/LXgBX9SB/Screenshot-2025-07-11-17-46-25.png
+   :alt:
+
+
+CWE-329 Detection Process Using Quark Script API
+================================================
+
+
+.. image:: https://i.postimg.cc/6pQZqWL2/Screenshot-2025-07-11-17-14-23.png
+   :target: https://i.postimg.cc/6pQZqWL2/Screenshot-2025-07-11-17-14-23.png
+   :alt:
+
+
+Let’s use the above APIs to show how the Quark script finds this vulnerability.
+
+To begin with, we created a detection rule named ``initializeCipherWithIV.json`` to identify behaviors that initialize a cipher process with IV. Then, we use API ``behaviorInstance.getParamValues()`` to check if the cipher process uses CBC mode.
+
+Finally, we use API ``behaviorInstance.isArgFromMethod(targetMethod)``  to check if any randomization API is applied on the IV used in the cipher process. If **NO**\ , it could imply that the APK uses a predictable IV in CBC mode cipher, potentially leading to a CWE-329 vulnerability.
+
+Quark Script CWE-329.py
+=======================
+
+
+.. image:: https://i.postimg.cc/cCXHG3zD/Screenshot-2025-07-11-17-22-28.png
+   :target: https://i.postimg.cc/cCXHG3zD/Screenshot-2025-07-11-17-22-28.png
+   :alt:
+
+
+.. code-block:: python
+
+   from quark.script import runQuarkAnalysis, Rule
+
+   SAMPLE_PATH = "InsecureBankv2.apk"
+   RULE_PATH = "initializeCipherWithIV.json"
+
+   randomizingAPIs = [
+       ["Ljava/security/SecureRandom", "next", "(I)I"],
+       ["Ljava/security/SecureRandom", "nextBytes", "([B)V"],
+   ]
+
+   ruleInstance = Rule(RULE_PATH)
+   quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)
+
+   for initCipherWithIV in quarkResult.behaviorOccurList:
+       methodcaller = initCipherWithIV.methodCaller
+       cipherName = initCipherWithIV.getParamValues()[0]
+
+       if "CBC" not in cipherName:
+           break
+
+       if not any(
+           initCipherWithIV.isArgFromMethod(api) for api in randomizingAPIs
+       ):
+           print(f"CWE-329 is detected in method, {methodcaller.fullName}")
+
+Quark Rule: initializeCipherWithIV.json
+=======================================
+
+
+.. image:: https://i.postimg.cc/Y9tM29YT/Screenshot-2025-07-11-17-49-41.png
+   :target: https://i.postimg.cc/Y9tM29YT/Screenshot-2025-07-11-17-49-41.png
+   :alt:
+
+
+.. code-block:: json
+
+   {
+       "crime": "Initialize a cipher process with IV",
+       "permission": [],
+       "api": [
+           {
+               "class": "Ljavax/crypto/spec/IvParameterSpec;",
+               "method": "<init>",
+               "descriptor": "([B)V"
+           },
+           {
+               "class": "Ljavax/crypto/Cipher;",
+               "method": "init",
+               "descriptor": "(ILjava/security/Key;Ljava/security/spec/AlgorithmParameterSpec;)V"
+           }
+       ],
+       "score": 1,
+       "label": []
+   }
+
+Quark Script Result
+===================
+
+.. code-block:: text
+
+   $ python CWE-329.py
+   CWE-329 is detected in method, Lcom/google/android/gms/internal/zzar; zzc ([B Ljava/lang/String;)[B
+   CWE-329 is detected in method, Lcom/android/insecurebankv2/CryptoClass; aes256encrypt ([B [B [B)[B
+   CWE-329 is detected in method, Lcom/android/insecurebankv2/CryptoClass; aes256decrypt ([B [B [B)[B

--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -2935,6 +2935,7 @@ Quark Script Result
     CWE-601 is detected in Loversecured/ovaa/activities/LoginActivity; onLoginFinished ()V
 
 
+
 Detect CWE-329 in Android Application
 -------------------------------------
 
@@ -2953,8 +2954,8 @@ See `CWE-329 <https://cwe.mitre.org/data/definitions/329.html>`_ for more detail
    :alt:
 
 
-Code of CWE-329 in pivaa.apk
-============================
+Code of CWE-329 in InsecureBankv2.apk
+========================================
 
 We use the `InsecureBankv2.apk <https://github.com/dineshshetty/Android-InsecureBankv2>`_ sample to explain the vulnerability code of CWE-329.
 
@@ -2975,16 +2976,16 @@ CWE-329 Detection Process Using Quark Script API
 
 Let’s use the above APIs to show how the Quark script finds this vulnerability.
 
-To begin with, we created a detection rule named ``initializeCipherWithIV.json`` to identify behaviors that initialize a cipher process with IV. Then, we use API ``behaviorInstance.getParamValues()`` to check if the cipher process uses CBC mode.
+To begin with, we created a detection rule named ``initializeCipherWithIV.json`` to identify behaviors that initialize a cipher object with IV. Then, we use API ``behaviorInstance.getParamValues()`` to check if the cipher object uses CBC mode.
 
-Finally, we use API ``behaviorInstance.isArgFromMethod(targetMethod)``  to check if any randomization API is applied on the IV used in the cipher process. If **NO**\ , it could imply that the APK uses a predictable IV in CBC mode cipher, potentially leading to a CWE-329 vulnerability.
+Finally, we use API ``behaviorInstance.isArgFromMethod(targetMethod)``  to check if any random API is applied on the IV used in the cipher object. If **NO**\ , it could imply that the APK uses a predictable IV in CBC mode cipher, potentially leading to a CWE-329 vulnerability.
 
 Quark Script CWE-329.py
 =======================
 
 
-.. image:: https://i.postimg.cc/cCXHG3zD/Screenshot-2025-07-11-17-22-28.png
-   :target: https://i.postimg.cc/cCXHG3zD/Screenshot-2025-07-11-17-22-28.png
+.. image:: https://i.postimg.cc/XqbJxDWY/Screenshot-2025-07-11-22-49-45.png
+   :target: https://i.postimg.cc/XqbJxDWY/Screenshot-2025-07-11-22-49-45.png
    :alt:
 
 
@@ -2995,7 +2996,7 @@ Quark Script CWE-329.py
    SAMPLE_PATH = "InsecureBankv2.apk"
    RULE_PATH = "initializeCipherWithIV.json"
 
-   randomizingAPIs = [
+   randomAPIs = [
        ["Ljava/security/SecureRandom", "next", "(I)I"],
        ["Ljava/security/SecureRandom", "nextBytes", "([B)V"],
    ]
@@ -3011,7 +3012,7 @@ Quark Script CWE-329.py
            break
 
        if not any(
-           initCipherWithIV.isArgFromMethod(api) for api in randomizingAPIs
+           initCipherWithIV.isArgFromMethod(api) for api in randomAPIs
        ):
            print(f"CWE-329 is detected in method, {methodcaller.fullName}")
 
@@ -3027,7 +3028,7 @@ Quark Rule: initializeCipherWithIV.json
 .. code-block:: json
 
    {
-       "crime": "Initialize a cipher process with IV",
+       "crime": "Initialize a cipher object with IV",
        "permission": [],
        "api": [
            {


### PR DESCRIPTION


# Detect CWE-329 in Android Application


This scenario seeks to find **Generation of Predictable IV with CBC Mode** in the APK file.

## CWE-329: Generation of Predictable IV with CBC Mode


We analyze the definition of CWE-329 and identify its characteristics.

See [CWE-329](https://cwe.mitre.org/data/definitions/329.html) for more details.

![](https://i.postimg.cc/ZY6WjB5z/Screenshot-2025-07-11-17-13-40.png)

## Code of CWE-329 in InsecureBankv2.apk


We use the [InsecureBankv2.apk](https://github.com/dineshshetty/Android-InsecureBankv2) sample to explain the vulnerability code of CWE-329.

![](https://i.postimg.cc/LXgBX9SB/Screenshot-2025-07-11-17-46-25.png)

## CWE-329 Detection Process Using Quark Script API


![](https://i.postimg.cc/50cscyh2/Screenshot-2025-07-12-10-02-34.png)

Let’s use the above APIs to show how the Quark script finds this vulnerability.

To begin with, we created a detection rule named ``initializeCipherWithIV.json`` to identify behaviors that initialize a cipher object with IV. Then, we use API `behaviorInstance.getParamValues()` to check if the cipher object uses CBC mode.

Finally, we use API ``behaviorInstance.isArgFromMethod(targetMethod)``  to check if any random API is applied on the IV used in the cipher object. If **NO**, it could imply that the APK uses a predictable IV in CBC mode cipher, potentially leading to a CWE-329 vulnerability.

## Quark Script CWE-329.py

![](https://i.postimg.cc/prCCnZpm/Screenshot-2025-07-12-10-02-58.png)

```python
from quark.script import runQuarkAnalysis, Rule

SAMPLE_PATH = "InsecureBankv2.apk"
RULE_PATH = "initializeCipherWithIV.json"

randomAPIs = [
    ["Ljava/security/SecureRandom", "next", "(I)I"],
    ["Ljava/security/SecureRandom", "nextBytes", "([B)V"],
]

ruleInstance = Rule(RULE_PATH)
quarkResult = runQuarkAnalysis(SAMPLE_PATH, ruleInstance)

for initCipherWithIV in quarkResult.behaviorOccurList:
    methodcaller = initCipherWithIV.methodCaller
    cipherName = initCipherWithIV.getParamValues()[0]

    if "CBC" not in cipherName:
        break

    if not any(
        initCipherWithIV.isArgFromMethod(api) for api in randomAPIs
    ):
        print(f"CWE-329 is detected in method, {methodcaller.fullName}")
```
            
## Quark Rule: initializeCipherWithIV.json

![](https://i.postimg.cc/Y9tM29YT/Screenshot-2025-07-11-17-49-41.png)

```json
{
    "crime": "Initialize a cipher object with IV",
    "permission": [],
    "api": [
        {
            "class": "Ljavax/crypto/spec/IvParameterSpec;",
            "method": "<init>",
            "descriptor": "([B)V"
        },
        {
            "class": "Ljavax/crypto/Cipher;",
            "method": "init",
            "descriptor": "(ILjava/security/Key;Ljava/security/spec/AlgorithmParameterSpec;)V"
        }
    ],
    "score": 1,
    "label": []
}
```

## Quark Script Result

```text
$ python CWE-329.py
CWE-329 is detected in method, Lcom/google/android/gms/internal/zzar; zzc ([B Ljava/lang/String;)[B
CWE-329 is detected in method, Lcom/android/insecurebankv2/CryptoClass; aes256encrypt ([B [B [B)[B
CWE-329 is detected in method, Lcom/android/insecurebankv2/CryptoClass; aes256decrypt ([B [B [B)[B
```

