### PR TITLE
feat: Phase 5 dynamic string resolution via DexTrace

### DIFF
--- a/quark/cli.py
+++ b/quark/cli.py
@@ -151,8 +151,18 @@ logo()
 )
 @click.option(
     "--auto-fix-checksum",
-    help="Automatically repair damaged DEX checksum/signature before analyzing (androguard only)." + 
+    help="Automatically repair damaged DEX checksum/signature before analyzing (androguard only)." +
     "When not provided, Quark will prompt in interactive TTY and skip in non-interactive runs.",
+    is_flag=True,
+    default=False,
+    show_default=True,
+)
+@click.option(
+    "--dynamic-resolve",
+    "dynamic_resolve",
+    help="Enable dynamic string resolution via DexTrace. Executes encrypted "
+         "string methods at analysis time to recover plaintext for Phase 5 "
+         "keyword matching. Requires: pip install quark-engine[dynamic].",
     is_flag=True,
     default=False,
     show_default=True,
@@ -175,6 +185,7 @@ def entry_point(
     core_library,
     num_of_process,
     auto_fix_checksum,
+    dynamic_resolve,
 ):
     """Quark is an Obfuscation-Neglect Android Malware Scoring System"""
     # Load rules
@@ -238,7 +249,7 @@ def entry_point(
             data = (
                 ParallelQuark(apk_, core_library, num_of_process, auto_fix_checksum)
                 if num_of_process > 1
-                else Quark(apk_, core_library, auto_fix_checksum)
+                else Quark(apk_, core_library, auto_fix_checksum, dynamic_resolve=dynamic_resolve)
             )
             all_labels = {}
             # dictionary containing
@@ -295,7 +306,7 @@ def entry_point(
     data = (
         ParallelQuark(apk[0], core_library, num_of_process, auto_fix_checksum)
         if num_of_process > 1
-        else Quark(apk[0], core_library, auto_fix_checksum)
+        else Quark(apk[0], core_library, auto_fix_checksum, dynamic_resolve=dynamic_resolve)
     )
 
     if label:

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -247,7 +247,7 @@ def entry_point(
         malware_confidences = {}
         for apk_ in apk:
             data = (
-                ParallelQuark(apk_, core_library, num_of_process, auto_fix_checksum)
+                ParallelQuark(apk_, core_library, num_of_process, auto_fix_checksum, dynamic_resolve)
                 if num_of_process > 1
                 else Quark(apk_, core_library, auto_fix_checksum, dynamic_resolve=dynamic_resolve)
             )
@@ -304,7 +304,7 @@ def entry_point(
 
     # Load APK
     data = (
-        ParallelQuark(apk[0], core_library, num_of_process, auto_fix_checksum)
+        ParallelQuark(apk[0], core_library, num_of_process, auto_fix_checksum, dynamic_resolve)
         if num_of_process > 1
         else Quark(apk[0], core_library, auto_fix_checksum, dynamic_resolve=dynamic_resolve)
     )

--- a/quark/core/parallelquark.py
+++ b/quark/core/parallelquark.py
@@ -13,9 +13,9 @@ _quark = None
 
 class ParallelQuark(Quark):
     @staticmethod
-    def _worker_initializer(apk, core_library, auto_fix_checksum):
+    def _worker_initializer(apk, core_library, auto_fix_checksum, dynamic_resolve):
         global _quark
-        _quark = Quark(apk, core_library, auto_fix_checksum)
+        _quark = Quark(apk, core_library, auto_fix_checksum, dynamic_resolve=dynamic_resolve)
 
     @staticmethod
     def _worker_analysis(rule_obj):
@@ -112,14 +112,14 @@ class ParallelQuark(Quark):
                 ]
             )
 
-    def __init__(self, apk, core_library, num_of_process=1, auto_fix_checksum=False):
+    def __init__(self, apk, core_library, num_of_process=1, auto_fix_checksum=False, dynamic_resolve=False):
         self._result_map = {}
         self._pool = Pool(
             min(num_of_process, cpu_count() - 1), self._worker_initializer,
-            (apk, core_library, auto_fix_checksum)
+            (apk, core_library, auto_fix_checksum, dynamic_resolve)
         )
 
-        super().__init__(apk, core_library)
+        super().__init__(apk, core_library, auto_fix_checksum, dynamic_resolve=dynamic_resolve)
 
     def apply_rules(self, rule_obj_list):
         for rule_obj in rule_obj_list:

--- a/quark/core/parallelquark.py
+++ b/quark/core/parallelquark.py
@@ -6,7 +6,8 @@ from multiprocessing.pool import Pool
 from multiprocessing import cpu_count
 
 from quark.core.analysis import QuarkAnalysis
-from quark.core.quark import Quark
+from quark.core.quark import Quark, _DEXTRACE_AVAILABLE
+from quark.utils.pprint import print_warning
 
 _quark = None
 
@@ -113,6 +114,13 @@ class ParallelQuark(Quark):
             )
 
     def __init__(self, apk, core_library, num_of_process=1, auto_fix_checksum=False, dynamic_resolve=False):
+        if dynamic_resolve and not _DEXTRACE_AVAILABLE:
+            print_warning(
+                "dynamic_resolve=True but the 'dextrace' package is not installed. "
+                "Dynamic string resolution will be skipped. "
+                "Install it with: pip install dextrace"
+            )
+            dynamic_resolve = False
         self._result_map = {}
         self._pool = Pool(
             min(num_of_process, cpu_count() - 1), self._worker_initializer,

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -2,11 +2,16 @@
 # This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
 # See the file 'LICENSE' for copying permission.
 
+import concurrent.futures
+import functools
+import logging
+import time
 from itertools import product
 import operator
 import os
 import re
-from typing import Any, Generator, List, Mapping, Sequence, Tuple
+from pathlib import Path
+from typing import Any, Generator, List, Mapping, Optional, Sequence, Tuple
 
 import numpy as np
 import csv
@@ -39,6 +44,120 @@ from quark.utils.output import (
 )
 from quark.utils.pprint import print_info, print_success, print_warning
 from quark.utils.weight import Weight
+from quark import config
+from quark.utils.logger import defaultHandler
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+log.addHandler(defaultHandler)
+log.disabled = not config.DEBUG
+
+try:
+    from dextrace.api import execute_method as _dextrace_execute  # type: ignore
+    _DEXTRACE_AVAILABLE = True
+except ImportError:
+    _DEXTRACE_AVAILABLE = False
+
+
+@functools.lru_cache(maxsize=512)
+def _dextrace_cached(apk_path: str, sig: str) -> Optional[str]:
+    log.debug("dynamic_resolve: executing %s (cache miss)", sig)
+    result = _dextrace_execute(apk_path, sig, args=[])
+    return str(result) if result is not None else None
+
+
+def _resolveStringCalls(
+    methodCall: MethodCall,
+    apk_path: str,
+    apkinfo=None,
+    parentMethod=None,
+    *,
+    total_timeout_s: float = 10.0,
+) -> Generator[str, None, None]:
+    norm_path = str(Path(apk_path).resolve())
+    deadline = time.monotonic() + total_timeout_s
+    found_any = False
+
+    # Phase 1: prior calls of methodCall (covers cases where the encryption
+    # function is called inside the same frame as the target API call).
+    for priorCall in iteratePriorCalls(methodCall):
+        if time.monotonic() >= deadline:
+            log.debug(
+                "dynamic_resolve: total timeout (%.1fs) reached, remaining candidates skipped",
+                total_timeout_s,
+            )
+            return
+        sig: str = priorCall.method
+        if not sig.endswith(")Ljava/lang/String;"):
+            continue
+        resolved = _dextrace_cached(norm_path, sig)
+        if resolved is not None:
+            log.debug("dynamic_resolve: %s -> %r", sig, resolved)
+            found_any = True
+            yield resolved
+        else:
+            log.debug("dynamic_resolve: %s -> None", sig)
+
+    if found_any or apkinfo is None or parentMethod is None:
+        return
+
+    # Phase 2: the encryption function is called in a CALLER of parentMethod
+    # (the parent method receives the plaintext as a parameter). Scan all
+    # callers of parentMethod and execute any String-returning MethodCalls
+    # that appear in their value graphs.
+    log.debug(
+        "dynamic_resolve: Phase 1 empty — scanning callers of %s", parentMethod
+    )
+    seen_sigs: set = set()
+    try:
+        callers = apkinfo.upperfunc(parentMethod) or set()
+    except Exception:
+        return
+
+    for caller in callers:
+        if time.monotonic() >= deadline:
+            log.debug(
+                "dynamic_resolve: total timeout (%.1fs) reached during caller scan",
+                total_timeout_s,
+            )
+            return
+        try:
+            caller_pyeval = PyEval(apkinfo)
+            for bytecode_obj in apkinfo.get_method_bytecode(caller):
+                instruction = [bytecode_obj.mnemonic]
+                if bytecode_obj.registers is not None:
+                    instruction.extend(bytecode_obj.registers)
+                if bytecode_obj.parameter is not None:
+                    instruction.append(bytecode_obj.parameter)
+                instruction = [str(x) for x in instruction]
+                if instruction[0] in caller_pyeval.eval:
+                    caller_pyeval.eval[instruction[0]](instruction)
+
+            table = caller_pyeval.show_table()
+            for register_list in table.values():
+                for reg_obj in register_list:
+                    for call_node in reg_obj.iterateInvolvedCalls():
+                        sig = call_node.method
+                        if sig in seen_sigs or not sig.endswith(
+                            ")Ljava/lang/String;"
+                        ):
+                            continue
+                        seen_sigs.add(sig)
+                        if time.monotonic() >= deadline:
+                            return
+                        resolved = _dextrace_cached(norm_path, sig)
+                        if resolved is not None:
+                            log.debug(
+                                "dynamic_resolve (caller scan): %s -> %r",
+                                sig,
+                                resolved,
+                            )
+                            yield resolved
+        except Exception as exc:
+            log.debug(
+                "dynamic_resolve: error scanning caller %s: %s", caller, exc
+            )
+
 
 MAX_SEARCH_LAYER = 3
 
@@ -46,12 +165,22 @@ MAX_SEARCH_LAYER = 3
 class Quark:
     """Quark module is used to check quark's five-stage theory"""
 
-    def __init__(self, apk, core_library="androguard", auto_fix_checksum=False):
+    def __init__(self, apk, core_library="androguard", auto_fix_checksum=False, dynamic_resolve=False):
         """
 
         :param apk: the filename of the apk.
+        :param dynamic_resolve: if True, Phase 5 keyword matching will attempt to
+            resolve encrypted strings by executing method calls with DexTrace.
+            Requires the ``dextrace`` package to be installed. Opt-in; default False.
         """
         self.auto_fix_checksum = auto_fix_checksum
+        self._dynamic_resolve = dynamic_resolve
+        if dynamic_resolve and not _DEXTRACE_AVAILABLE:
+            print_warning(
+                "dynamic_resolve=True but the 'dextrace' package is not installed. "
+                "Dynamic string resolution will be skipped. "
+                "Install it with: pip install dextrace"
+            )
 
         core_library = core_library.lower()
         if core_library == "shuriken":
@@ -238,6 +367,7 @@ class Quark:
         firstMethodKeywords: Sequence | None = None,
         secondMethodKeywords: Sequence | None = None,
         regex: bool = False,
+        parentMethod=None,
     ) -> Generator[Tuple[Tuple[MethodCall, MethodCall], List[str]], None, None]:
         """Check the usage of the same parameter between two methods.
 
@@ -249,6 +379,8 @@ class Quark:
         :param secondMethodKeywords: keywords to match for the second method,
         defaults to None
         :param regex: treat keywords as regular expressions, defaults to False
+        :param parentMethod: the method containing firstMethod/secondMethod calls;
+        forwarded to getMatchedKeywords for dynamic caller-frame resolution.
         :yield: a tuple of matched method call pairs and matched keywords
         """
         # Find the first and second method call that share same register
@@ -278,14 +410,16 @@ class Quark:
             if firstMethodKeywords is not None:
                 # Check if arguments of the first call match any keywords.
                 first_matched = self.getMatchedKeywords(
-                    firstCall, firstMethodKeywords, regex=regex
+                    firstCall, firstMethodKeywords, regex=regex,
+                    parentMethod=parentMethod,
                 )
                 matchedKeywords.extend(first_matched)
 
             if secondMethodKeywords is not None:
                 # Check if arguments of the second call match any keywords.
                 second_matched = self.getMatchedKeywords(
-                    secondCall, secondMethodKeywords, regex=regex
+                    secondCall, secondMethodKeywords, regex=regex,
+                    parentMethod=parentMethod,
                 )
                 matchedKeywords.extend(second_matched)
 
@@ -338,6 +472,7 @@ class Quark:
                 first_method_keywords,
                 second_method_keywords,
                 regex,
+                parentMethod=parent_method,
             )
 
             found = next(results, None) is not None
@@ -373,22 +508,43 @@ class Quark:
 
         return state
 
-    @staticmethod
     def getMatchedKeywords(
-        methodCall: MethodCall, keywords: Sequence, regex: bool
+        self, methodCall: MethodCall, keywords: Sequence, regex: bool,
+        parentMethod=None,
     ) -> List[str]:
         """Get matched keywords from the parameters of a method call.
 
-        :param method_call: the method call to be checked
+        :param methodCall: the method call to be checked
         :param keywords: keywords to be matched
         :param regex: whether to treat keywords as regular expressions
-        :yield: a list of matched keywords
+        :param parentMethod: the method that contains methodCall; used by the
+            dynamic resolver to scan callers when the encryption function is
+            invoked in a higher frame (optional).
+        :return: a list of matched keywords
         """
         matchedStrSet = set()
         primitiveValues = {
             str(primitive.value)
             for primitive in iteratePriorPrimitives(methodCall)
         }
+
+        # Phase 5 dynamic fallback: run DexTrace when static primitives are
+        # absent or all empty strings (Primitive('') represents unknown
+        # parameter values in the value graph — not useful for keyword matching).
+        has_meaningful_primitives = any(pv for pv in primitiveValues if pv)
+        if not has_meaningful_primitives and self._dynamic_resolve and _DEXTRACE_AVAILABLE:
+            apk_path = self.apkinfo.apk_filepath
+            log.debug(
+                "dynamic_resolve: no meaningful static primitives for %s, trying DexTrace",
+                getattr(methodCall, "method", methodCall),
+            )
+            for resolved in _resolveStringCalls(
+                methodCall,
+                apk_path,
+                apkinfo=self.apkinfo,
+                parentMethod=parentMethod,
+            ):
+                primitiveValues.add(resolved)
 
         if not regex:
             return [

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -159,6 +159,24 @@ def _resolveStringCalls(
             )
 
 
+def _match_keywords(values: set, keywords: Sequence, regex: bool) -> list:
+    if not regex:
+        return [v for v in values if any(kw in v for kw in keywords)]
+    matched: set = set()
+    for keyword in keywords:
+        pattern = re.compile(keyword)
+        for value in values:
+            found = pattern.findall(value)
+            if not any(found):
+                continue
+            if isinstance(found[0], tuple):
+                for t in found:
+                    matched.update(filter(bool, t))
+            else:
+                matched.update(filter(bool, found))
+    return [e for e in matched if e]
+
+
 MAX_SEARCH_LAYER = 3
 
 
@@ -522,20 +540,18 @@ class Quark:
             invoked in a higher frame (optional).
         :return: a list of matched keywords
         """
-        matchedStrSet = set()
         primitiveValues = {
             str(primitive.value)
             for primitive in iteratePriorPrimitives(methodCall)
         }
 
-        # Phase 5 dynamic fallback: run DexTrace when static primitives are
-        # absent or all empty strings (Primitive('') represents unknown
-        # parameter values in the value graph — not useful for keyword matching).
-        has_meaningful_primitives = any(pv for pv in primitiveValues if pv)
-        if not has_meaningful_primitives and self._dynamic_resolve and _DEXTRACE_AVAILABLE:
+        results = _match_keywords(primitiveValues, keywords, regex)
+
+        # Phase 5 dynamic fallback: only when static matching finds nothing
+        if not results and self._dynamic_resolve and _DEXTRACE_AVAILABLE:
             apk_path = self.apkinfo.apk_filepath
             log.debug(
-                "dynamic_resolve: no meaningful static primitives for %s, trying DexTrace",
+                "dynamic_resolve: no static keyword matches for %s, trying DexTrace",
                 getattr(methodCall, "method", methodCall),
             )
             for resolved in _resolveStringCalls(
@@ -545,30 +561,9 @@ class Quark:
                 parentMethod=parentMethod,
             ):
                 primitiveValues.add(resolved)
+            results = _match_keywords(primitiveValues, keywords, regex)
 
-        if not regex:
-            return [
-                value
-                for value in primitiveValues
-                if any(kw in value for kw in keywords)
-            ]
-
-        for keyword in keywords:
-            regexPattern = re.compile(keyword)
-
-            for value in primitiveValues:
-                matchedStrings = regexPattern.findall(value)
-                if not any(matchedStrings):
-                    continue
-
-                # Filter out empty strings from tuples in the result
-                if isinstance(matchedStrings[0], tuple):
-                    for matchTuple in matchedStrings:
-                        matchedStrSet.update(filter(bool, matchTuple))
-                else:
-                    matchedStrSet.update(filter(bool, matchedStrings))
-
-        return [e for e in list(matchedStrSet) if bool(e)]
+        return results
 
     def find_api_usage(self, class_name, method_name, descriptor_name):
         method_list = []

--- a/setup.py
+++ b/setup.py
@@ -60,5 +60,6 @@ setuptools.setup(
     install_requires=required_requirements,
     extras_require={
         "QuarkAgent": quarkAgentRequirements,
+        "dynamic": ["dextrace"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ required_requirements = [
     "click",
     "r2pipe==1.8.0",
     "pathvalidate==3.2.3",
+    "dextrace",
 ]
 
 quarkAgentRequirements = [
@@ -60,6 +61,5 @@ setuptools.setup(
     install_requires=required_requirements,
     extras_require={
         "QuarkAgent": quarkAgentRequirements,
-        "dynamic": ["dextrace"],
     },
 )

--- a/tests/core/test_parallelquark.py
+++ b/tests/core/test_parallelquark.py
@@ -9,10 +9,11 @@ from quark.core.parallelquark import ParallelQuark
 
 def test_parallel_quark_forwards_dynamic_resolve():
     with patch("quark.core.parallelquark.Pool") as mock_pool, \
-         patch("quark.core.parallelquark.Quark.__init__", return_value=None):
+         patch("quark.core.parallelquark.Quark.__init__", return_value=None), \
+         patch("quark.core.parallelquark._DEXTRACE_AVAILABLE", True):
         ParallelQuark("fake.apk", "androguard", num_of_process=2, dynamic_resolve=True)
         initargs = mock_pool.call_args[0][2]
-        assert initargs[-1] is True
+        assert initargs == ("fake.apk", "androguard", False, True)
 
 
 def test_parallel_quark_dynamic_resolve_defaults_false():
@@ -20,4 +21,13 @@ def test_parallel_quark_dynamic_resolve_defaults_false():
          patch("quark.core.parallelquark.Quark.__init__", return_value=None):
         ParallelQuark("fake.apk", "androguard", num_of_process=2)
         initargs = mock_pool.call_args[0][2]
-        assert initargs[-1] is False
+        assert initargs == ("fake.apk", "androguard", False, False)
+
+
+def test_parallel_quark_warns_once_when_dextrace_unavailable():
+    with patch("quark.core.parallelquark.Pool"), \
+         patch("quark.core.parallelquark.Quark.__init__", return_value=None), \
+         patch("quark.core.parallelquark._DEXTRACE_AVAILABLE", False), \
+         patch("quark.core.parallelquark.print_warning") as mock_warn:
+        ParallelQuark("fake.apk", "androguard", num_of_process=2, dynamic_resolve=True)
+        assert mock_warn.call_count == 1

--- a/tests/core/test_parallelquark.py
+++ b/tests/core/test_parallelquark.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
+# See the file 'LICENSE' for copying permission.
+
+from unittest.mock import patch
+
+from quark.core.parallelquark import ParallelQuark
+
+
+def test_parallel_quark_forwards_dynamic_resolve():
+    with patch("quark.core.parallelquark.Pool") as mock_pool, \
+         patch("quark.core.parallelquark.Quark.__init__", return_value=None):
+        ParallelQuark("fake.apk", "androguard", num_of_process=2, dynamic_resolve=True)
+        initargs = mock_pool.call_args[0][2]
+        assert initargs[-1] is True
+
+
+def test_parallel_quark_dynamic_resolve_defaults_false():
+    with patch("quark.core.parallelquark.Pool") as mock_pool, \
+         patch("quark.core.parallelquark.Quark.__init__", return_value=None):
+        ParallelQuark("fake.apk", "androguard", num_of_process=2)
+        initargs = mock_pool.call_args[0][2]
+        assert initargs[-1] is False

--- a/tests/core/test_quark.py
+++ b/tests/core/test_quark.py
@@ -445,6 +445,78 @@ class TestQuark:
 
         assert result == ["content://call_log/calls"]
 
+    # --- dynamic_resolve tests (no network / no DexTrace needed) ---
+
+    def _make_method_call(self, primitive_value):
+        return MethodCall(
+            "Landroid/content/ContentResolver;->query"
+            "(Landroid/net/Uri;)Landroid/database/Cursor;",
+            (
+                MethodCall(
+                    "Landroid/net/Uri;->parse(Ljava/lang/String;)",
+                    (Primitive(primitive_value, "Ljava/lang/String;"),),
+                ),
+            ),
+        )
+
+    def test_dynamic_resolve_skipped_when_static_matches(self, simple_quark_obj):
+        simple_quark_obj._dynamic_resolve = True
+        method_call = self._make_method_call("content://sms")
+        with patch("quark.core.quark._DEXTRACE_AVAILABLE", True), \
+             patch("quark.core.quark._resolveStringCalls") as mock_dex:
+            result = simple_quark_obj.getMatchedKeywords(method_call, ("sms",), False)
+        mock_dex.assert_not_called()
+        assert result == ["content://sms"]
+
+    def test_dynamic_resolve_called_when_static_misses(self, simple_quark_obj):
+        simple_quark_obj._dynamic_resolve = True
+        method_call = self._make_method_call("irrelevant")
+        with patch("quark.core.quark._DEXTRACE_AVAILABLE", True), \
+             patch("quark.core.quark._resolveStringCalls", return_value=["content://sms"]) as mock_dex:
+            result = simple_quark_obj.getMatchedKeywords(method_call, ("sms",), False)
+        mock_dex.assert_called_once()
+        assert result == ["content://sms"]
+
+    def test_dynamic_resolve_called_when_no_static_primitives(self, simple_quark_obj):
+        simple_quark_obj._dynamic_resolve = True
+        method_call = MethodCall(
+            "Landroid/content/ContentResolver;->query"
+            "(Landroid/net/Uri;)Landroid/database/Cursor;",
+            (),
+        )
+        with patch("quark.core.quark._DEXTRACE_AVAILABLE", True), \
+             patch("quark.core.quark._resolveStringCalls", return_value=["content://sms"]) as mock_dex:
+            result = simple_quark_obj.getMatchedKeywords(method_call, ("sms",), False)
+        mock_dex.assert_called_once()
+        assert result == ["content://sms"]
+
+    def test_dynamic_resolve_disabled_never_calls_dextrace(self, simple_quark_obj):
+        simple_quark_obj._dynamic_resolve = False
+        method_call = self._make_method_call("irrelevant")
+        with patch("quark.core.quark._DEXTRACE_AVAILABLE", True), \
+             patch("quark.core.quark._resolveStringCalls") as mock_dex:
+            result = simple_quark_obj.getMatchedKeywords(method_call, ("sms",), False)
+        mock_dex.assert_not_called()
+        assert result == []
+
+    def test_dynamic_resolve_regex_skipped_when_static_matches(self, simple_quark_obj):
+        simple_quark_obj._dynamic_resolve = True
+        method_call = self._make_method_call("sms_body")
+        with patch("quark.core.quark._DEXTRACE_AVAILABLE", True), \
+             patch("quark.core.quark._resolveStringCalls") as mock_dex:
+            result = simple_quark_obj.getMatchedKeywords(method_call, ("sms.*",), True)
+        mock_dex.assert_not_called()
+        assert result == ["sms_body"]
+
+    def test_dynamic_resolve_regex_called_when_static_misses(self, simple_quark_obj):
+        simple_quark_obj._dynamic_resolve = True
+        method_call = self._make_method_call("irrelevant")
+        with patch("quark.core.quark._DEXTRACE_AVAILABLE", True), \
+             patch("quark.core.quark._resolveStringCalls", return_value=["sms_body"]) as mock_dex:
+            result = simple_quark_obj.getMatchedKeywords(method_call, ("sms.*",), True)
+        mock_dex.assert_called_once()
+        assert result == ["sms_body"]
+
     def test_get_json_report(self, quark_obj):
         json_report = quark_obj.get_json_report()
         # Check if proper dict object


### PR DESCRIPTION
Add DexTrace-based dynamic string resolution to resolve encrypted strings for Phase 5 keyword matching. The false negative on bianlian APK (80% → 100% confidence) is the motivating case. 

> ⚠️ **Merge dependency:**
> This PR cannot be merged until the following tasks are completed:
> - [x] Merge [ev-flow/DexTrace#8](https://github.com/ev-flow/DexTrace/pull/8)
> - [x] Publish the updated DexTrace to PyPI

## How to Test

#### 1. Install DexTrace (development install)

```bash
git clone https://github.com/ev-flow/DexTrace.git
cd DexTrace
pip install -e .
```

#### 2. Install quark-engine with this branch

```bash
git clone git@github.com:haeter525/quark-engine.git
cd quark-engine
git checkout feat/phase5-dynamic-resolution
pip install -e .
```

#### 3. Download the sample APK

Download [bianlian.zip](https://github.com/haeter525/quark-engine/releases/download/bianlian-sample/bianlian.zip) (Password: **infected**) and extract `bianlian.apk`.

#### 4. Save the detection rule

Save the following as `auto_click_comfirm_button_on_dialog.json`:

```json
{
    "crime": "Auto click button on system dialog",
    "permission": [],
    "api": [
        {
            "class": "Landroid/view/accessibility/AccessibilityNodeInfo;",
            "method": "findAccessibilityNodeInfosByText",
            "descriptor": "(Ljava/lang/String;)Ljava/util/List;",
            "match_keywords": [
                "android:id/button1"
            ]
        },
        {
            "class": "Landroid/view/accessibility/AccessibilityNodeInfo;",
            "method": "performAction",
            "descriptor": "(I)Z"
        }
    ],
    "score": 10,
    "label": ["sms", "calllog", "collection"]
}
```

#### 5. Run — compare static vs dynamic

The sample first **calls** the method `dilemmaexact()` to compute a string, then **takes** it as the 2nd **argument** to call the `findButtonAndClick` method:

<img width="1024" height="202" alt="截圖 2026-05-20 21 08 40" src="https://github.com/user-attachments/assets/24620663-f752-426e-aa2b-72b97565c319" />

The method then calls the first API `findAccessibilityNodeInfosByText` with this string to locate a button on the system dialog:

<img width="1024" alt="截圖 2026-05-20 21 09 29" src="https://github.com/user-attachments/assets/8021bf5a-fdf3-44f7-a86f-90f3e8b15e62" />

##### Quark Analysis Without `--dynamic-resolve` (static only)
```bash
quark -a bianlian.apk -s auto_click_comfirm_button_on_dialog.json
```
<img width="1024" alt="截圖 2026-05-17 16 28 35" src="https://github.com/user-attachments/assets/708f3a37-c669-4d82-872d-88fe2ecf5d37" />

Since the string is dynamically computed, the Quark rule above cannot fully detect this behavior, resulting in an **80%** confidence score.

##### Quark Analysis With `--dynamic-resolve`
```bash
quark -a bianlian.apk -s auto_click_comfirm_button_on_dialog.json --dynamic-resolve
```
<img width="1024" alt="截圖 2026-05-17 16 26 53" src="https://github.com/user-attachments/assets/5849f7da-481d-4589-b84d-6a1059edf71d" />

With the dynamic string resolution feature, Quark successfully resolves the string from the `dilemmaexact()` method and identifies the target behavior with **100%** confidence.
