### PR TITLE
feat(forensic): add get_certificate() to extract APK signing certificate

### DIFF
--- a/docs/source/malware_report.rst
+++ b/docs/source/malware_report.rst
@@ -1476,3 +1476,141 @@ The table below lists the APKs we tested.
 +-------+------------------------------------------------------------------+
 | 8     | E5B96E80935CA83BBE895F6239EABCA1337DC575A066BB6AE2B56FAACD29DDAA |
 +-------+------------------------------------------------------------------+
+
+
+New Quark Rules For Antidot
+===========================
+
+New Quark rules (#00266–#00270) are now available. These rules target `Antidot <https://malpedia.caad.fkie.fraunhofer.de/details/apk.antidot>`__, an Android malware family known for stealing sensitive information and executing a wide range of malicious activities on infected devices. Antidot primarily targets banking applications and leverages multiple evasion and persistence techniques to avoid detection. Check `here <https://github.com/quark-engine/quark-rules>`__ for the rule details.
+
+With these rules, Quark is now able to identify the Antidot malware family as high-risk. In our experiment, Quark achieved **100% accuracy** and **100% precision**. Please check :ref:`here <list-of-tested-apks-antidot>` for the APKs we tested.
+
+Below is a summary report of a Antidot sample (``07DA124F1F4BA891E7917082BDFA74C580E78543164DF2FEC86E8B0C3AB0211E``). The report shows that Quark identified the sample as **high-risk**, with a list of behaviors as evidence.
+
+.. image:: https://i.postimg.cc/zBZs9zjr/jie-tu-2026-04-10-wan-shang8-07-29.png
+
+.. image:: https://i.postimg.cc/4yXrxWq6/jie-tu-2026-04-10-wan-shang8-07-44.png
+
+Identified Well-Known Threats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With Quark's rule classification feature, analysts can generate behavior maps and see how behaviors are related. This feature helps identify 4 well-known threats from Antidot, as shown below.
+
+**1. Data Theft**
+
+.. image:: https://files.catbox.moe/85uqku.png
+
+The behavior map shows that the ``Lcom/luck/picture/lib/loader/LocalMediaPageLoader$1;doInBackground`` function queries device data using ContentResolver to read sensitive information such as SMS and call logs, and appends the results into a string for potential exfiltration.
+
+Behaviors detected by Quark:
+
+* Query device data with ContentResolver (#00218)
+* Read sensitive data(SMS, CALLLOG, etc) (#00077)
+* Query a URI and check the result (#00187)
+* Query device data with ContentResolver and obtain the number of results (#00215)
+* Query a URI and append the result into a string (#00190)
+
+**2. Sms Interception**
+
+.. image:: https://files.catbox.moe/gumdy3.png
+
+The diagram indicates that the ``Lcom/arsryg/auto/login/activity/ActivityShow2;uploadSms`` function retrieves the content and address of SMS messages by querying a URI, facilitating the interception and potential unauthorized access to SMS data.
+
+Behaviors detected by Quark:
+
+* Get the content of a SMS message (#00189)
+* Get the address of a SMS message (#00188)
+* Query a URI and check the result (#00187)
+* Query data from URI (SMS, CALLLOGS) (#00011)
+
+**3. Keylogging**
+
+.. image:: https://files.catbox.moe/2m1aw4.png
+
+The behavior map reveals that the ``Lcom/arsryg/auto/tools/AutoApiTool;dragXyToEnd`` function uses AccessibilityService to build and dispatch gestures for input injection, enabling keylogging and remote control capabilities.
+
+Behaviors detected by Quark:
+
+* Build gesture and dispatch via AccessibilityService for input injection (keylogging / remote control) (#00267)
+
+**4. Remote Control**
+
+.. image:: https://files.catbox.moe/3yl9us.png
+
+The diagram shows that the ``Lcom/arsryg/auto/AccUtils;clickScreen`` function simulates touch gestures on the device screen, allowing for remote control by mimicking user interactions.
+
+Behaviors detected by Quark:
+
+* Simulate a touch gesture on the device screen (#00205)
+* Simulate user gestures (#00240)
+
+.. _list-of-tested-apks-antidot:
+
+List of Tested APKs
+~~~~~~~~~~~~~~~~~~~
+
+The table below lists the APKs we tested.
+
++-------+------------------------------------------------------------------+
+| index | sha256                                                           |
++=======+==================================================================+
+| 1     | 07DA124F1F4BA891E7917082BDFA74C580E78543164DF2FEC86E8B0C3AB0211E |
++-------+------------------------------------------------------------------+
+| 2     | 08A646C04974EACA9F50CE5D77FF6216AF5BFF400EC1B48782A4DAE22FEFBEF0 |
++-------+------------------------------------------------------------------+
+| 3     | 0AF689DA84A03383863583DCAD6C640BA4AB9762AFFDE3D56C199A9EB08E9F41 |
++-------+------------------------------------------------------------------+
+| 4     | 0B7F4C3BE1D0B0F0B53495FF33E8C4B22ADF122E01F8C72D705C489A975FE498 |
++-------+------------------------------------------------------------------+
+| 5     | 12D1FC37FBFA5E0EEC3954F5FC31CDBD55AC61EBD84E41C59FF00567D03B107A |
++-------+------------------------------------------------------------------+
+| 6     | 160940892DC1983ED1B46D8756F1A529D9EC9CE5E3C4481F75C57C568748A38C |
++-------+------------------------------------------------------------------+
+| 7     | 1AE0C4FFE18E7934C019AD1279219D1E8E8491BF62E8B34102E1497010C58247 |
++-------+------------------------------------------------------------------+
+| 8     | 2EDC7CBC0DCE61739A4D977ACD8B6E6940A817D4E698CBCCAA8CE1DDBE0A7BBC |
++-------+------------------------------------------------------------------+
+| 9     | 335FB32EE34E2374D28C9C5A95549FC2965D254B22A9550B505AC7F7304BAE80 |
++-------+------------------------------------------------------------------+
+| 10    | 4338AB77D05AEACD7EAC5ACBE9EED5568778C8E3E9499562816805B54B4D1A6A |
++-------+------------------------------------------------------------------+
+| 11    | 476DDA92941E2F211ABC209EA411D97E3007E9434632C0A721AE48F4FE427259 |
++-------+------------------------------------------------------------------+
+| 12    | 506033F7A6EA5C9E4D89F9EDCC998ED1F33FB74E4A2A4F32AF8CEC2EC009A906 |
++-------+------------------------------------------------------------------+
+| 13    | 518F74277C26B9CA91A2FE4AEABB26AE9B675A5E2E1BC6BDBE53067183477071 |
++-------+------------------------------------------------------------------+
+| 14    | 578D3B5DBB35738F47165EE053138021F88C4BEBFE5EBB2B79DBB998600EAA16 |
++-------+------------------------------------------------------------------+
+| 15    | 6499730A01703CAD20711803829862F3D19EE7A3FEDBE72FEA2F319394B29627 |
++-------+------------------------------------------------------------------+
+| 16    | 6A99E6D4ABC66F09A490443786432D90C675CB6282C791FAE996136CBB69B7E9 |
++-------+------------------------------------------------------------------+
+| 17    | 7748CA5B385DB3FDA3E07000B1552CA05405333083B33C4F470DD3AE4F0E3A5F |
++-------+------------------------------------------------------------------+
+| 18    | 7A373702F30FB4A293574DFF762AB4B89D101DA117F5152BD3BA2369B9DE1661 |
++-------+------------------------------------------------------------------+
+| 19    | 89CACC44F42639F27EFE324F4937B923E2711B88B67B1FDAE8BBAE1210F573E7 |
++-------+------------------------------------------------------------------+
+| 20    | 8EA78D335B8B931B49945E3CE36D12B1576647E7FB797840D3D1FA61B2F42200 |
++-------+------------------------------------------------------------------+
+| 21    | 9DA55AD04E480FA1FD3B45A5F245E6511DFC45D44123000E1CC2D1E10C65E8B8 |
++-------+------------------------------------------------------------------+
+| 22    | A2A9FB573C9F39E3654467EFD78C9B5424DE3033303FACAD972DF1A5F8B2FA04 |
++-------+------------------------------------------------------------------+
+| 23    | B482C7A2734B90EEA3E35E61962DE17336ED81F26BC9432175A03D4E7DA03D65 |
++-------+------------------------------------------------------------------+
+| 24    | BC02322AAF96FA1841101636DC4C8011DA3BCC5571A6F0278813884CE54B5B3F |
++-------+------------------------------------------------------------------+
+| 25    | C6E52BD7D8A1DE54E5A6551A7A737C989D93537C1BB440FDF37914C799E77F16 |
++-------+------------------------------------------------------------------+
+| 26    | DA7B254CB8877278EC38C674B922D54C2AF67405694823C2A35F12EBF920891B |
++-------+------------------------------------------------------------------+
+| 27    | DD4BCE9274CABCBCB2F3EA2B00867932399AD0DE9B923896A70AC03076231EFA |
++-------+------------------------------------------------------------------+
+| 28    | E11DBB99B9083326FC1F148C161A5ED9F4B3C59F44C976248C43600334308E21 |
++-------+------------------------------------------------------------------+
+| 29    | F3DFED0600935C66C5CB48CA9C4D0CAA65E01545A63CF9256964AF06AA4665AD |
++-------+------------------------------------------------------------------+
+| 30    | FE4B2B288565CC1A85B7DD23398CC8AB850B0B0C73D46EC9E7C308AF86A96D60 |
++-------+------------------------------------------------------------------+

--- a/docs/source/malware_report.rst
+++ b/docs/source/malware_report.rst
@@ -1616,3 +1616,157 @@ The table below lists the APKs we tested.
 +-------+------------------------------------------------------------------+
 | 30    | FE4B2B288565CC1A85B7DD23398CC8AB850B0B0C73D46EC9E7C308AF86A96D60 |
 +-------+------------------------------------------------------------------+
+
+
+New Quark Rules For Arsink
+==========================
+
+New Quark rule (#00271) is now available. This rule targets `Arsink <https://malpedia.caad.fkie.fraunhofer.de/details/apk.arsink>`__. The Arsink malware family is a type of Android malware that primarily targets users by leveraging various malicious behaviors, including sending SMS messages without user consent and accessing sensitive device information. It is often disguised as a legitimate application to evade detection and gain unauthorized access to user data. Check `here <https://github.com/quark-engine/quark-rules>`__ for the rule details.
+
+With these rules, Quark is now able to identify the Arsink malware family as high-risk. In our experiment, Quark achieved 100% accuracy and 100% precision. Please check :ref:`here <list-of-tested-apks-arsink>` for the APKs we tested.
+
+Below is a summary report of an Arsink sample (``06F7DFDFBFF03719082750FB11CA1F1FE720DAA57F11C7D30D3B3277BFECEB13``). The report shows that Quark identified the sample as **high-risk**, with a list of behaviors as evidence.
+
+.. image:: https://i.postimg.cc/8zm82TtM/jie-tu-2026-04-16-wan-shang8-56-42.png
+
+Identified Well-Known Threats
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With Quark's rule classification feature, analysts can generate behavior maps and see how behaviors are related. This feature helps identify 3 well-known threats from Arsink, as shown below.
+
+**1. Accessing Device Information**
+
+.. image:: https://i.ibb.co/8nXprq12/accessing-device-information.png
+   :alt: Accessing Device Information
+
+The diagram indicates that the ``LSay/hello/To/Arthur/FileUtil;convertUriToFilePath`` function queries device data using a ContentResolver and URI, and calls ``LSay/hello/To/Arthur/FileUtil;getDataColumn`` to access sensitive information from content providers.
+
+Behaviors detected by Quark:
+
+* Query data from URI (SMS, CALLLOGS) (#00011)
+* Read sensitive data(SMS, CALLLOG, etc) (#00077)
+* Query device data with ContentResolver (#00212)
+* Query device data with ContentResolver and a URI parsed from a string (#00222)
+* Accessing sensitive data from content provider (#00271)
+
+**2. Intercepting Sms Messages**
+
+.. image:: https://i.ibb.co/HDv1R0GQ/intercepting-sms-messages.png
+   :alt: Intercepting Sms Messages
+
+The behavior map reveals that the ``LSay/hello/To/Arthur/FileUtil;convertUriToFilePath`` function queries SMS and call log data from URIs, and invokes ``LSay/hello/To/Arthur/FileUtil;getDataColumn`` to read this sensitive data, enabling SMS interception.
+
+Behaviors detected by Quark:
+
+* Query data from URI (SMS, CALLLOGS) (#00011)
+* Read sensitive data(SMS, CALLLOG, etc) (#00077)
+
+**3. Manipulating System Settings**
+
+.. image:: https://i.ibb.co/QFYR9Cqy/manipulating-system-settings.png
+   :alt: Manipulating System Settings
+
+The diagram shows that the ``LSay/hello/To/Arthur/SketchLogger$1;run`` function executes specified Linux commands, which can be used to manipulate system settings.
+
+Behaviors detected by Quark:
+
+* Executes the specified string Linux command (#00068)
+
+.. _list-of-tested-apks-arsink:
+
+List of Tested APKs
+~~~~~~~~~~~~~~~~~~~
+
+The table below lists the APKs we tested.
+
++-------+------------------------------------------------------------------+
+| index | sha256                                                           |
++=======+==================================================================+
+| 1     | 06F7DFDFBFF03719082750FB11CA1F1FE720DAA57F11C7D30D3B3277BFECEB13 |
++-------+------------------------------------------------------------------+
+| 2     | 0BCDF887E6BD21EA4073385A8B2E59025768BE3131A92E9940886E05C748E1CC |
++-------+------------------------------------------------------------------+
+| 3     | 16CB7952AB3CE88EC30B57E1C5F16A8871457E9985D43675AAE47D8DDB5044C8 |
++-------+------------------------------------------------------------------+
+| 4     | 1FC3BA39F0CE8109BCB4F42441250DF5E9C601744B738A2E7C40D612CD29FEC3 |
++-------+------------------------------------------------------------------+
+| 5     | 2063030918DF932A61673559F99E51CC47F3436337F94AFB2E8ACAAFA84289FF |
++-------+------------------------------------------------------------------+
+| 6     | 2C0BCE17BC9BBFBEA95E5B75E6294FD1D5205B915B24729D1F2377E2A6F2B578 |
++-------+------------------------------------------------------------------+
+| 7     | 35F06F91902FAF5A4BC27C8B73F74B74AEA6A6BE2215AE1E990EE504CEB29E4F |
++-------+------------------------------------------------------------------+
+| 8     | 3AE188387DD8B01CD5595B9AD937DAE48D90C4D17FA8BA7F85D3A1F34D1EF3C8 |
++-------+------------------------------------------------------------------+
+| 9     | 3E6EDEBC2DA9A4A80507EEB7ABF529C9C3A70201927F1AE864F9F257CA64BC2E |
++-------+------------------------------------------------------------------+
+| 10    | 4070678717CF011417C9E4307C9ECB4D481563DB4758FFAADA5FA6870E06A4AC |
++-------+------------------------------------------------------------------+
+| 11    | 48F19EEF9D420137DEE9974E3CC6AF3DED9532BD631ACE36F7D15EEBEC6A2DCE |
++-------+------------------------------------------------------------------+
+| 12    | 4CF809B14083143E921BD8FDB7E7725E20E303653D9A3E6C848D9596A33F6C8E |
++-------+------------------------------------------------------------------+
+| 13    | 501E35F1600CE0548226C9957EED76F5F04CB2E1DBFD4F3FB8652009B38E8C9F |
++-------+------------------------------------------------------------------+
+| 14    | 5948A349B534156F5734B3A99E761EC6D84E527AB729B1F28242049B3AFAB2E6 |
++-------+------------------------------------------------------------------+
+| 15    | 595355DAAA6AAD284090210CD55C4A2E276C5263C83D2B202E1486D347AF3701 |
++-------+------------------------------------------------------------------+
+| 16    | 5E48BBE1C62DA18D4C0F2CCA0F8855219C5A05F81C5FB64C1B4A0A6871FA8736 |
++-------+------------------------------------------------------------------+
+| 17    | 603D89C5A2883AB2ED68E12517212BD0B74760F1EF755A61D059440AEBA045FD |
++-------+------------------------------------------------------------------+
+| 18    | 68F800FBED83116AC9EFB2524326FA5D710A911B506762D580A34C19932A21E8 |
++-------+------------------------------------------------------------------+
+| 19    | 6D06806CCEE64D3BAA5B9DA63019C3AC7A23DFE210747FBDBC048A84196325C5 |
++-------+------------------------------------------------------------------+
+| 20    | 744346BD46F139837BF2825206FA95D48DDF6DC078E341492B34B35743A0B297 |
++-------+------------------------------------------------------------------+
+| 21    | 76B8569EFF05CE94BA580E10FB1161AF6537D931F8C9D07EDBA20E93A4A34BB6 |
++-------+------------------------------------------------------------------+
+| 22    | 7DDD3C4808372C91C916C4B77A07A09F61753BC26A592FF7DA3BD71D12802A0C |
++-------+------------------------------------------------------------------+
+| 23    | 8159C79C8A9B54AD363516F9B53C7CADA3EA4AFA0B2D0F6E7DC66FE147D03A93 |
++-------+------------------------------------------------------------------+
+| 24    | 8314ECE95207FF28466D4FC8BF6CEF22CC6E28FEF47E9BEDE381B502F038B552 |
++-------+------------------------------------------------------------------+
+| 25    | 89D492B7539B5552445764907A96B517D08D448F8FF0E3E7A93958DF82D3DF58 |
++-------+------------------------------------------------------------------+
+| 26    | 8E9C6AA5EA90DDD2C3199128E41DE82C4D406B3D2D32BA34CF9D6B1F9C5A8F26 |
++-------+------------------------------------------------------------------+
+| 27    | 917CDE4F5DFDE864C07A412E586E218F65826B71810083BFFB086C3518DEC645 |
++-------+------------------------------------------------------------------+
+| 28    | 9A778FBB730EE653F45B36700A369C81792509F855C2529ACA73DE1443C62DE8 |
++-------+------------------------------------------------------------------+
+| 29    | 9FB8A940492EE6095A24B4A34ECFA252A515FB681F16636A8F00B1E0E7D47FE2 |
++-------+------------------------------------------------------------------+
+| 30    | A3F487BBE5AC9A9EB3556E9612C7A16177EA2767783E9401A6643765B1EE39B3 |
++-------+------------------------------------------------------------------+
+| 31    | BA71C7E507E1B0D8202447F9F86F585286B4AB01B58C7E32BB4F495381EF5004 |
++-------+------------------------------------------------------------------+
+| 32    | BBB41EC382738C0EE5B94D023F023209928CA98893F146A8CFDAA608AFE7B4E6 |
++-------+------------------------------------------------------------------+
+| 33    | C002E68F52DE1B2B62013A82828245D8A956A075B87E220C3F6E1B2BFB220D19 |
++-------+------------------------------------------------------------------+
+| 34    | C1183C6868BF4E006BA412A538A3A07DADBAEDED2BE6F148765DECF69DC284EC |
++-------+------------------------------------------------------------------+
+| 35    | C4F51CCDE0525887B61FB919EEFC5830B24EC35FDCB2AF2AA3893E5F56957C40 |
++-------+------------------------------------------------------------------+
+| 36    | CB93D5C96AE3E0B358AC2A0C57008A5655A049AC3BC5543F814AF5157E2F27DE |
++-------+------------------------------------------------------------------+
+| 37    | D41329E084AD90A62C37E906F18E1089002F4D5E7C5CE123F7753DA90E410372 |
++-------+------------------------------------------------------------------+
+| 38    | D41A27EE5D4B12F6C94E73CC453C69B20FF92CE29823B0FF5BCC50C0D61F826E |
++-------+------------------------------------------------------------------+
+| 39    | D5B6C048A278C06E2625C47A3A57F5CE2E4D6D73D830051A84DE1768E0445882 |
++-------+------------------------------------------------------------------+
+| 40    | D7362FF697A5CAE24B4B084D0436CCDE7060524A24C34F37F185F64597930514 |
++-------+------------------------------------------------------------------+
+| 41    | DB5B22F8D3400BAFA449B6DB01F44896DD8040733B03D11DBC187146E58DFBCD |
++-------+------------------------------------------------------------------+
+| 42    | EB76F62F4BA0718AFD9B1BCCCD6389A6043A4394A6769730F75F8E1F8B3752AF |
++-------+------------------------------------------------------------------+
+| 43    | F9B00165598A0600D53064B2871477FEC3BD62549A69328C4BDD39467AF2D48D |
++-------+------------------------------------------------------------------+
+| 44    | FD263056ADFE6CB5596A11612440FA5D851B3B9BED34A481139C2206A6C570B1 |
++-------+------------------------------------------------------------------+

--- a/docs/source/malware_report.rst
+++ b/docs/source/malware_report.rst
@@ -1487,9 +1487,9 @@ With these rules, Quark is now able to identify the Antidot malware family as hi
 
 Below is a summary report of a Antidot sample (``07DA124F1F4BA891E7917082BDFA74C580E78543164DF2FEC86E8B0C3AB0211E``). The report shows that Quark identified the sample as **high-risk**, with a list of behaviors as evidence.
 
-.. image:: https://i.postimg.cc/zBZs9zjr/jie-tu-2026-04-10-wan-shang8-07-29.png
+.. image:: https://i.postimg.cc/W1qRFhpd/jie-tu-2026-04-11-xia-wu2-45-08.png
 
-.. image:: https://i.postimg.cc/4yXrxWq6/jie-tu-2026-04-10-wan-shang8-07-44.png
+.. image:: https://i.postimg.cc/qv6fhzBW/jie-tu-2026-04-11-xia-wu2-45-57.png
 
 Identified Well-Known Threats
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1525,24 +1525,26 @@ Behaviors detected by Quark:
 
 **3. Keylogging**
 
-.. image:: https://files.catbox.moe/2m1aw4.png
+.. image:: https://files.catbox.moe/upg9ja.png
 
-The behavior map reveals that the ``Lcom/arsryg/auto/tools/AutoApiTool;dragXyToEnd`` function uses AccessibilityService to build and dispatch gestures for input injection, enabling keylogging and remote control capabilities.
+The behavior map shows that the ``Lcom/blankj/utilcode/util/ClipboardUtils;getText`` function reads the primary clipboard content, allowing the malware to passively capture credentials and other sensitive text the user copies.
 
 Behaviors detected by Quark:
 
-* Build gesture and dispatch via AccessibilityService for input injection (keylogging / remote control) (#00267)
+* Read clipboard (#00266)
 
 **4. Remote Control**
 
-.. image:: https://files.catbox.moe/3yl9us.png
+.. image:: https://files.catbox.moe/j8937k.png
 
-The diagram shows that the ``Lcom/arsryg/auto/AccUtils;clickScreen`` function simulates touch gestures on the device screen, allowing for remote control by mimicking user interactions.
+The diagram shows that the ``Lcom/arsryg/auto/AccUtils;longClickScreen`` function builds and dispatches accessibility gestures to simulate user input, enabling the attacker to remotely drive the device as if they were sitting in front of it.
 
 Behaviors detected by Quark:
 
-* Simulate a touch gesture on the device screen (#00205)
 * Simulate user gestures (#00240)
+* Simulate a touch gesture on the device screen (#00205)
+* Dispatch gesture (#00267)
+
 
 .. _list-of-tested-apks-antidot:
 

--- a/quark/forensic/forensic.py
+++ b/quark/forensic/forensic.py
@@ -98,6 +98,46 @@ class Forensic:
 
         return self.apk.android_apis
 
+    def get_certificate(self):
+        """
+        Return the signing certificate(s) of the APK.
+
+        :return: a list of dicts, each describing one signing certificate
+            (subject, issuer, serial number, sha1/sha256 fingerprint,
+            validity period and signature algorithm). Returns an empty list
+            when the sample is unsigned or carries no APK-level certificate
+            (e.g. a bare DEX input or the rizin backend).
+        """
+
+        androguard_apk = getattr(self.apk, "apk", None)
+
+        if androguard_apk is None or not hasattr(
+            androguard_apk, "get_certificates"
+        ):
+            return []
+
+        if not androguard_apk.is_signed():
+            return []
+
+        certificates = []
+        for cert in androguard_apk.get_certificates():
+            validity = cert["tbs_certificate"]["validity"]
+
+            certificates.append(
+                {
+                    "subject": cert.subject.human_friendly,
+                    "issuer": cert.issuer.human_friendly,
+                    "serial_number": cert.serial_number,
+                    "sha1": cert.sha1_fingerprint,
+                    "sha256": cert.sha256_fingerprint,
+                    "not_before": str(validity["not_before"].native),
+                    "not_after": str(validity["not_after"].native),
+                    "signature_algorithm": cert.signature_algo,
+                }
+            )
+
+        return certificates
+
 
 if __name__ == "__main__":
     pass

--- a/tests/forensic/test_forensic.py
+++ b/tests/forensic/test_forensic.py
@@ -56,3 +56,21 @@ class TestForensic:
         result = [str(x) for x in forensic.get_android_api()]
         assert any("getCellLocation" in meth for meth in result)
         assert any("sendTextMessage" in meth for meth in result)
+
+    def test_get_certificate(self, forensic):
+        certificates = forensic.get_certificate()
+
+        assert len(certificates) == 1
+
+        cert = certificates[0]
+        assert cert["subject"] == (
+            "Common Name: Android Debug, Organization: Android, Country: US"
+        )
+        assert cert["issuer"] == (
+            "Common Name: Android Debug, Organization: Android, Country: US"
+        )
+        assert cert["sha256"] == (
+            "E2 19 39 06 1B 8B 26 C8 08 B9 4C 47 4F ED C3 80 "
+            "52 B6 3E 66 07 AF 9C 7C 37 20 38 74 AF E5 E5 70"
+        )
+        assert cert["signature_algorithm"] == "rsassa_pkcs1v15"


### PR DESCRIPTION
## What
Add `Forensic.get_certificate()` to surface the APK's signing certificate.

## Why
The `Forensic` module already extracts APK metadata (strings, URLs, IPs, content/file URIs, base64, Android APIs) but had no way to get the signing certificate. Certificate subject/issuer and fingerprints are useful IOCs for provenance and family clustering — e.g. flagging AOSP test-key self-signing, which is common in repackaged malware.

## How
`get_certificate()` reuses the certificate parsing already available from the Androguard backend (no new dependency) and returns a list of dicts: `subject`, `issuer`, `serial_number`, `sha1`, `sha256`, `not_before`, `not_after`, `signature_algorithm`. Returns an empty list for unsigned input, a bare DEX, or the rizin backend.

## Test
Adds `test_get_certificate` in `tests/forensic/test_forensic.py`, asserting the signing cert (subject/issuer/sha256/sig-algo) of the existing test sample `14d9f1a92dd984d6040cc41ed06e273e.apk`.

## Notes
Backend support: implemented for the Androguard backend; rizin backend returns `[]` (can be added in a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)