### PR TITLE
Add DexTrace core-library backend (continuation of PR #855)

### DIFF
--- a/quark/cli.py
+++ b/quark/cli.py
@@ -134,7 +134,7 @@ logo()
     "core_library",
     help="Specify the core library used to analyze an APK",
     type=click.Choice(
-        ("androguard", "rizin", "radare2", "shuriken"),
+        ("androguard", "rizin", "radare2", "shuriken", "dextrace"),
         case_sensitive=False
     ),
     required=False,

--- a/quark/core/dextraceapkinfo.py
+++ b/quark/core/dextraceapkinfo.py
@@ -1,0 +1,679 @@
+# -*- coding: utf-8 -*-
+# This file is part of Quark-Engine - https://github.com/ev-flow/quark-engine
+# See the file 'LICENSE' for copying permission.
+
+
+from __future__ import annotations
+
+import functools
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from os import PathLike
+from typing import DefaultDict, Dict, Generator, Iterable, List, Optional, Set, Tuple
+
+from quark.core.interface.baseapkinfo import BaseApkinfo
+from quark.core.struct.bytecodeobject import BytecodeObject
+from quark.core.struct.methodobject import MethodObject
+from quark.utils.tools import descriptor_to_androguard_format
+
+# DexTrace public API (NO CLI fallback)
+# You said: api.py is DexTrace’s external interface.
+from dextrace.api import (  # type: ignore
+    DextraceApiOptions,
+    disasm_method,
+    extract_api_calls,
+    get_apk_permissions,
+)
+
+# ---- Compatibility cache object (MethodObject.cache) ----
+@dataclass(frozen=True)
+class DextraceMethodCache:
+    """
+    Minimal fields Quark/MethodObject may access.
+    """
+    full_name: str
+    external: bool
+    is_android_api: bool
+
+
+class DexTraceImp(BaseApkinfo):
+    """
+    DexTrace-based Apkinfo backend.
+
+    - Call graph source: dextrace.api.extract_api_calls() (pure function)
+    - Evidence source:  dextrace.api.disasm_method() (pure function)
+    - Permissions:      dextrace.api.get_apk_permissions() (pure function)
+
+    NO CLI fallback.
+    """
+
+    def __init__(
+        self,
+        apk_filepath: str | PathLike,
+        tmp_dir: str | PathLike = None,
+        *,
+        api_options: Optional[DextraceApiOptions] = None,
+        enable_disasm: bool = True,
+        debug: bool = False,
+    ):
+        super().__init__(apk_filepath, "dextrace", tmp_dir)
+
+        self._target_path = str(apk_filepath)
+        self._options = api_options or DextraceApiOptions()
+        self._enable_disasm = bool(enable_disasm)
+        self._debug = bool(debug)
+
+        # Permissions (APK mode only) via DexTrace api
+        self._permissions: List[str] = []
+        if self.ret_type == "APK":
+            try:
+                self._permissions = list(get_apk_permissions(self._target_path))
+            except Exception:
+                self._permissions = []
+
+        # registries
+        self._method_by_sig: Dict[Tuple[str, str, str], MethodObject] = {}
+
+        # Quark graph structures
+        self._calls_by_caller: DefaultDict[MethodObject, List[Tuple[MethodObject, int]]] = defaultdict(list)
+        self._callers_by_callee: DefaultDict[MethodObject, Set[MethodObject]] = defaultdict(set)
+
+        # Helper: signature-indexed ordered callees (for evidence)
+        self._calls_by_caller_sig: DefaultDict[str, List[Tuple[str, int]]] = defaultdict(list)
+
+        # Build call graph from DexTrace api
+        dex_report = extract_api_calls(self._target_path, options=self._options)
+        api_calls = self._extract_api_calls(dex_report)
+        self._build_graph(api_calls)
+
+    # ---------- Basic metadata ----------
+    @property
+    def permissions(self) -> List[str]:
+        return self._permissions
+
+    # ---------- Method sets ----------
+    @functools.cached_property
+    def all_methods(self) -> Set[MethodObject]:
+        return set(self._method_by_sig.values())
+
+    @property
+    def android_apis(self) -> Set[MethodObject]:
+        return {m for m in self.all_methods if getattr(m, "cache", None) and m.cache.is_android_api}
+
+    @property
+    def custom_methods(self) -> Set[MethodObject]:
+        return {m for m in self.all_methods if getattr(m, "cache", None) and not m.cache.external}
+
+    # ---------- Find method ----------
+    @functools.lru_cache()
+    def find_method(
+        self,
+        class_name: Optional[str] = None,
+        method_name: Optional[str] = None,
+        descriptor: Optional[str] = None,
+    ) -> List[MethodObject]:
+        methods: Iterable[MethodObject] = self.all_methods
+        if class_name:
+            methods = (m for m in methods if m.class_name == class_name)
+        if method_name:
+            methods = (m for m in methods if m.name == method_name)
+        if descriptor:
+            methods = (m for m in methods if m.descriptor == descriptor)
+        return list(methods)
+
+    # ---------- XREFs ----------
+    @functools.lru_cache()
+    def upperfunc(self, method_object: MethodObject) -> Set[MethodObject]:
+        return set(self._callers_by_callee.get(method_object, set()))
+
+    @functools.lru_cache()
+    def lowerfunc(self, method_object: MethodObject) -> List[Tuple[MethodObject, int]]:
+        # Second element is call-order (0..n-1), stable and per-caller
+        return list(self._calls_by_caller.get(method_object, []))
+
+    # ---------- Bytecode ----------
+    def get_method_bytecode(self, method_object: MethodObject) -> Generator[BytecodeObject, None, None]:
+        """
+        Best-effort for Quark stage-5 evidence/reporting.
+        We convert smali lines to BytecodeObject.
+        """
+        ins_json = self._get_method_instructions_json(method_object)
+        if not ins_json:
+            return
+        for ins in ins_json:
+            smali = (ins.get("smali") or "").strip()
+            if not smali or smali.startswith(":"):
+                continue
+            try:
+                yield self._parse_smali_to_bytecodeobject(smali)
+            except Exception:
+                continue
+
+    def get_strings(self) -> Set[str]:
+        return set()
+
+    @property
+    def superclass_relationships(self) -> Dict[str, Set[str]]:
+        return defaultdict(set)
+
+    @property
+    def subclass_relationships(self) -> Dict[str, Set[str]]:
+        return defaultdict(set)
+
+    # ---------- Evidence / wrapper smali ----------
+    @functools.lru_cache
+    def get_wrapper_smali(
+        self,
+        parent_method: MethodObject,
+        first_method: MethodObject,
+        second_method: MethodObject,
+    ) -> dict[str, object]:
+        """
+        Quark evidence expects:
+          first  = [mnemonic, "L...;->callee(...)R"]
+          second = [mnemonic, "L...;->callee(...)R"]
+        (NOT Quark's spaced full_name)
+        """
+        parent_sig = self._methodobject_to_dextrace_sig(parent_method)
+        calls = self._calls_by_caller_sig.get(parent_sig, [])
+
+        first_idx = None
+        second_idx = None
+
+        first_sig = self._methodobject_to_dextrace_sig(first_method)
+        second_sig = self._methodobject_to_dextrace_sig(second_method)
+
+        for i, (callee_sig, _order) in enumerate(calls):
+            if first_idx is None and callee_sig == first_sig:
+                first_idx = i
+            if first_idx is not None and callee_sig == second_sig:
+                second_idx = i
+                break
+
+        # IMPORTANT: always use dextrace sig as callee signature in evidence
+        first_callee_sig = first_sig
+        second_callee_sig = second_sig
+
+        # default fallback
+        first_line = ["invoke", first_callee_sig]
+        second_line = ["invoke", second_callee_sig]
+        first_hex = ""
+        second_hex = ""
+
+        first_context: List[dict] = []
+        second_context: List[dict] = []
+        first_context_smali: List[str] = []
+        second_context_smali: List[str] = []
+
+        def _it_smali(it: dict) -> str:
+            return (it.get("smali") or "").strip()
+
+        def _it_hex(it: dict) -> str:
+            h = it.get("raw_hex") or it.get("hex") or it.get("bytes") or it.get("insn_hex")
+            return (h or "").strip()
+
+        def _it_off(it: dict) -> Optional[int]:
+            v = it.get("offset")
+            if v is None:
+                return None
+            try:
+                return int(v)
+            except Exception:
+                return None
+
+        def _it_byte_off(it: dict) -> Optional[int]:
+            v = it.get("byte_off") or it.get("byteOff")
+            if v is None:
+                return None
+            try:
+                return int(v)
+            except Exception:
+                return None
+
+        ins_json = self._get_method_instructions_json(parent_method)
+        if ins_json:
+
+            def _norm(s: str) -> str:
+                # remove ALL whitespace for robust matching
+                return re.sub(r"\s+", "", s or "")
+
+            def _find_line_idx(needle_sig: str) -> Optional[int]:
+                n = _norm(needle_sig)
+                if not n:
+                    return None
+                for j, it in enumerate(ins_json):
+                    s = _it_smali(it)
+                    if not s or s.startswith(":"):
+                        continue
+                    if n in _norm(s):
+                        return j
+                return None
+
+            i1 = _find_line_idx(first_callee_sig)
+            i2 = _find_line_idx(second_callee_sig)
+
+            def _make_ctx(center: int, window: int) -> Tuple[List[dict], List[str]]:
+                a = max(0, center - window)
+                b = min(len(ins_json), center + window + 1)
+                ctx_dicts: List[dict] = []
+                ctx_smali: List[str] = []
+                for k in range(a, b):
+                    it = ins_json[k]
+                    s = _it_smali(it)
+                    if not s:
+                        continue
+                    ctx_smali.append(s)
+                    ctx_dicts.append(
+                        {
+                            "smali": s,
+                            "hex": _it_hex(it),
+                            "offset": _it_off(it),
+                            "byte_off": _it_byte_off(it),
+                        }
+                    )
+                return ctx_dicts, ctx_smali
+
+            window = int(getattr(self._options, "disasm_context_window", 2) or 2)
+
+            if i1 is not None:
+                s1 = _it_smali(ins_json[i1])
+                if s1 and not s1.startswith(":"):
+                    first_line = [s1.split()[0], first_callee_sig]
+                first_hex = _it_hex(ins_json[i1]) or ""
+                first_context, first_context_smali = _make_ctx(i1, window=window)
+
+            if i2 is not None:
+                s2 = _it_smali(ins_json[i2])
+                if s2 and not s2.startswith(":"):
+                    second_line = [s2.split()[0], second_callee_sig]
+                second_hex = _it_hex(ins_json[i2]) or ""
+                second_context, second_context_smali = _make_ctx(i2, window=window)
+
+        return {
+            "first": first_line,
+            "first_hex": first_hex,
+            "second": second_line,
+            "second_hex": second_hex,
+            "meta": {
+                "parent": parent_sig,
+                "first_call_order": first_idx,
+                "second_call_order": second_idx,
+                "first_context": first_context,
+                "second_context": second_context,
+                "first_context_smali": first_context_smali,
+                "second_context_smali": second_context_smali,
+                "note": "Evidence from DexTrace api disasm_method(). Callee signatures forced to L...;->m(...)R form.",
+            },
+        }
+
+    # =========================
+    # Internal helpers
+    # =========================
+
+    def _extract_api_calls(self, dex_report: dict) -> List[dict]:
+        """
+        Accept these containers:
+        - {"dex": {"api_calls": [...]}}
+        - {"dex": {"apiCalls": [...]}}
+        - {"api_calls": [...]}
+        - {"apiCalls": [...]}
+        """
+        if not isinstance(dex_report, dict):
+            return []
+
+        root = dex_report
+        if isinstance(dex_report.get("dex"), dict):
+            root = dex_report["dex"]
+
+        for key in ("api_calls", "apiCalls", "apiCall", "calls"):
+            calls = root.get(key)
+            if isinstance(calls, list):
+                # api.py already normalizes ApiCall -> dict
+                return [c for c in calls if isinstance(c, dict)]
+
+        if isinstance(root.get("result"), dict):
+            rr = root["result"]
+            for key in ("api_calls", "apiCalls", "calls"):
+                calls = rr.get(key)
+                if isinstance(calls, list):
+                    return [c for c in calls if isinstance(c, dict)]
+
+        return []
+
+    def _build_graph(self, api_calls: List[dict]) -> None:
+        """
+        Build Quark graph using stable per-caller call order.
+
+        Strategy:
+        - Group by caller_sig
+        - Sort by invoke offset/uoff/byte_off if present (best-effort)
+        - Enumerate -> call order (0..n-1) for Quark lowerfunc()
+        - Also populate _calls_by_caller_sig for evidence
+        """
+
+        def _pick(d: dict, *keys):
+            for k in keys:
+                if k in d and d.get(k) is not None:
+                    return d.get(k)
+            return None
+
+        def _parse_dextrace_sig(sig: str) -> dict:
+            """
+            Parse into {"class":..., "method":..., "proto":...}
+            Accept: Lpkg/name/Cls;->m(I)Z
+            """
+            s = (sig or "").strip()
+            if not s:
+                return {}
+            s = re.sub(r"\s+", "", s)
+
+            if "->" not in s:
+                return {"class": s}
+
+            cls, rest = s.split("->", 1)
+            if "(" in rest:
+                mname = rest.split("(", 1)[0]
+                proto = "(" + rest.split("(", 1)[1]
+            else:
+                mname = rest
+                proto = ""
+            if not cls.startswith("L"):
+                cls = "L" + cls
+            if not cls.endswith(";") and ";" not in cls:
+                cls = cls + ";"
+            return {"class": cls, "method": mname, "proto": proto}
+
+        def _extract_method_raw(call: dict, which: str) -> dict:
+            if not isinstance(call, dict):
+                return {}
+
+            raw = call.get(which)
+            if isinstance(raw, dict):
+                return raw
+
+            raw = _pick(call, f"{which}_method", f"{which}Method", f"{which}_info", f"{which}Info")
+            if isinstance(raw, dict):
+                return raw
+
+            sig = _pick(call, f"{which}_sig", f"{which}Sig", f"{which}_signature", f"{which}Signature")
+            if isinstance(sig, str) and sig.strip():
+                return _parse_dextrace_sig(sig)
+
+            return {}
+
+        def _extract_offset(call: dict) -> Optional[int]:
+            if not isinstance(call, dict):
+                return None
+
+            inv = call.get("invoke")
+            if isinstance(inv, dict):
+                v = _pick(
+                    inv,
+                    "offset",
+                    "uoff",
+                    "insn_off",
+                    "insnOff",
+                    "byte_off",
+                    "byteOff",
+                    "idx",
+                    "index",
+                    "order",
+                )
+                if v is not None:
+                    try:
+                        return int(v)
+                    except Exception:
+                        pass
+
+            v = _pick(
+                call,
+                "offset",
+                "uoff",
+                "insn_off",
+                "byte_off",
+                "idx",
+                "index",
+                "order",
+                "invoke_offset",
+                "invokeOffset",
+            )
+            if v is not None:
+                try:
+                    return int(v)
+                except Exception:
+                    pass
+            return None
+
+        per_caller: DefaultDict[str, List[Tuple[Optional[int], str]]] = defaultdict(list)
+
+        for call in api_calls:
+            if not isinstance(call, dict):
+                continue
+
+            caller_raw = _extract_method_raw(call, "caller")
+            callee_raw = _extract_method_raw(call, "callee")
+
+            caller_mo = self._to_method_object(caller_raw or {})
+            callee_mo = self._to_method_object(callee_raw or {})
+
+            caller_sig = self._methodobject_to_dextrace_sig(caller_mo)
+            callee_sig = self._methodobject_to_dextrace_sig(callee_mo)
+
+            off = _extract_offset(call)
+            per_caller[caller_sig].append((off, callee_sig))
+
+        for caller_sig, items in per_caller.items():
+            # stable sort: offset-present first (ascending), then missing; keep original order as tiebreaker
+            items_sorted = sorted(
+                enumerate(items),
+                key=lambda x: (x[1][0] is None, x[1][0] if x[1][0] is not None else 0, x[0]),
+            )
+
+            caller_mo = self._sig_to_method_object(caller_sig)
+
+            for order, (_orig_idx, (_off, callee_sig)) in enumerate(items_sorted):
+                callee_mo = self._sig_to_method_object(callee_sig)
+
+                self._calls_by_caller[caller_mo].append((callee_mo, int(order)))
+                self._callers_by_callee[callee_mo].add(caller_mo)
+
+                self._calls_by_caller_sig[caller_sig].append((callee_sig, int(order)))
+
+    def _sig_to_method_object(self, dextrace_sig: str) -> MethodObject:
+        """
+        Create/find a MethodObject from a DexTrace method signature:
+          Lpkg/name/Class;->method(Args)Ret
+        """
+        sig = self._normalize_dextrace_sig(dextrace_sig)
+
+        m = re.match(r"^(L[^;]+;)->([^(]+)(\(.*\).*)$", sig)
+        if not m:
+            cls = ""
+            name = sig
+            desc = ""
+        else:
+            cls = m.group(1)
+            name = m.group(2)
+            desc = m.group(3)
+
+        desc = self._normalize_descriptor(desc)
+        key = (cls, name, desc)
+        if key in self._method_by_sig:
+            return self._method_by_sig[key]
+
+        full_name = f"{cls}->{name}{desc}"
+        external = self._is_external_class(cls)
+        is_android_api = self._is_android_api_class(cls)
+        cache = DextraceMethodCache(full_name=full_name, external=external, is_android_api=is_android_api)
+        mo = MethodObject(class_name=cls, name=name, descriptor=desc, cache=cache)
+        self._method_by_sig[key] = mo
+        return mo
+
+    def _to_method_object(self, raw: dict) -> MethodObject:
+        """
+        Normalize raw method dict to Quark MethodObject.
+        Accept flexible key names.
+        """
+        if not isinstance(raw, dict):
+            raw = {}
+
+        cls = raw.get("class") or raw.get("class_name") or raw.get("clazz") or ""
+        name = raw.get("method") or raw.get("name") or raw.get("method_name") or ""
+        desc = raw.get("descriptor") or raw.get("proto") or raw.get("signature") or ""
+
+        cls = self._normalize_class(str(cls))
+        desc = self._normalize_descriptor(str(desc))
+
+        key = (cls, str(name), desc)
+        if key in self._method_by_sig:
+            return self._method_by_sig[key]
+
+        full_name = f"{cls}->{name}{desc}"
+        external = self._is_external_class(cls)
+        is_android_api = self._is_android_api_class(cls)
+        cache = DextraceMethodCache(full_name=full_name, external=external, is_android_api=is_android_api)
+        mo = MethodObject(class_name=cls, name=str(name), descriptor=desc, cache=cache)
+        self._method_by_sig[key] = mo
+        return mo
+
+    def _normalize_class(self, cls: str) -> str:
+        cls = str(cls).strip()
+        if not cls:
+            return cls
+        if cls.startswith("L") and cls.endswith(";"):
+            return cls.replace(".", "/")
+        if "/" in cls and not cls.startswith("L"):
+            return f"L{cls};"
+        return f"L{cls.replace('.', '/')};"
+
+    def _normalize_descriptor(self, desc: str) -> str:
+        desc = str(desc).strip()
+        if not desc:
+            return desc
+        if "(" in desc and ")" in desc:
+            try:
+                # Quark uses androguard-format descriptors with spaces
+                return descriptor_to_androguard_format(desc.replace(" ", ""))
+            except Exception:
+                return desc
+        return desc
+
+    def _normalize_dextrace_sig(self, sig: str) -> str:
+        return re.sub(r"\s+", "", str(sig))
+
+    def _methodobject_to_dextrace_sig(self, mo: MethodObject) -> str:
+        """
+        Convert Quark MethodObject to DexTrace signature (no spaces):
+          Lcls;->name(Args)Ret
+        """
+        cls = (mo.class_name or "").strip()
+        name = (mo.name or "").strip()
+        desc = (mo.descriptor or "").strip()
+
+        desc = re.sub(r"\s+", "", desc)
+        cls = self._normalize_class(cls)
+        return f"{cls}->{name}{desc}"
+
+    def _is_android_api_class(self, cls: str) -> bool:
+        # Android framework + Java/Kotlin stdlib
+        return cls.startswith("Landroid/") or cls.startswith("Ljava/") or cls.startswith("Ljavax/") or cls.startswith(
+            "Lkotlin/"
+        )
+
+    def _is_external_class(self, cls: str) -> bool:
+        # Conservative: framework/stdlib are external.
+        return self._is_android_api_class(cls)
+
+    # -------- Disasm integration (DexTrace api) --------
+
+    @functools.lru_cache(maxsize=4096)
+    def _disasm_by_sig(self, dextrace_sig: str) -> Optional[List[dict]]:
+        """
+        Cached disasm result by DexTrace signature.
+        Returns list[dict] like:
+          [{"offset":..,"byte_off":..,"smali":"...","raw_hex":"..."} ...] or None.
+        """
+        if not self._enable_disasm:
+            return None
+
+        sig = self._normalize_dextrace_sig(dextrace_sig)
+        if self._debug:
+            print("[dextrace api disasm]", sig)
+
+        try:
+            out = disasm_method(self._target_path, sig, options=self._options)
+        except Exception:
+            return None
+
+        methods = out.get("methods")
+        if not isinstance(methods, dict):
+            return None
+
+        m = methods.get(sig)
+        if not isinstance(m, dict):
+            # fallback: try normalized key match
+            for k, v in methods.items():
+                if isinstance(k, str) and self._normalize_dextrace_sig(k) == sig and isinstance(v, dict):
+                    m = v
+                    break
+            if not isinstance(m, dict):
+                return None
+
+        ins = m.get("instructions")
+        if not isinstance(ins, list):
+            return None
+
+        out_list: List[dict] = []
+        for it in ins:
+            if isinstance(it, dict) and "smali" in it:
+                out_list.append(it)
+        return out_list or None
+
+    def _get_method_instructions_json(self, method_object: MethodObject) -> Optional[List[dict]]:
+        sig = self._methodobject_to_dextrace_sig(method_object)
+        return self._disasm_by_sig(sig)
+
+    # -------- Small smali parser --------
+    _SMALI_SPLIT_RE = re.compile(r"[{},]+")
+
+    def _parse_smali_to_bytecodeobject(self, smali: str) -> BytecodeObject:
+        smali = smali.rsplit("//", maxsplit=1)[0].strip()
+        if not smali:
+            raise ValueError("Empty smali")
+
+        if " " not in smali:
+            return BytecodeObject(smali, None, None)
+
+        mnemonic, args_str = smali.split(maxsplit=1)
+        args = [a.strip() for a in self._SMALI_SPLIT_RE.split(args_str) if a.strip()]
+
+        regs: List[str] = []
+        params: List[str] = []
+        for a in args:
+            if a.startswith(("v", "p")):
+                regs.append(a)
+            else:
+                params.append(a)
+
+        parameter = params[-1] if params else None
+
+        # ---- IMPORTANT: normalize invoke parameter to Quark/Androguard style ----
+        # smali invoke last arg is usually: Lcls;->m(Args)Ret
+        # Quark pattern in rules often uses androguard format with spaces:
+        #   Lcls; m (ArgsWithSpaces)Ret
+        if parameter and mnemonic.startswith("invoke-") and "->" in parameter and "(" in parameter:
+            try:
+                cls, rest = parameter.split("->", 1)
+                mname = rest.split("(", 1)[0]
+                proto = "(" + rest.split("(", 1)[1]  # includes return type
+                proto = proto.replace(" ", "")
+                # make it androguard-format (adds spaces between params)
+                proto_fmt = descriptor_to_androguard_format(proto)
+                # match Quark's common printing style: "Lcls; method (..).."
+                parameter = f"{cls}->{mname}{proto_fmt}"
+            except Exception:
+                # if anything fails, keep raw parameter
+                pass
+
+        return BytecodeObject(mnemonic, regs or None, parameter)

--- a/quark/core/dextraceapkinfo.py
+++ b/quark/core/dextraceapkinfo.py
@@ -23,6 +23,7 @@ from dextrace.api import (  # type: ignore
     DextraceApiOptions,
     disasm_method,
     extract_api_calls,
+    extract_class_hierarchy,
     get_apk_permissions,
 )
 
@@ -174,13 +175,21 @@ class DexTraceImp(BaseApkinfo):
     def get_strings(self) -> Set[str]:
         return set()
 
-    @property
+    @functools.cached_property
     def superclass_relationships(self) -> Dict[str, Set[str]]:
-        return defaultdict(set)
+        result: DefaultDict[str, Set[str]] = defaultdict(set)
+        for cls, superclass in extract_class_hierarchy(self.apk_filepath).items():
+            if superclass is not None:
+                result[cls].add(superclass)
+        return result
 
-    @property
+    @functools.cached_property
     def subclass_relationships(self) -> Dict[str, Set[str]]:
-        return defaultdict(set)
+        result: DefaultDict[str, Set[str]] = defaultdict(set)
+        for cls, supers in self.superclass_relationships.items():
+            for superclass in supers:
+                result[superclass].add(cls)
+        return result
 
     # ---------- Evidence / wrapper smali ----------
     @functools.lru_cache

--- a/quark/core/dextraceapkinfo.py
+++ b/quark/core/dextraceapkinfo.py
@@ -27,6 +27,7 @@ from dextrace.api import (  # type: ignore
     extract_api_calls,
     extract_class_hierarchy,
     get_apk_permissions,
+    iter_apk_dex_files,
 )
 
 # ---- Compatibility cache object (MethodObject.cache) ----
@@ -62,9 +63,8 @@ class DexTraceImp(BaseApkinfo):
     ):
         import tempfile
 
