### PR TITLE
fix: validate default rules path only when used

### DIFF
--- a/quark/cli.py
+++ b/quark/cli.py
@@ -66,7 +66,7 @@ logo()
     "-r",
     "--rule",
     help="Rules directory",
-    type=click.Path(exists=True, file_okay=True, dir_okay=True),
+    type=click.Path(exists=False, file_okay=True, dir_okay=True),
     default=f"{config.DIR_PATH}",
     required=False,
     show_default=True,
@@ -205,6 +205,14 @@ def entry_point(
 
         rule_path_list = [rule_filter]
     else:
+        if not os.path.exists(rule):
+            print_warning(
+                f"Specified rules path not found.\n"
+                f"Run {yellow('freshquark')} to download the default rules, "
+                f"or pass an existing rules directory with {yellow('--rule')}."
+            )
+            return
+
         rule_path_list = [
             os.path.join(dir_path, file)
             for dir_path, _, file_list in os.walk(rule)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,85 @@
+import json
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from quark import cli
+
+
+class DummyQuark:
+    def __init__(self, *args, **kwargs):
+        self.quark_analysis = SimpleNamespace(
+            score_sum=0,
+            weight_sum=0,
+            summary_report_table="",
+        )
+
+    def run(self, rule_checker):
+        pass
+
+    def show_summary_report(self, rule_checker, threshold):
+        pass
+
+
+def get_rule_option():
+    return next(param for param in cli.entry_point.params if param.name == "rule")
+
+
+def test_custom_rule_file_does_not_require_default_rules_directory(
+    tmp_path, monkeypatch
+):
+    missing_default_rules = tmp_path / "missing-rules"
+    apk_path = tmp_path / "sample.apk"
+    apk_path.write_bytes(b"not a real apk")
+
+    custom_rule_path = tmp_path / "custom_rule.json"
+    custom_rule_path.write_text(
+        json.dumps(
+            {
+                "crime": "Test rule",
+                "permission": [],
+                "api": [
+                    {
+                        "class": "Landroid/test/First;",
+                        "method": "first",
+                        "descriptor": "()V",
+                    },
+                    {
+                        "class": "Landroid/test/Second;",
+                        "method": "second",
+                        "descriptor": "()V",
+                    },
+                ],
+                "score": 1,
+                "label": ["test"],
+            }
+        )
+    )
+
+    monkeypatch.setattr(get_rule_option(), "default", str(missing_default_rules))
+    monkeypatch.setattr(cli, "Quark", DummyQuark)
+
+    result = CliRunner().invoke(
+        cli.entry_point,
+        ["--apk", str(apk_path), "--summary", str(custom_rule_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_missing_rules_directory_is_reported_when_default_rules_are_used(
+    tmp_path, monkeypatch
+):
+    missing_default_rules = tmp_path / "missing-rules"
+    apk_path = tmp_path / "sample.apk"
+    apk_path.write_bytes(b"not a real apk")
+
+    monkeypatch.setattr(get_rule_option(), "default", str(missing_default_rules))
+
+    result = CliRunner().invoke(
+        cli.entry_point,
+        ["--apk", str(apk_path), "--summary"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Specified rules path not found" in result.output


### PR DESCRIPTION
## Summary

- Allow `--rule` to be parsed even when the default rules directory has not been downloaded yet.
- Report a clear warning only when Quark actually needs to load rules from the configured rules path.
- Add CLI regression tests for using a custom single rule file while the default rules path is missing.

## Root cause

`--rule` used `click.Path(exists=True)` together with the default rules directory. Click validated that default during argument parsing, so commands that supplied their own rule file via `--summary custom_rule.json` could fail before Quark reached the code path that uses the custom rule.

## Validation

- `python -m pytest tests\test_cli.py -q` -> 2 passed
- `python -m black --check tests\test_cli.py` -> passed
- `git diff --cached --check` -> passed before commit

I also tried `python -m pytest tests\test_cli.py tests\test_freshquark.py -q`. The new CLI tests passed, but the existing `tests/test_freshquark.py` assertions fail on Windows because expected paths use `\` while the mocked command builds paths with `/`; this appears unrelated to this change.

Closes #936