### PR TITLE
[codex] fix rule path validation for custom summary rules

### DIFF
--- a/quark/cli.py
+++ b/quark/cli.py
@@ -66,7 +66,7 @@ logo()
     "-r",
     "--rule",
     help="Rules directory",
-    type=click.Path(exists=True, file_okay=True, dir_okay=True),
+    type=click.Path(file_okay=True, dir_okay=True),
     default=f"{config.DIR_PATH}",
     required=False,
     show_default=True,
@@ -205,6 +205,12 @@ def entry_point(
 
         rule_path_list = [rule_filter]
     else:
+        if not os.path.exists(rule):
+            raise click.BadParameter(
+                "Rules directory does not exist.",
+                param_hint="--rule",
+            )
+
         rule_path_list = [
             os.path.join(dir_path, file)
             for dir_path, _, file_list in os.walk(rule)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,3 +51,17 @@ def test_summary_rule_file_does_not_validate_default_rule_path(tmp_path):
 
     assert result.exit_code == 0, result.output
     assert seen_rule_paths == [str(rule_path)]
+
+
+def test_missing_rule_directory_reports_parameter_error(tmp_path):
+    apk_path = tmp_path / "sample.apk"
+    apk_path.write_bytes(b"")
+    missing_rules = tmp_path / "missing-rules"
+
+    result = CliRunner().invoke(
+        cli.entry_point,
+        ["-a", str(apk_path), "-r", str(missing_rules)],
+    )
+
+    assert result.exit_code != 0
+    assert "Rules directory does not exist." in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from quark import cli
+
+
+def test_summary_rule_file_does_not_validate_default_rule_path(tmp_path):
+    apk_path = tmp_path / "sample.apk"
+    apk_path.write_bytes(b"")
+    rule_path = tmp_path / "custom_rule.json"
+    rule_path.write_text("{}", encoding="utf-8")
+    missing_default_rules = tmp_path / "missing-rules"
+
+    rule_param = next(
+        param for param in cli.entry_point.params if param.name == "rule"
+    )
+    previous_default = rule_param.default
+    rule_param.default = str(missing_default_rules)
+
+    seen_rule_paths = []
+
+    def fake_update_rule_buffer(rule_buffer_list, rule_path_list):
+        seen_rule_paths.extend(rule_path_list)
+        rule_buffer_list.append(SimpleNamespace(label=[]))
+
+    quark = Mock()
+    quark.quark_analysis = SimpleNamespace(
+        score_sum=0,
+        weight_sum=1,
+        summary_report_table="",
+    )
+
+    try:
+        with (
+            patch("quark.cli.Quark", return_value=quark),
+            patch(
+                "quark.cli.update_rule_buffer",
+                side_effect=fake_update_rule_buffer,
+            ),
+            patch("quark.cli.Weight") as weight,
+        ):
+            weight.return_value.calculate.return_value = 0
+            result = CliRunner().invoke(
+                cli.entry_point,
+                ["-a", str(apk_path), "-s", str(rule_path)],
+            )
+    finally:
+        rule_param.default = previous_default
+
+    assert result.exit_code == 0, result.output
+    assert seen_rule_paths == [str(rule_path)]


### PR DESCRIPTION
﻿## Summary

Fixes #936.

This delays validation of the default rules directory until the CLI actually needs to walk a rules directory. Commands that provide a specific JSON rule with `-s custom_rule.json` no longer fail during Click option parsing just because the default rules directory has not been downloaded yet.

## Root cause

The `--rule` option used `click.Path(exists=True)` with a default path. Click validates default values while parsing, so an absent default rules directory blocked commands even when the command used a specific rule file instead.

## Changes

- Remove eager `exists=True` validation from the `--rule` Click option.
- Add an explicit missing-directory check before walking the rules directory.
- Add a regression test that sets the default rule path to a missing directory and verifies a custom summary rule file is still accepted.

## Validation

- `python -m pytest tests/test_cli.py -q` passed.
- `python -m pytest tests/test_cli.py tests/test_freshquark.py -q` shows the new test passing, while the existing `tests/test_freshquark.py` tests fail on Windows path separator expectations (`/` vs `\\`), unrelated to this change.