-        super().__init__(apk_filepath, "dextrace", tmp_dir)
-
         self._patched_tmp: Optional[str] = None
+        super().__init__(apk_filepath, "dextrace", tmp_dir)
 
         # BaseApkinfo.patch() rewrote self.data (mmap copy) in-place.
         # DexTrace API only accepts file paths, so write the patched bytes to a
@@ -103,6 +103,12 @@ class DexTraceImp(BaseApkinfo):
         dex_report = extract_api_calls(self._target_path, options=self._options)
         api_calls = self._extract_api_calls(dex_report)
         self._build_graph(api_calls)
+        self._register_abstract_methods()
+
+        # Class-keyed index so find_method() avoids O(|all_methods|) scans
+        self._methods_by_class: DefaultDict[str, List[MethodObject]] = defaultdict(list)
+        for _mo in self._method_by_sig.values():
+            self._methods_by_class[_mo.class_name].append(_mo)
 
     def __del__(self):
         if self._patched_tmp:
@@ -135,15 +141,16 @@ class DexTraceImp(BaseApkinfo):
         method_name: Optional[str] = None,
         descriptor: Optional[str] = None,
     ) -> List[MethodObject]:
-        methods: Iterable[MethodObject] = self.all_methods
         if class_name:
             normalized_class = self._normalize_class(class_name)
