### PR TITLE
fix: include interfaces in superclass relationships

### DIFF
--- a/quark/core/apkinfo.py
+++ b/quark/core/apkinfo.py
@@ -452,7 +452,7 @@ class AndroguardImp(BaseApkinfo):
 
         for _class in self.analysis.get_classes():
             hierarchy_dict[str(_class.name)].add(str(_class.extends))
-            hierarchy_dict[str(_class.name)].union(
+            hierarchy_dict[str(_class.name)].update(
                 str(implements) for implements in _class.implements
             )
 

--- a/tests/core/test_apkinfo.py
+++ b/tests/core/test_apkinfo.py
@@ -1,4 +1,5 @@
 import os
+from types import SimpleNamespace
 from typing import Literal, Tuple
 import zipfile
 
@@ -688,6 +689,24 @@ class TestApkinfo:
         upper_set = apkinfo.superclass_relationships[class_name]
 
         assert expected_upper_class == upper_set
+
+    def test_superclass_relationships_include_implemented_interfaces(self):
+        apkinfo = AndroguardImp.__new__(AndroguardImp)
+        apkinfo.analysis = SimpleNamespace(
+            get_classes=lambda: [
+                SimpleNamespace(
+                    name="Lexample/Child;",
+                    extends="Lexample/Parent;",
+                    implements=["Lexample/FirstInterface;", "Lexample/SecondInterface;"],
+                )
+            ]
+        )
+
+        assert apkinfo.superclass_relationships["Lexample/Child;"] == {
+            "Lexample/Parent;",
+            "Lexample/FirstInterface;",
+            "Lexample/SecondInterface;",
+        }
 
     @staticmethod
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- include implemented interfaces in `superclass_relationships`
- add a regression test covering a class with a parent and two interfaces

## Validation
- `python -m compileall -q quark/core/apkinfo.py tests/core/test_apkinfo.py`
- `git diff --check`
- verified the expected set-update behavior with a minimal local fixture

The targeted pytest invocation could not be collected locally because this machine lacks the project's pinned `androguard==3.4.0a1` dependency; the new regression test will run in the repository CI environment.