### PR TITLE
fix: validate default rule path only when used

### DIFF
--- a/quark/cli.py
+++ b/quark/cli.py
@@ -66,7 +66,7 @@ logo()
     "-r",
     "--rule",
     help="Rules directory",
-    type=click.Path(exists=True, file_okay=True, dir_okay=True),
+    type=click.Path(exists=False, file_okay=True, dir_okay=True),
     default=f"{config.DIR_PATH}",
     required=False,
     show_default=True,
@@ -207,7 +207,7 @@ def entry_point(
     else:
         if not os.path.exists(rule):
             raise click.BadParameter(
-                f"Path {rule!r} does not exist.",
+                f"Path {rule} does not exist.",
                 param_hint="--rule",
             )
 
@@ -467,13 +467,6 @@ def entry_point(
 
     if isinstance(data, ParallelQuark):
         data.close()
-
-
-# Click validates option defaults before the command body can choose a rule source.
-for param in entry_point.params:
-    if param.name == "rule":
-        param.type = click.Path(exists=False, file_okay=True, dir_okay=True)
-        break
 
 
 def update_rule_buffer(rule_buffer_list, rule_path_list):

--- a/quark/cli.py
+++ b/quark/cli.py
@@ -205,6 +205,12 @@ def entry_point(
 
         rule_path_list = [rule_filter]
     else:
+        if not os.path.exists(rule):
+            raise click.BadParameter(
+                f"Path {rule!r} does not exist.",
+                param_hint="--rule",
+            )
+
         rule_path_list = [
             os.path.join(dir_path, file)
             for dir_path, _, file_list in os.walk(rule)
@@ -461,6 +467,13 @@ def entry_point(
 
     if isinstance(data, ParallelQuark):
         data.close()
+
+
+# Click validates option defaults before the command body can choose a rule source.
+for param in entry_point.params:
+    if param.name == "rule":
+        param.type = click.Path(exists=False, file_okay=True, dir_okay=True)
+        break
 
 
 def update_rule_buffer(rule_buffer_list, rule_path_list):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,20 @@
 import json
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 
 from quark.cli import entry_point
+
+
+@pytest.fixture
+def mock_quark():
+    with patch("quark.cli.Quark") as mock:
+        data = mock.return_value
+        data.quark_analysis.score_sum = 0
+        data.quark_analysis.weight_sum = 0
+        data.quark_analysis.summary_report_table = ""
+        yield mock
 
 
 def _rule_option():
@@ -38,7 +49,9 @@ def _write_rule(path):
     )
 
 
-def test_custom_rule_does_not_validate_missing_default_rules(tmp_path, monkeypatch):
+def test_custom_rule_does_not_validate_missing_default_rules(
+    tmp_path, monkeypatch, mock_quark
+):
     missing_default_rules = tmp_path / "missing-rules"
     custom_rule = tmp_path / "custom_rule.json"
     apk = tmp_path / "sample.apk"
@@ -48,16 +61,10 @@ def test_custom_rule_does_not_validate_missing_default_rules(tmp_path, monkeypat
 
     runner = CliRunner()
 
-    with patch("quark.cli.Quark") as mock_quark:
-        data = mock_quark.return_value
-        data.quark_analysis.score_sum = 0
-        data.quark_analysis.weight_sum = 0
-        data.quark_analysis.summary_report_table = ""
-
-        result = runner.invoke(
-            entry_point,
-            ["-a", str(apk), "-s", str(custom_rule)],
-        )
+    result = runner.invoke(
+        entry_point,
+        ["-a", str(apk), "-s", str(custom_rule)],
+    )
 
     assert result.exit_code == 0
     mock_quark.assert_called_once()
@@ -78,7 +85,7 @@ def test_missing_rules_path_fails_when_rules_are_loaded(tmp_path, monkeypatch):
     assert str(missing_rules) in result.output
 
 
-def test_existing_rules_directory_is_loaded(tmp_path, monkeypatch):
+def test_existing_rules_directory_is_loaded(tmp_path, monkeypatch, mock_quark):
     rules_dir = tmp_path / "rules"
     rules_dir.mkdir()
     _write_rule(rules_dir / "custom_rule.json")
@@ -88,13 +95,7 @@ def test_existing_rules_directory_is_loaded(tmp_path, monkeypatch):
 
     runner = CliRunner()
 
-    with patch("quark.cli.Quark") as mock_quark:
-        data = mock_quark.return_value
-        data.quark_analysis.score_sum = 0
-        data.quark_analysis.weight_sum = 0
-        data.quark_analysis.summary_report_table = ""
-
-        result = runner.invoke(entry_point, ["-a", str(apk), "-s"])
+    result = runner.invoke(entry_point, ["-a", str(apk), "-s"])
 
     assert result.exit_code == 0
     mock_quark.assert_called_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,100 @@
+import json
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from quark.cli import entry_point
+
+
+def _rule_option():
+    for param in entry_point.params:
+        if param.name == "rule":
+            return param
+    raise AssertionError("rule option not found")
+
+
+def _write_rule(path):
+    path.write_text(
+        json.dumps(
+            {
+                "crime": "test",
+                "permission": [],
+                "api": [
+                    {
+                        "class": "Lfoo/Bar;",
+                        "method": "first",
+                        "descriptor": "()V",
+                    },
+                    {
+                        "class": "Lfoo/Bar;",
+                        "method": "second",
+                        "descriptor": "()V",
+                    },
+                ],
+                "score": 1,
+                "label": ["test"],
+            }
+        )
+    )
+
+
+def test_custom_rule_does_not_validate_missing_default_rules(tmp_path, monkeypatch):
+    missing_default_rules = tmp_path / "missing-rules"
+    custom_rule = tmp_path / "custom_rule.json"
+    apk = tmp_path / "sample.apk"
+    _write_rule(custom_rule)
+    apk.write_text("")
+    monkeypatch.setattr(_rule_option(), "default", str(missing_default_rules))
+
+    runner = CliRunner()
+
+    with patch("quark.cli.Quark") as mock_quark:
+        data = mock_quark.return_value
+        data.quark_analysis.score_sum = 0
+        data.quark_analysis.weight_sum = 0
+        data.quark_analysis.summary_report_table = ""
+
+        result = runner.invoke(
+            entry_point,
+            ["-a", str(apk), "-s", str(custom_rule)],
+        )
+
+    assert result.exit_code == 0
+    mock_quark.assert_called_once()
+
+
+def test_missing_rules_path_fails_when_rules_are_loaded(tmp_path, monkeypatch):
+    missing_rules = tmp_path / "missing-rules"
+    apk = tmp_path / "sample.apk"
+    apk.write_text("")
+    monkeypatch.setattr(_rule_option(), "default", str(missing_rules))
+
+    runner = CliRunner()
+
+    result = runner.invoke(entry_point, ["-a", str(apk), "-s"])
+
+    assert result.exit_code != 0
+    assert "Path" in result.output
+    assert str(missing_rules) in result.output
+
+
+def test_existing_rules_directory_is_loaded(tmp_path, monkeypatch):
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    _write_rule(rules_dir / "custom_rule.json")
+    apk = tmp_path / "sample.apk"
+    apk.write_text("")
+    monkeypatch.setattr(_rule_option(), "default", str(rules_dir))
+
+    runner = CliRunner()
+
+    with patch("quark.cli.Quark") as mock_quark:
+        data = mock_quark.return_value
+        data.quark_analysis.score_sum = 0
+        data.quark_analysis.weight_sum = 0
+        data.quark_analysis.summary_report_table = ""
+
+        result = runner.invoke(entry_point, ["-a", str(apk), "-s"])
+
+    assert result.exit_code == 0
+    mock_quark.assert_called_once()


### PR DESCRIPTION
## Summary
- stop Click from validating the default --rule path during option parsing
- validate the rule path only when Quark actually loads rules from that path
- add CLI regression tests for custom single-rule use and missing rule-directory use

Fixes #936.

## Tests
- uv run --with pytest --with requests --with click --with numpy --with tqdm --with prettytable --with colorama --with pathvalidate --with graphviz --with plotly --with-editable . pytest tests/test_cli.py -q
- uv run --with black black --check tests/test_cli.py
- git diff --check

Note: I did not run  because the current file has pre-existing formatting that newer Black would reflow outside this fix. I kept the production diff to the rule option and the runtime path check.