-            methods = (m for m in methods if m.class_name == normalized_class)
+            candidates: Iterable[MethodObject] = self._methods_by_class.get(normalized_class, [])
+        else:
+            candidates = self._method_by_sig.values()
         if method_name:
-            methods = (m for m in methods if m.name == method_name)
+            candidates = (m for m in candidates if m.name == method_name)
         if descriptor:
-            methods = (m for m in methods if m.descriptor == descriptor)
-        return list(methods)
+            candidates = (m for m in candidates if m.descriptor == descriptor)
+        return list(candidates)
 
     # ---------- XREFs ----------
     @functools.lru_cache()
@@ -530,6 +537,35 @@ class DexTraceImp(BaseApkinfo):
                 self._callers_by_callee[callee_mo].add(caller_mo)
 
                 self._calls_by_caller_sig[caller_sig].append((callee_sig, int(order)))
+
+    def _register_abstract_methods(self) -> None:
+        """Second pass: register abstract/interface method declarations into _method_by_sig.
+
+        extract_api_calls() only sees invoke-* bytecode targets, so abstract
+        methods (code_off=0) never appear as callees and are absent from the
+        call graph.  Quark's find_api_usage needs them as stepping-stones for
+        subtype resolution (level-2/3 combination check).
+        """
+        from dextrace.core.dex_class_iter import iter_class_defs, iter_class_data_methods  # type: ignore
+        from dextrace.core.dex_resolver import DexResolver  # type: ignore
+
+        for _dex_name, dex_bytes in iter_apk_dex_files(self._target_path):
+            try:
+                resolver = DexResolver(dex_bytes)
+            except Exception:
+                continue
+            for cdef in iter_class_defs(dex_bytes):
+                if not cdef.class_data_off:
+                    continue
+                for em in iter_class_data_methods(dex_bytes, cdef.class_data_off):
+                    if em.code_off != 0:
+                        continue  # only abstract (no-bytecode) declarations needed
+                    result = resolver._get_method(em.method_idx)
+                    if not result:
+                        continue
+                    cls, mname, proto = result
+                    # _sig_to_method_object is idempotent: returns existing entry if present
+                    self._sig_to_method_object(f"{cls}->{mname}{proto}")
 
     def _sig_to_method_object(self, dextrace_sig: str) -> MethodObject:
         """

--- a/quark/core/dextraceapkinfo.py
+++ b/quark/core/dextraceapkinfo.py
@@ -26,8 +26,8 @@ from dextrace.api import (  # type: ignore
     disasm_method,
     extract_api_calls,
     extract_class_hierarchy,
-    get_apk_permissions,
     iter_apk_dex_files,
+    parse_manifest,
 )
 
 # ---- Compatibility cache object (MethodObject.cache) ----
@@ -81,13 +81,13 @@ class DexTraceImp(BaseApkinfo):
         self._enable_disasm = bool(enable_disasm)
         self._debug = bool(debug)
 
-        # Permissions (APK mode only) via DexTrace api.
+        # Permissions (APK mode only). parse_manifest() raises ValueError on
+        # unreadable manifest so Quark exits fast (trickmo/tanglebot pattern).
         self._permissions: List[str] = []
         if self.ret_type == "APK":
-            try:
-                self._permissions = list(get_apk_permissions(self._target_path))
-            except Exception:
-                self._permissions = []
+            self._permissions = list(
+                parse_manifest(self._target_path).get("permissions", [])
+            )
 
         # registries
         self._method_by_sig: Dict[Tuple[str, str, str], MethodObject] = {}

--- a/quark/core/dextraceapkinfo.py
+++ b/quark/core/dextraceapkinfo.py
@@ -116,7 +116,8 @@ class DexTraceImp(BaseApkinfo):
     ) -> List[MethodObject]:
         methods: Iterable[MethodObject] = self.all_methods
         if class_name:
-            methods = (m for m in methods if m.class_name == class_name)
+            normalized_class = self._normalize_class(class_name)
+            methods = (m for m in methods if m.class_name == normalized_class)
         if method_name:
             methods = (m for m in methods if m.name == method_name)
         if descriptor:
@@ -573,6 +574,8 @@ class DexTraceImp(BaseApkinfo):
             return cls
         if cls.startswith("L") and cls.endswith(";"):
             return cls.replace(".", "/")
+        if cls.startswith("L") and not cls.endswith(";"):
+            return f"{cls};"
         if "/" in cls and not cls.startswith("L"):
             return f"L{cls};"
         return f"L{cls.replace('.', '/')};"
@@ -667,8 +670,23 @@ class DexTraceImp(BaseApkinfo):
     # -------- Small smali parser --------
     _SMALI_SPLIT_RE = re.compile(r"[{},]+")
 
+    @staticmethod
+    def _strip_smali_comment(smali: str) -> str:
+        idx = smali.find("//")
+        if idx == -1:
+            return smali.strip()
+        if smali[:idx].count('"') % 2 == 0:
+            return smali[:idx].strip()
+        in_string = False
+        for i, c in enumerate(smali):
+            if c == '"':
+                in_string = not in_string
+            elif not in_string and smali[i:i+2] == '//':
+                return smali[:i].strip()
+        return smali.strip()
+
     def _parse_smali_to_bytecodeobject(self, smali: str) -> BytecodeObject:
-        smali = smali.rsplit("//", maxsplit=1)[0].strip()
+        smali = self._strip_smali_comment(smali)
         if not smali:
             raise ValueError("Empty smali")
 

--- a/quark/core/dextraceapkinfo.py
+++ b/quark/core/dextraceapkinfo.py
@@ -24,9 +24,9 @@ from quark.utils.tools import descriptor_to_androguard_format
 from dextrace.api import (  # type: ignore
     DextraceApiOptions,
     disasm_method,
+    extract_abstract_methods,
     extract_api_calls,
     extract_class_hierarchy,
-    iter_apk_dex_files,
     parse_manifest,
 )
 
@@ -99,11 +99,15 @@ class DexTraceImp(BaseApkinfo):
         # Helper: signature-indexed ordered callees (for evidence)
         self._calls_by_caller_sig: DefaultDict[str, List[Tuple[str, int]]] = defaultdict(list)
 
-        # Build call graph from DexTrace api
+        # Build call graph from DexTrace api.
+        # extract_api_calls() triggers _all_dex_data_cached(), which performs a
+        # single class_def_item scan and caches api_calls, abstract_methods, and
+        # parent_map together.  The extract_abstract_methods() call below is a
+        # cache hit — no ZIP re-open, no second DEX pass.
         dex_report = extract_api_calls(self._target_path, options=self._options)
         api_calls = self._extract_api_calls(dex_report)
         self._build_graph(api_calls)
-        self._register_abstract_methods()
+        self._register_abstract_methods_from_cache()
 
         # Class-keyed index so find_method() avoids O(|all_methods|) scans
         self._methods_by_class: DefaultDict[str, List[MethodObject]] = defaultdict(list)
@@ -200,8 +204,11 @@ class DexTraceImp(BaseApkinfo):
 
     @functools.cached_property
     def superclass_relationships(self) -> Dict[str, Set[str]]:
+        # extract_class_hierarchy() reads from the _all_dex_data_cached() result
+        # that was already populated by extract_api_calls() in __init__ — no ZIP
+        # re-open and no second class_def_item scan.
         result: DefaultDict[str, Set[str]] = defaultdict(set)
-        for cls, parents in extract_class_hierarchy(self.apk_filepath).items():
+        for cls, parents in extract_class_hierarchy(self._target_path).items():
             result[cls].update(parents)
         return result
 
@@ -285,16 +292,15 @@ class DexTraceImp(BaseApkinfo):
 
         ins_json = self._get_method_instructions_json(parent_method)
         if ins_json:
-            _ws_re_local = self._WHITESPACE_RE
-            n1 = _ws_re_local.sub("", first_callee_sig or "")
-            n2 = _ws_re_local.sub("", second_callee_sig or "")
+            n1 = self._WHITESPACE_RE.sub("", first_callee_sig or "")
+            n2 = self._WHITESPACE_RE.sub("", second_callee_sig or "")
             i1 = None
             i2 = None
             for j, it in enumerate(ins_json):
                 s = _it_smali(it)
                 if not s or s.startswith(":"):
                     continue
-                ns = _ws_re_local.sub("", s)
+                ns = self._WHITESPACE_RE.sub("", s)
                 if i1 is None and n1 and n1 in ns:
                     i1 = j
                 if i2 is None and n2 and n2 in ns:
@@ -400,8 +406,6 @@ class DexTraceImp(BaseApkinfo):
         - Enumerate -> call order (0..n-1) for Quark lowerfunc()
         - Also populate _calls_by_caller_sig for evidence
         """
