### PR TITLE
ci: drop Shuriken-Analyzer build from CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -60,10 +60,6 @@ jobs:
         sh install.sh -y
         cargo install project_ares@0.10.0
 
-    - name: Install Shuriken-Analyzer
-      run: |
-        pip install git+https://github.com/Fare9/Shuriken-Analyzer.git@main#subdirectory=shuriken/bindings/Python/
-
     - name: Install Quark-Engine
       run: pip install .
 

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -42,16 +42,6 @@ jobs:
         # Install click <= 8.1.7 for CLI supports
         python -m pip install "click<=8.1.7"
    
-    - name: Install Shuriken-Analyzer for Linux
-      run: |
-        pip install git+https://github.com/Fare9/Shuriken-Analyzer.git@main#subdirectory=shuriken/bindings/Python/
-      if: matrix.os == 'ubuntu-latest'
-
-    - name: Install Shuriken-Analyzer for MacOS
-      run: |
-        pip install git+https://github.com/Fare9/Shuriken-Analyzer.git@main#subdirectory=shuriken/bindings/Python/
-      if: matrix.os == 'macos-latest'
-
     - name: Install MacPorts
       uses: melusina-org/setup-macports@v1
       if: matrix.os == 'macos-latest'

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -12,6 +12,13 @@ from quark.core.shurikenapkinfo import ShurikenImp
 from quark.core.struct.bytecodeobject import BytecodeObject
 from quark.core.struct.methodobject import MethodObject
 
+try:
+    import shuriken  # noqa: F401
+
+    _HAS_SHURIKEN = True
+except ModuleNotFoundError:
+    _HAS_SHURIKEN = False
+
 
 @pytest.fixture(scope="session")
 def dex_file(SAMPLE_PATH_13667):
@@ -70,6 +77,9 @@ def __generateTestIDs(testInput: Tuple[BaseApkinfo, Literal["DEX", "APK"]]):
 def apkinfo(request, SAMPLE_PATH_13667, dex_file):
     apkinfoClass, fileType = request.param
 
+    if apkinfoClass is ShurikenImp and not _HAS_SHURIKEN:
+        pytest.skip("Shuriken-Analyzer is not installed")
+
     fileToBeAnalyzed = SAMPLE_PATH_13667
     if fileType == "DEX":
         fileToBeAnalyzed = dex_file
@@ -115,6 +125,9 @@ def apkinfo_with_R2Imp_only(request, SAMPLE_PATH_13667, dex_file):
 )
 def apkinfoPivaa(request, SAMPLE_PATH_pivaa, dex_file_pivaa):
     apkinfoClass, fileType = request.param
+
+    if apkinfoClass is ShurikenImp and not _HAS_SHURIKEN:
+        pytest.skip("Shuriken-Analyzer is not installed")
 
     fileToBeAnalyzed = SAMPLE_PATH_pivaa
     if fileType == "DEX":


### PR DESCRIPTION
## Why

The CI env-prep step installed Shuriken-Analyzer via:

```
pip install git+https://github.com/Fare9/Shuriken-Analyzer.git@main#subdirectory=shuriken/bindings/Python/
```

That compiles C++/pybind11 bindings at install time. The upstream Shuriken-Analyzer is unmaintained and the build has started **failing during CI setup**, blocking otherwise-unrelated PRs.

Shuriken is **not** a required (or extras) dependency of Quark — the CLI defaults to the `androguard` core library (`quark/cli.py`), and Shuriken stays an optional, user-installable core (`from shuriken import ...` is already guarded by `try/except ModuleNotFoundError` in `quark/core/shurikenapkinfo.py`).

## What

- `.github/workflows/pytest.yml`: drop the `Install Shuriken-Analyzer` step
- `.github/workflows/smoke_test.yml`: drop the Linux + macOS `Install Shuriken-Analyzer` steps
- `tests/core/test_apkinfo.py`: since pytest no longer installs Shuriken, guard the `ShurikenImp` parametrized fixtures (`apkinfo`, `apkinfoPivaa`) with `pytest.skip` when the `shuriken` module is absent — `ShurikenImp.__init__` otherwise raises, which would turn those cases into pytest ERRORs.

After the change, `grep -rni shuriken .github/` returns nothing; no other workflow or Dockerfile rebuilds it. Shuriken CLI support and its docs (`--core-library shuriken`) are intentionally left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)