### PR TITLE
Add Quark Script APIs to detect CWE-359

### DIFF
--- a/docs/source/quark_script.rst
+++ b/docs/source/quark_script.rst
@@ -339,6 +339,19 @@ applicationInstance.isDebuggable(none)
 - **params**: none
 - **return**:  True/False
 
+getProviders(samplePath)
+==========================
+- **Description**: Get provider elements from the manifest file of the target sample.
+- **params**:
+    1. samplePath: the file path of target sample
+- **return**: python list containing provider elements
+
+providerInstance.isExported(none)
+==================================
+- **Description**: Check if the provider element set ``android:exported=true``.
+- **params**: none
+- **return**:  True/False
+
 Analyzing real case (InstaStealer) using Quark Script
 ------------------------------------------------------
 

--- a/quark/core/interface/baseapkinfo.py
+++ b/quark/core/interface/baseapkinfo.py
@@ -153,6 +153,20 @@ class BaseApkinfo:
             return root.findall("application/receiver")
 
     @property
+    def providers(self) -> List[XMLElement] | None:
+        """Get provider elements from the manifest file.
+
+        :return: python list containing provider elements
+        """
+        if self.ret_type != "APK":
+            return None
+
+        with AxmlReader(self._manifest) as axml:
+            root = axml.get_xml_tree()
+
+            return root.findall("application/provider")
+
+    @property
     @abstractmethod
     def android_apis(self) -> Set[MethodObject]:
         """

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -154,7 +154,7 @@ class Receiver:
         return str(exported).lower() == 'true'
 
 
-class Providers:
+class Provider:
     def __init__(self, xml: XMLElement) -> None:
         self.xml: XMLElement = xml
 
@@ -165,7 +165,7 @@ class Providers:
         realAttributeName = (
             f"{{http://schemas.android.com/apk/res/android}}{attributeName}"
         )
-        return self.xml.get(realAttributeName, "")
+        return self.xml.get(realAttributeName, None)
 
     def isExported(self) -> bool:
         """Check if the provider element set ``android:exported=true``.
@@ -656,7 +656,7 @@ def getApplication(samplePath: PathLike) -> Application:
     return Application(apkinfo.application)
 
 