-        _ws_re = self._WHITESPACE_RE
-
         def _pick(d: dict, *keys):
             for k in keys:
                 if k in d and d.get(k) is not None:
@@ -416,7 +420,7 @@ class DexTraceImp(BaseApkinfo):
             s = (sig or "").strip()
             if not s:
                 return {}
-            s = _ws_re.sub("", s)
+            s = self._WHITESPACE_RE.sub("", s)
 
             if "->" not in s:
                 return {"class": s}
@@ -530,34 +534,20 @@ class DexTraceImp(BaseApkinfo):
 
                 self._calls_by_caller_sig[caller_sig].append((callee_sig, int(order)))
 
-    def _register_abstract_methods(self) -> None:
-        """Second pass: register abstract/interface method declarations into _method_by_sig.
+    def _register_abstract_methods_from_cache(self) -> None:
+        """Register abstract/interface method declarations into _method_by_sig.
 
         extract_api_calls() only sees invoke-* bytecode targets, so abstract
         methods (code_off=0) never appear as callees and are absent from the
         call graph.  Quark's find_api_usage needs them as stepping-stones for
         subtype resolution (level-2/3 combination check).
-        """
-        from dextrace.core.dex_class_iter import iter_class_defs, iter_class_data_methods  # type: ignore
-        from dextrace.core.dex_resolver import DexResolver  # type: ignore
 
-        for _dex_name, dex_bytes in iter_apk_dex_files(self._target_path):
-            try:
-                resolver = DexResolver(dex_bytes)
-            except Exception:
-                continue
-            for cdef in iter_class_defs(dex_bytes):
-                if not cdef.class_data_off:
-                    continue
-                for em in iter_class_data_methods(dex_bytes, cdef.class_data_off):
-                    if em.code_off != 0:
-                        continue  # only abstract (no-bytecode) declarations needed
-                    result = resolver._get_method(em.method_idx)
-                    if not result:
-                        continue
-                    cls, mname, proto = result
-                    # _sig_to_method_object is idempotent: returns existing entry if present
-                    self._sig_to_method_object(f"{cls}->{mname}{proto}")
+        This method reads from the cached _all_dex_data_cached() result — no
+        ZIP re-open and no second class_def_item scan.
+        """
+        for sig in extract_abstract_methods(self._target_path):
+            # _sig_to_method_object is idempotent: returns existing entry if present
+            self._sig_to_method_object(sig)
 
     def _create_method_object(self, cls: str, name: str, desc: str) -> MethodObject:
         key = (cls, name, desc)

