### PR TITLE
Fix CI failing due to missing `auto_fix_checksum` in BaseApkinfo object

### DIFF
--- a/quark/core/interface/baseapkinfo.py
+++ b/quark/core/interface/baseapkinfo.py
@@ -31,6 +31,7 @@ class BaseApkinfo:
         "data",
         "isPatched",
         "_manifest",
+        "auto_fix_checksum",
     ]
 
     def __init__(


### PR DESCRIPTION
Fix #878 .