-def getProviders(samplePath: PathLike) -> List[Receiver]:
+def getProviders(samplePath: PathLike) -> List[Provider]:
     """Get provider elements from the manifest file of the target sample.
 
     :param samplePath: the file path of target sample
@@ -665,7 +665,7 @@ def getProviders(samplePath: PathLike) -> List[Receiver]:
     quark = _getQuark(samplePath)
     apkinfo = quark.apkinfo
 
-    return [Providers(xml) for xml in apkinfo.providers]
+    return [Provider(xml) for xml in apkinfo.providers]
 
 
 def findMethodInAPK(

--- a/quark/script/__init__.py
+++ b/quark/script/__init__.py
@@ -154,6 +154,28 @@ class Receiver:
         return str(exported).lower() == 'true'
 
 
+class Providers:
+    def __init__(self, xml: XMLElement) -> None:
+        self.xml: XMLElement = xml
+
+    def __str__(self) -> str:
+        return self._getAttribute("name")
+
+    def _getAttribute(self, attributeName: str) -> Any:
+        realAttributeName = (
+            f"{{http://schemas.android.com/apk/res/android}}{attributeName}"
+        )
+        return self.xml.get(realAttributeName, "")
+
+    def isExported(self) -> bool:
+        """Check if the provider element set ``android:exported=true``.
+
+        :return: True/False
+        """
+        exported = self._getAttribute("exported")
+        return exported
+
+
 class Method:
     def __init__(
         self,
@@ -632,6 +654,18 @@ def getApplication(samplePath: PathLike) -> Application:
     apkinfo = quark.apkinfo
 
     return Application(apkinfo.application)
+
+
+def getProviders(samplePath: PathLike) -> List[Receiver]:
+    """Get provider elements from the manifest file of the target sample.
+
+    :param samplePath: the file path of target sample
+    :return: python list containing provider elements
+    """
+    quark = _getQuark(samplePath)
+    apkinfo = quark.apkinfo
+
+    return [Providers(xml) for xml in apkinfo.providers]
 
 
 def findMethodInAPK(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,13 @@ SAMPLES = [
             "/raw/master/vulnerable-samples/pivaa.apk"
         ),
         "fileName": "pivaa.apk"
+    },
+    {
+        "sourceUrl": (
+            "https://github.com/quark-engine/apk-samples"
+            "/raw/master/vulnerable-samples/Vuldroid.apk"
+        ),
+        "fileName": "Vuldroid.apk"
     }
 ]
 
@@ -74,3 +81,7 @@ def SAMPLE_PATH_Ahmyth(tmp_path_factory: pytest.TempPathFactory) -> str:
 @pytest.fixture(scope="session")
 def SAMPLE_PATH_pivaa(tmp_path_factory: pytest.TempPathFactory) -> str:
     return downloadSample(tmp_path_factory, SAMPLES[3])
+
+@pytest.fixture(scope="session")
+def SAMPLE_PATH_Vuldroid(tmp_path_factory: pytest.TempPathFactory) -> str:
+    return downloadSample(tmp_path_factory, SAMPLES[4])

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -750,7 +750,7 @@ def apkinfoPivaa(request, SAMPLE_PATH_pivaa, dex_file):
 
     yield apkinfo
 
-class AnotherTestApkinfo:
+class TestAnotherApkinfo:
     @staticmethod
     def test_providers(apkinfoPivaa):
         match apkinfo.ret_type:

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -31,20 +31,22 @@ def dex_file(SAMPLE_PATH_13667):
 
 
 @pytest.fixture(scope="session")
-def dex_file_pivaa(SAMPLE_PATH_pivaa):
+def dex_file_pivaa(tmp_path_factory, SAMPLE_PATH_pivaa):
     APK_NAME = SAMPLE_PATH_pivaa
     DEX_NAME = "classes.dex"
+    DEX_DIR = tmp_path_factory.mktemp("dex_pivaa")
+    DEX_PATH = str(os.path.join(DEX_DIR, "classes.dex"))
 
     with zipfile.ZipFile(APK_NAME, "r") as zip:
-        zip.extract(DEX_NAME)
+        zip.extract(DEX_NAME, path=DEX_DIR)
 
-    yield DEX_NAME
+    yield DEX_PATH
 
-    if os.path.exists(DEX_NAME):
-        os.remove(DEX_NAME)
+    if os.path.exists(DEX_PATH):
+        os.remove(DEX_PATH)
 
-    if os.path.exists(APK_NAME):
-        os.remove(APK_NAME)
+    if os.path.exists(DEX_PATH):
+        os.remove(DEX_PATH)
 
 
 def __generateTestIDs(testInput: Tuple[BaseApkinfo, Literal["DEX", "APK"]]):

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -80,6 +80,32 @@ def apkinfo_with_R2Imp_only(request, SAMPLE_PATH_13667, dex_file):
     yield apkinfo
 
 
+@pytest.fixture(
+    scope="function",
+    params=(
+        (AndroguardImp, "DEX"),
+        (AndroguardImp, "APK"),
+        (RizinImp, "DEX"),
+        (RizinImp, "APK"),
+        (R2Imp, "DEX"),
+        (R2Imp, "APK"),
+        (ShurikenImp, "DEX"),
+        (ShurikenImp, "APK"),
+    ),
+    ids=__generateTestIDs,
+)
+def apkinfoPivaa(request, SAMPLE_PATH_pivaa, dex_file_pivaa):
+    apkinfoClass, fileType = request.param
+
+    fileToBeAnalyzed = SAMPLE_PATH_pivaa
+    if fileType == "DEX":
+        fileToBeAnalyzed = dex_file_pivaa
+
+    apkinfo = apkinfoClass(fileToBeAnalyzed)
+
+    yield apkinfo
+
+
 class TestApkinfo:
     def test_init_with_invalid_type(self):
         filepath = None
@@ -206,6 +232,22 @@ class TestApkinfo:
                         "{http://schemas.android.com/apk/res/android}name"
                     )
                     == "com.example.google.service.MyDeviceAdminReceiver"
+                )
+
+    @staticmethod
+    def test_providers(apkinfoPivaa):
+        match apkinfoPivaa.ret_type:
+            case "DEX":
+                assert apkinfoPivaa.providers is None
+            case "APK":
+                providers= apkinfoPivaa.providers
+
+                assert len(providers) == 1
+                assert (
+                    providers[0].get(
+                        "{http://schemas.android.com/apk/res/android}name"
+                    )
+                    == "com.htbridge.pivaa.handlers.VulnerableContentProvider"
                 )
 
     def test_android_apis(self, apkinfo):
@@ -739,45 +781,3 @@ def dex_file_pivaa(SAMPLE_PATH_pivaa):
 
     if os.path.exists(APK_NAME):
         os.remove(APK_NAME)
-
-@pytest.fixture(
-    scope="function",
-    params=(
-        (AndroguardImp, "DEX"),
-        (AndroguardImp, "APK"),
-        (RizinImp, "DEX"),
-        (RizinImp, "APK"),
-        (R2Imp, "DEX"),
-        (R2Imp, "APK"),
-        (ShurikenImp, "DEX"),
-        (ShurikenImp, "APK"),
-    ),
-    ids=__generateTestIDs,
-)
-def apkinfoPivaa(request, SAMPLE_PATH_pivaa, dex_file_pivaa):
-    apkinfoClass, fileType = request.param
-
-    fileToBeAnalyzed = SAMPLE_PATH_pivaa
-    if fileType == "DEX":
-        fileToBeAnalyzed = dex_file_pivaa
-
-    apkinfo = apkinfoClass(fileToBeAnalyzed)
-
-    yield apkinfo
-
-class TestAnotherApkinfo:
-    @staticmethod
-    def test_providers(apkinfoPivaa):
-        match apkinfoPivaa.ret_type:
-            case "DEX":
-                assert apkinfoPivaa.providers is None
-            case "APK":
-                providers= apkinfoPivaa.providers
-
-                assert len(providers) == 1
-                assert (
-                    providers[0].get(
-                        "{http://schemas.android.com/apk/res/android}name"
-                    )
-                    == "com.htbridge.pivaa.handlers.VulnerableContentProvider"
-                )

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -724,6 +724,21 @@ class TestApkinfo:
         for key, expected in expected_result.items():
             assert result[key] == expected
 
+@pytest.fixture(scope="session")
+def dex_file_pivaa(SAMPLE_PATH_pivaa):
+    APK_NAME = SAMPLE_PATH_pivaa
+    DEX_NAME = "classes.dex"
+
+    with zipfile.ZipFile(APK_NAME, "r") as zip:
+        zip.extract(DEX_NAME)
+
+    yield DEX_NAME
+
+    if os.path.exists(DEX_NAME):
+        os.remove(DEX_NAME)
+
+    if os.path.exists(APK_NAME):
+        os.remove(APK_NAME)
 
 @pytest.fixture(
     scope="function",
@@ -739,12 +754,12 @@ class TestApkinfo:
     ),
     ids=__generateTestIDs,
 )
-def apkinfoPivaa(request, SAMPLE_PATH_pivaa, dex_file):
+def apkinfoPivaa(request, SAMPLE_PATH_pivaa, dex_file_pivaa):
     apkinfoClass, fileType = request.param
 
     fileToBeAnalyzed = SAMPLE_PATH_pivaa
     if fileType == "DEX":
-        fileToBeAnalyzed = dex_file
+        fileToBeAnalyzed = dex_file_pivaa
 
     apkinfo = apkinfoClass(fileToBeAnalyzed)
 
@@ -753,7 +768,7 @@ def apkinfoPivaa(request, SAMPLE_PATH_pivaa, dex_file):
 class TestAnotherApkinfo:
     @staticmethod
     def test_providers(apkinfoPivaa):
-        match apkinfo.ret_type:
+        match apkinfoPivaa.ret_type:
             case "DEX":
                 assert apkinfoPivaa.providers is None
             case "APK":

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -30,6 +30,23 @@ def dex_file(SAMPLE_PATH_13667):
         os.remove(APK_NAME)
 
 
+@pytest.fixture(scope="session")
+def dex_file_pivaa(SAMPLE_PATH_pivaa):
+    APK_NAME = SAMPLE_PATH_pivaa
+    DEX_NAME = "classes.dex"
+
+    with zipfile.ZipFile(APK_NAME, "r") as zip:
+        zip.extract(DEX_NAME)
+
+    yield DEX_NAME
+
+    if os.path.exists(DEX_NAME):
+        os.remove(DEX_NAME)
+
+    if os.path.exists(APK_NAME):
+        os.remove(APK_NAME)
+
+
 def __generateTestIDs(testInput: Tuple[BaseApkinfo, Literal["DEX", "APK"]]):
     return f"{testInput[0].__name__} with {testInput[1]}"
 
@@ -765,19 +782,3 @@ class TestApkinfo:
 
         for key, expected in expected_result.items():
             assert result[key] == expected
-
-@pytest.fixture(scope="session")
-def dex_file_pivaa(SAMPLE_PATH_pivaa):
-    APK_NAME = SAMPLE_PATH_pivaa
-    DEX_NAME = "classes.dex"
-
-    with zipfile.ZipFile(APK_NAME, "r") as zip:
-        zip.extract(DEX_NAME)
-
-    yield DEX_NAME
-
-    if os.path.exists(DEX_NAME):
-        os.remove(DEX_NAME)
-
-    if os.path.exists(APK_NAME):
-        os.remove(APK_NAME)

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -723,3 +723,46 @@ class TestApkinfo:
 
         for key, expected in expected_result.items():
             assert result[key] == expected
+
+
+@pytest.fixture(
+    scope="function",
+    params=(
+        (AndroguardImp, "DEX"),
+        (AndroguardImp, "APK"),
+        (RizinImp, "DEX"),
+        (RizinImp, "APK"),
+        (R2Imp, "DEX"),
+        (R2Imp, "APK"),
+        (ShurikenImp, "DEX"),
+        (ShurikenImp, "APK"),
+    ),
+    ids=__generateTestIDs,
+)
+def apkinfoPivaa(request, SAMPLE_PATH_pivaa, dex_file):
+    apkinfoClass, fileType = request.param
+
+    fileToBeAnalyzed = SAMPLE_PATH_pivaa
+    if fileType == "DEX":
+        fileToBeAnalyzed = dex_file
+
+    apkinfo = apkinfoClass(fileToBeAnalyzed)
+
+    yield apkinfo
+
+class AnotherTestApkinfo:
+    @staticmethod
+    def test_providers(apkinfoPivaa):
+        match apkinfo.ret_type:
+            case "DEX":
+                assert apkinfoPivaa.providers is None
+            case "APK":
+                providers= apkinfoPivaa.providers
+
+                assert len(providers) == 1
+                assert (
+                    providers[0].get(
+                        "{http://schemas.android.com/apk/res/android}name"
+                    )
+                    == "com.htbridge.pivaa.handlers.VulnerableContentProvider"
+                )

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -15,6 +15,7 @@ from quark.script import (
     getActivities,
     getReceivers,
     getApplication,
+    getProviders,
     runQuarkAnalysis,
     findMethodInAPK,
     findMethodImpls,
@@ -132,6 +133,16 @@ class TestReceiver:
         receiver = getReceivers(SAMPLE_PATH_13667)[0]
         assert receiver.isExported() is True
 
+class TestProvider:
+    @staticmethod
+    def testIsNotExported(SAMPLE_PATH_Vuldroid):
+        provider = getProviders(SAMPLE_PATH_Vuldroid)[0]
+        assert provider.isExported() is False
+
+    @staticmethod
+    def testIsExported(SAMPLE_PATH_pivaa):
+        provider = getProviders(SAMPLE_PATH_pivaa)[0]
+        assert provider.isExported() is True
 
 class TestMethod:
     @staticmethod


### PR DESCRIPTION
The following three APIs are added to detect [CWE-359](https://cwe.mitre.org/data/definitions/359.html):

## Quark Core API

### BaseApkinfo.providers(self)
+ Description: Get provider elements from the manifest file.
+ return: python list containing provider elements 



## Quark Script API


### getProviders(samplePath)
+ Description: Get provider elements from the manifest file of the target sample.
+ params:
    1. samplePath: the file path of target sample
+ return: python list containing provider elements 

### providerInstance.isExported(none)

+ Description: Check if the provider element set ``android:exported=true``.
+ params: none
+ return: True/False
