### PR TITLE
Add freshquark command to installation instructions

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -13,6 +13,10 @@ Install from Source::
     $ pipenv install --skip-lock
     $ pipenv shell
 
+Download the latest rules::
+
+    $ freshquark
+
 Run the help cmd of quark::
 
     $ quark --help


### PR DESCRIPTION
For newcomers it might not be obvious how to get the rules. Previously, if they followed the install guide and tried to analyze an APK, they were presented with the following error:
`Path '/<path>/.quark-engine/quark-rules/rules' does not exist.`