--- a/quark/core/dextraceapkinfo.py
+++ b/quark/core/dextraceapkinfo.py
@@ -137,7 +137,28 @@ class DexTraceImp(BaseApkinfo):
         """
         Best-effort for Quark stage-5 evidence/reporting.
         We convert smali lines to BytecodeObject.
+
+        Fast path: methods that appear as callers in the DexTrace call graph
+        definitely have DEX bytecode.  Yield a no-op sentinel FIRST so that
+        callers who only check `next(..., None)` (e.g. find_api_usage) short-
+        circuit without triggering the expensive disasm call.  Full consumers
+        (e.g. _evaluate_method) iterate past the sentinel and get real opcodes.
         """
+        if method_object in self._calls_by_caller:
+            yield BytecodeObject("", None, "")  # sentinel — signals "has bytecode"
+            # Reached only when consumer iterates beyond the sentinel
+            ins_json = self._get_method_instructions_json(method_object)
+            if ins_json:
+                for ins in ins_json:
+                    smali = (ins.get("smali") or "").strip()
+                    if not smali or smali.startswith(":"):
+                        continue
+                    try:
+                        yield self._parse_smali_to_bytecodeobject(smali)
+                    except Exception:
+                        continue
+            return
+
         ins_json = self._get_method_instructions_json(method_object)
         if not ins_json:
             return

--- a/quark/core/dextraceapkinfo.py
+++ b/quark/core/dextraceapkinfo.py
@@ -6,8 +6,10 @@
 from __future__ import annotations
 
 import functools
+import os
 import re
 from collections import defaultdict
+from contextlib import suppress
 from dataclasses import dataclass
 from os import PathLike
 from typing import DefaultDict, Dict, Generator, Iterable, List, Optional, Set, Tuple
@@ -58,14 +60,28 @@ class DexTraceImp(BaseApkinfo):
         enable_disasm: bool = True,
         debug: bool = False,
     ):
+        import tempfile
+
         super().__init__(apk_filepath, "dextrace", tmp_dir)
 
-        self._target_path = str(apk_filepath)
+        self._patched_tmp: Optional[str] = None
+
+        # BaseApkinfo.patch() rewrote self.data (mmap copy) in-place.
+        # DexTrace API only accepts file paths, so write the patched bytes to a
+        # temp file and point all DexTrace calls there.
+        if self.isPatched and self.ret_type == "APK":
+            fd, self._patched_tmp = tempfile.mkstemp(suffix=".apk")
+            try:
+                os.write(fd, self.data[:])
+            finally:
+                os.close(fd)  # close fd; file remains on disk until __del__
+
+        self._target_path = self._patched_tmp if self._patched_tmp else str(apk_filepath)
         self._options = api_options or DextraceApiOptions()
         self._enable_disasm = bool(enable_disasm)
         self._debug = bool(debug)
 
-        # Permissions (APK mode only) via DexTrace api
+        # Permissions (APK mode only) via DexTrace api.
         self._permissions: List[str] = []
         if self.ret_type == "APK":
             try:
@@ -87,6 +103,11 @@ class DexTraceImp(BaseApkinfo):
         dex_report = extract_api_calls(self._target_path, options=self._options)
         api_calls = self._extract_api_calls(dex_report)
         self._build_graph(api_calls)
+
+    def __del__(self):
+        if self._patched_tmp:
+            with suppress(Exception):
+                os.unlink(self._patched_tmp)
 
     # ---------- Basic metadata ----------
     @property
@@ -179,9 +200,8 @@ class DexTraceImp(BaseApkinfo):
     @functools.cached_property
     def superclass_relationships(self) -> Dict[str, Set[str]]:
         result: DefaultDict[str, Set[str]] = defaultdict(set)
-        for cls, superclass in extract_class_hierarchy(self.apk_filepath).items():
-            if superclass is not None:
-                result[cls].add(superclass)
+        for cls, parents in extract_class_hierarchy(self.apk_filepath).items():
+            result[cls].update(parents)
         return result
 
     @functools.cached_property

--- a/quark/core/dextraceapkinfo.py
+++ b/quark/core/dextraceapkinfo.py
@@ -125,13 +125,13 @@ class DexTraceImp(BaseApkinfo):
     def all_methods(self) -> Set[MethodObject]:
         return set(self._method_by_sig.values())
 
-    @property
+    @functools.cached_property
     def android_apis(self) -> Set[MethodObject]:
-        return {m for m in self.all_methods if getattr(m, "cache", None) and m.cache.is_android_api}
+        return {m for m in self.all_methods if m.cache.is_android_api}
 
-    @property
+    @functools.cached_property
     def custom_methods(self) -> Set[MethodObject]:
-        return {m for m in self.all_methods if getattr(m, "cache", None) and not m.cache.external}
+        return {m for m in self.all_methods if not m.cache.external}
 
     # ---------- Find method ----------
     @functools.lru_cache()
@@ -163,6 +163,16 @@ class DexTraceImp(BaseApkinfo):
         return list(self._calls_by_caller.get(method_object, []))
 
     # ---------- Bytecode ----------
+    def _yield_bytecode_from_json(self, ins_json: List[dict]) -> Generator[BytecodeObject, None, None]:
+        for ins in ins_json:
+            smali = (ins.get("smali") or "").strip()
+            if not smali or smali.startswith(":"):
+                continue
+            try:
+                yield self._parse_smali_to_bytecodeobject(smali)
+            except Exception:
+                continue
+
     def get_method_bytecode(self, method_object: MethodObject) -> Generator[BytecodeObject, None, None]:
         """
         Best-effort for Quark stage-5 evidence/reporting.
@@ -176,30 +186,14 @@ class DexTraceImp(BaseApkinfo):
         """
         if method_object in self._calls_by_caller:
             yield BytecodeObject("", None, "")  # sentinel — signals "has bytecode"
-            # Reached only when consumer iterates beyond the sentinel
             ins_json = self._get_method_instructions_json(method_object)
             if ins_json:
-                for ins in ins_json:
-                    smali = (ins.get("smali") or "").strip()
-                    if not smali or smali.startswith(":"):
-                        continue
-                    try:
-                        yield self._parse_smali_to_bytecodeobject(smali)
-                    except Exception:
-                        continue
+                yield from self._yield_bytecode_from_json(ins_json)
             return
 
         ins_json = self._get_method_instructions_json(method_object)
-        if not ins_json:
-            return
-        for ins in ins_json:
-            smali = (ins.get("smali") or "").strip()
-            if not smali or smali.startswith(":"):
-                continue
-            try:
-                yield self._parse_smali_to_bytecodeobject(smali)
-            except Exception:
-                continue
+        if ins_json:
+            yield from self._yield_bytecode_from_json(ins_json)
 
     def get_strings(self) -> Set[str]:
         return set()
@@ -291,25 +285,22 @@ class DexTraceImp(BaseApkinfo):
 
         ins_json = self._get_method_instructions_json(parent_method)
         if ins_json:
-
-            def _norm(s: str) -> str:
-                # remove ALL whitespace for robust matching
-                return re.sub(r"\s+", "", s or "")
-
-            def _find_line_idx(needle_sig: str) -> Optional[int]:
-                n = _norm(needle_sig)
-                if not n:
-                    return None
-                for j, it in enumerate(ins_json):
-                    s = _it_smali(it)
-                    if not s or s.startswith(":"):
-                        continue
-                    if n in _norm(s):
-                        return j
-                return None
-
-            i1 = _find_line_idx(first_callee_sig)
-            i2 = _find_line_idx(second_callee_sig)
+            _ws_re_local = self._WHITESPACE_RE
+            n1 = _ws_re_local.sub("", first_callee_sig or "")
+            n2 = _ws_re_local.sub("", second_callee_sig or "")
+            i1 = None
+            i2 = None
+            for j, it in enumerate(ins_json):
+                s = _it_smali(it)
+                if not s or s.startswith(":"):
+                    continue
+                ns = _ws_re_local.sub("", s)
+                if i1 is None and n1 and n1 in ns:
+                    i1 = j
+                if i2 is None and n2 and n2 in ns:
+                    i2 = j
+                if i1 is not None and i2 is not None:
+                    break
 
             def _make_ctx(center: int, window: int) -> Tuple[List[dict], List[str]]:
                 a = max(0, center - window)
@@ -409,6 +400,7 @@ class DexTraceImp(BaseApkinfo):
         - Enumerate -> call order (0..n-1) for Quark lowerfunc()
         - Also populate _calls_by_caller_sig for evidence
         """
+        _ws_re = self._WHITESPACE_RE
 
         def _pick(d: dict, *keys):
             for k in keys:
@@ -424,7 +416,7 @@ class DexTraceImp(BaseApkinfo):
             s = (sig or "").strip()
             if not s:
                 return {}
-            s = re.sub(r"\s+", "", s)
+            s = _ws_re.sub("", s)
 
             if "->" not in s:
                 return {"class": s}
@@ -525,7 +517,7 @@ class DexTraceImp(BaseApkinfo):
             # stable sort: offset-present first (ascending), then missing; keep original order as tiebreaker
             items_sorted = sorted(
                 enumerate(items),
-                key=lambda x: (x[1][0] is None, x[1][0] if x[1][0] is not None else 0, x[0]),
+                key=lambda x: (x[1][0] is None, x[1][0] or 0, x[0]),
             )
 
             caller_mo = self._sig_to_method_object(caller_sig)
@@ -567,6 +559,18 @@ class DexTraceImp(BaseApkinfo):
                     # _sig_to_method_object is idempotent: returns existing entry if present
                     self._sig_to_method_object(f"{cls}->{mname}{proto}")
 
+    def _create_method_object(self, cls: str, name: str, desc: str) -> MethodObject:
+        key = (cls, name, desc)
+        if key in self._method_by_sig:
+            return self._method_by_sig[key]
+        full_name = f"{cls}->{name}{desc}"
+        external = self._is_external_class(cls)
+        is_android_api = self._is_android_api_class(cls)
+        cache = DextraceMethodCache(full_name=full_name, external=external, is_android_api=is_android_api)
+        mo = MethodObject(class_name=cls, name=name, descriptor=desc, cache=cache)
+        self._method_by_sig[key] = mo
+        return mo
+
     def _sig_to_method_object(self, dextrace_sig: str) -> MethodObject:
         """
         Create/find a MethodObject from a DexTrace method signature:
@@ -585,17 +589,7 @@ class DexTraceImp(BaseApkinfo):
             desc = m.group(3)
 
         desc = self._normalize_descriptor(desc)
-        key = (cls, name, desc)
-        if key in self._method_by_sig:
-            return self._method_by_sig[key]
-
-        full_name = f"{cls}->{name}{desc}"
-        external = self._is_external_class(cls)
-        is_android_api = self._is_android_api_class(cls)
-        cache = DextraceMethodCache(full_name=full_name, external=external, is_android_api=is_android_api)
-        mo = MethodObject(class_name=cls, name=name, descriptor=desc, cache=cache)
-        self._method_by_sig[key] = mo
-        return mo
+        return self._create_method_object(cls, name, desc)
 
     def _to_method_object(self, raw: dict) -> MethodObject:
         """
@@ -611,18 +605,7 @@ class DexTraceImp(BaseApkinfo):
 
         cls = self._normalize_class(str(cls))
         desc = self._normalize_descriptor(str(desc))
-
-        key = (cls, str(name), desc)
-        if key in self._method_by_sig:
-            return self._method_by_sig[key]
-
-        full_name = f"{cls}->{name}{desc}"
-        external = self._is_external_class(cls)
-        is_android_api = self._is_android_api_class(cls)
-        cache = DextraceMethodCache(full_name=full_name, external=external, is_android_api=is_android_api)
-        mo = MethodObject(class_name=cls, name=str(name), descriptor=desc, cache=cache)
-        self._method_by_sig[key] = mo
-        return mo
+        return self._create_method_object(cls, str(name), desc)
 
     def _normalize_class(self, cls: str) -> str:
         cls = str(cls).strip()
@@ -649,7 +632,7 @@ class DexTraceImp(BaseApkinfo):
         return desc
 
     def _normalize_dextrace_sig(self, sig: str) -> str:
-        return re.sub(r"\s+", "", str(sig))
+        return self._WHITESPACE_RE.sub("", str(sig))
 
     def _methodobject_to_dextrace_sig(self, mo: MethodObject) -> str:
         """
@@ -660,7 +643,7 @@ class DexTraceImp(BaseApkinfo):
         name = (mo.name or "").strip()
         desc = (mo.descriptor or "").strip()
 
-        desc = re.sub(r"\s+", "", desc)
+        desc = self._WHITESPACE_RE.sub("", desc)
         cls = self._normalize_class(cls)
         return f"{cls}->{name}{desc}"
 
@@ -725,6 +708,7 @@ class DexTraceImp(BaseApkinfo):
 
     # -------- Small smali parser --------
     _SMALI_SPLIT_RE = re.compile(r"[{},]+")
+    _WHITESPACE_RE = re.compile(r"\s+")
 
     @staticmethod
     def _strip_smali_comment(smali: str) -> str:

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -17,6 +17,7 @@ import numpy as np
 import csv
 
 from quark.core.analysis import QuarkAnalysis
+from quark.core.dextraceapkinfo import DexTraceImp
 from quark.core.shurikenapkinfo import ShurikenImp
 from quark.core.apkinfo import AndroguardImp
 from quark.core.rzapkinfo import RizinImp
@@ -201,7 +202,9 @@ class Quark:
             )
 
         core_library = core_library.lower()
-        if core_library == "shuriken":
+        if core_library == "dextrace":
+            self.apkinfo = DexTraceImp(apk)
+        elif core_library == "shuriken":
             self.apkinfo = ShurikenImp(apk)
         elif core_library == "rizin":
             self.apkinfo = RizinImp(apk)

--- a/quark/core/quark.py
+++ b/quark/core/quark.py
@@ -607,8 +607,7 @@ class Quark:
 
                 current_class_set = next_class_set
 
-            current_class_set.discard("Ljava/lang/Object;")
-            if current_class_set:
+            if class_name in current_class_set:
                 method_list.append(method)
 
         return method_list

--- a/tests/core/test_dextraceapkinfo.py
+++ b/tests/core/test_dextraceapkinfo.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+# This file is part of Quark-Engine - https://github.com/quark-engine/quark-engine
+# See the file 'LICENSE' for copying permission.
+
+"""
+Unit and integration tests for DexTraceImp in quark/core/dextraceapkinfo.py.
+
+Tests cover bugs that were fixed:
+  1. _normalize_class did not handle the case where input starts with "L" but
+     lacks a trailing ";" — it would produce a double-"L" prefix.
+  2. find_method used raw == equality against DexTrace-normalized class names,
+     so class names from rule files (which lack the trailing ";") returned empty
+     lists.
+  3. APKs with bogus ZIP compression types (e.g. 8744) caused DexTrace to
+     return 0% confidence on all rules: DexTraceImp must detect the patching
+     done by ApkPatcher and forward a patched temp file to DexTrace APIs so
+     DexTrace reads the corrected bytes.
+"""
+
+import os
+import zipfile
+
+import pytest
+
+try:
+    from quark.core.dextraceapkinfo import DexTraceImp
+
+    _HAS_DEXTRACE = True
+except ImportError:
+    _HAS_DEXTRACE = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_DEXTRACE, reason="DexTrace not installed"
+)
+
+
+@pytest.fixture(scope="module")
+def dextrace_instance(SAMPLE_PATH_Ahmyth):
+    """Return a DexTraceImp instance backed by the Ahmyth APK."""
+    return DexTraceImp(SAMPLE_PATH_Ahmyth)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for find_method with class names lacking trailing ";"
+# ---------------------------------------------------------------------------
+
+
+class TestFindMethodClassNormalization:
+    """
+    Regression tests verifying that find_method accepts class names both with
+    and without a trailing semicolon and returns the same non-empty result.
+
+    SmsManager.sendTextMessage is called by Ahmyth for SMS exfiltration, so it
+    is reliably present in the Ahmyth call graph.
+    """
+
+    def test_find_method_with_canonical_class_name(self, dextrace_instance):
+        """Fully-qualified Dalvik class name (with semicolon) returns results."""
+        results = dextrace_instance.find_method(
+            "Landroid/telephony/SmsManager;", "sendTextMessage", None
+        )
+        assert results, (
+            "find_method returned empty list for canonical class name "
+            "'Landroid/telephony/SmsManager;'"
+        )
+
+    def test_find_method_without_trailing_semicolon_matches(
+        self, dextrace_instance
+    ):
+        """Bug regression: class name without trailing semicolon returns same
+        non-empty result as the canonical form."""
+        with_semicolon = dextrace_instance.find_method(
+            "Landroid/telephony/SmsManager;", "sendTextMessage", None
+        )
+        # Clear LRU cache so the two calls are independent (different args).
+        dextrace_instance.find_method.cache_clear()
+        without_semicolon = dextrace_instance.find_method(
+            "Landroid/telephony/SmsManager", "sendTextMessage", None
+        )
+        assert without_semicolon, (
+            "find_method returned empty list when class name lacks trailing ';' "
+            "— regression of the _normalize_class / find_method bug"
+        )
+        assert set(with_semicolon) == set(without_semicolon), (
+            "find_method returns different results depending on whether the "
+            "trailing ';' is present"
+        )
+
+    def test_find_method_slash_separated_without_l_prefix_matches(
+        self, dextrace_instance
+    ):
+        """Bug regression: slash-separated class name without L prefix returns
+        same non-empty result as the canonical form."""
+        canonical = dextrace_instance.find_method(
+            "Landroid/telephony/SmsManager;", "sendTextMessage", None
+        )
+        dextrace_instance.find_method.cache_clear()
+        slash_only = dextrace_instance.find_method(
+            "android/telephony/SmsManager", "sendTextMessage", None
+        )
+        assert slash_only, (
+            "find_method returned empty list for slash-separated class name "
+            "without L prefix"
+        )
+        assert set(canonical) == set(slash_only)
+
+

--- a/tests/core/test_dextraceapkinfo.py
+++ b/tests/core/test_dextraceapkinfo.py
@@ -105,3 +105,55 @@ class TestFindMethodClassNormalization:
         assert set(canonical) == set(slash_only)
 
 
+# ---------------------------------------------------------------------------
+# Bogus ZIP compression anti-analysis fix (3d52b APK)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def dextrace_3d52b(SAMPLE_PATH_3d52b):
+    """DexTraceImp backed by the APK that uses a bogus compression type (8744)
+    on AndroidManifest.xml as an anti-analysis trick."""
+    return DexTraceImp(SAMPLE_PATH_3d52b)
+
+
+@pytest.mark.skipif(not _HAS_DEXTRACE, reason="DexTrace not installed")
+class TestBogusCompressionFix:
+    """Regression tests for the bogus ZIP compression / permissions fix.
+
+    The 3d52b APK sets AndroidManifest.xml's compression type to 8744 while
+    storing data uncompressed.  Before the fix this caused 0% confidence on
+    all Quark rules because permissions came back empty (Level 1 failure).
+    """
+
+    def test_apk_is_detected_as_patched(self, dextrace_3d52b):
+        """ApkPatcher must recognise the bogus compression and set isPatched."""
+        assert dextrace_3d52b.isPatched is True
+
+    def test_permissions_non_empty(self, dextrace_3d52b):
+        """After the fix, permissions must be non-empty (Level 1 passes)."""
+        perms = dextrace_3d52b.permissions
+        assert len(perms) > 0, (
+            "permissions is empty — Level 1 will fail for all rules "
+            "(regression of bogus-compression fix)"
+        )
+
+    def test_permissions_include_expected(self, dextrace_3d52b):
+        """INTERNET permission must be present (known from manual inspection)."""
+        assert "android.permission.INTERNET" in dextrace_3d52b.permissions
+
+    def test_no_temp_file_leak_after_gc(self, SAMPLE_PATH_3d52b):
+        """DexTraceImp must not leave temp APK files on disk after the instance is GC'd."""
+        import glob
+        import tempfile
+        tmp_dir = tempfile.gettempdir()
+        apk_before = set(glob.glob(os.path.join(tmp_dir, "*.apk")))
+        instance = DexTraceImp(SAMPLE_PATH_3d52b)
+        del instance
+        apk_after = set(glob.glob(os.path.join(tmp_dir, "*.apk")))
+        assert not (apk_after - apk_before), (
+            "DexTraceImp leaked temp APK files after __del__: "
+            f"{apk_after - apk_before}"
+        )
+
+

--- a/tests/core/test_dextraceapkinfo.py
+++ b/tests/core/test_dextraceapkinfo.py
@@ -157,3 +157,33 @@ class TestBogusCompressionFix:
         )
 
 
+# ---------------------------------------------------------------------------
+# Manifest fast-fail: DexTraceImp must raise ValueError on broken manifests
+# ---------------------------------------------------------------------------
+
+
+class TestManifestFastFail:
+    """
+    Regression tests for Issue 4 (broken manifest fast-fail).
+
+    trickmo/tanglebot APKs have unreadable AndroidManifest.xml entries.
+    Before the fix, DexTraceImp silently swallowed the parse error and ran
+    3 full DEX passes (134 s on trickmo).  After the fix it raises ValueError
+    immediately, matching Androguard's behavior.
+    """
+
+    @pytest.mark.parametrize("include_manifest,manifest_content", [
+        (True, b"not-valid-axml-bytes"),   # bad AXML bytes
+        (False, None),                      # missing manifest entry
+    ])
+    def test_unreadable_manifest_raises_value_error(
+        self, tmp_path, include_manifest, manifest_content
+    ):
+        """APK with bad or absent AndroidManifest.xml raises ValueError."""
+        apk_path = tmp_path / "test.apk"
+        with zipfile.ZipFile(apk_path, "w") as zf:
+            if include_manifest:
+                zf.writestr("AndroidManifest.xml", manifest_content)
+            zf.writestr("classes.dex", b"")
+        with pytest.raises(ValueError, match="AndroidManifest"):
+            DexTraceImp(str(apk_path))


### PR DESCRIPTION
## Description

Adds `DexTraceImp` as a new concrete implementation of `BaseApkinfo`, allowing Quark to use DexTrace as an alternative APK analysis backend. Activate it with `--core-library dextrace`:

```bash
quark -a <apk_file> --core-library dextrace -s
```

## Key Changes

- `quark/core/dextraceapkinfo.py`: Add `DexTraceImp`, implementing the same `BaseApkinfo` interface as `AndroguardImp`.

- `quark/core/quark.py`:
  - Wire `core_library="dextrace"` to `DexTraceImp`.
  - Fix false positive in `find_api_usage` subclass BFS: check `class_name in current_class_set` instead of discarding `Ljava/lang/Object;` and testing non-empty.

- `tests/core/test_dextraceapkinfo.py`: Add integration tests covering:
  - Class name normalisation (Ahmyth APK).
  - Bogus ZIP compression and permissions (3d52b APK).
  - Manifest fast-fail (synthetic APK via `tmp_path`).

## Motivation and Context

DexTrace is a Python APK analysis library that parses DEX bytecode independently of the androguard package. Adding it as a backend gives Quark an alternative that does not depend on androguard. The implementation handles the anti-analysis patterns and class naming conventions seen in real-world malware samples.

## How Has This Been Tested?

- `pytest tests/` passes with no regressions.
- Full run on 497 APKs from the Quark malware family analysis report:
  - **Accuracy:** DexTrace's result is more accurate than Androguard's.
  - **Performance:** mean 27.5 s vs 5.7 s (4.8x faster), total wall time 57 min vs 11 min (5.2x faster).